### PR TITLE
Remove mutes from the database if they expire

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 plugins {
     val kotlinVersion = "1.5.0"
 
-    id("org.springframework.boot") version "2.4.5"
+    id("org.springframework.boot") version "2.4.6"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.spring") version kotlinVersion


### PR DESCRIPTION
This change removes users from the database if their mute has expired.

 Instead of waiting for the user to rejoin and then be unmuted.