### PR TITLE
Add message link quote capability to Quote command class and add spoiler tag ability for mobile users

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/bot/commands/Quote.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/bot/commands/Quote.kt
@@ -28,7 +28,7 @@ class Quote(
     userBlockService: UserBlockService
 ) : CommandModule(
     arrayOf("Quote"),
-    "[message id to quote] [response text]",
+    "[message id / message link to quote] [response text]",
     "Will quote text and put a response under it, response text is optional",
     ignoreWhitelist = true,
     userBlockService = userBlockService

--- a/src/main/kotlin/be/duncanc/discordmodbot/bot/commands/Quote.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/bot/commands/Quote.kt
@@ -33,6 +33,9 @@ class Quote(
     ignoreWhitelist = true,
     userBlockService = userBlockService
 ) {
+    companion object {
+        private const val JUMP_URL_PREFIX = "https://discord.com/channels/"
+    }
 
     override fun commandExec(event: MessageReceivedEvent, command: String, arguments: String?) {
         if (arguments == null) {
@@ -42,10 +45,11 @@ class Quote(
         val toQuoteSource = arguments.split(" ")[0]
         // This assumes a standard format of
         // https://discord.com/channels/<SERVER ID>/<CHANNEL ID>/<MESSAGE ID>
-        if (toQuoteSource.startsWith("https://discord.com/channels/")) {
-            toQuoteSource.removePrefix("https://discord.com/channels/")
+        if (toQuoteSource.startsWith(JUMP_URL_PREFIX)) {
             // idArray, as shown above, follows the pattern Server ID, TextChannel ID, Message ID.
-            val idArray = toQuoteSource.split("/")
+            val idArray = toQuoteSource
+                .removePrefix(JUMP_URL_PREFIX)
+                .split("/")
             // make sure we are pulling from a valid place
             val guild = event.jda.getGuildById(idArray[0])
             guild?.getTextChannelById(idArray[1])?.retrieveMessageById(idArray[2])?.queue { messageToQuote ->
@@ -84,14 +88,14 @@ class Quote(
                 quotedMessage.author.effectiveAvatarUrl
             )
             .setDescription(quotedMessage.contentDisplay)
-            .setFooter(event.author.id, event.author.effectiveAvatarUrl)
+            .setFooter("Posted by ${event.author}", event.author.effectiveAvatarUrl)
         val responseEmbed = if (responseString.isBlank()) {
             null
         } else {
             EmbedBuilder()
                 .setAuthor(event.member?.nicknameAndUsername, null, event.author.effectiveAvatarUrl)
                 .setDescription(responseString)
-                .setFooter(event.author.id, null)
+                .setFooter("Posted by ${event.member}", event.author.effectiveAvatarUrl)
         }
         event.textChannel.sendMessage(quoteEmbed.build()).queue()
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/bot/commands/Spoiler.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/bot/commands/Spoiler.kt
@@ -6,14 +6,14 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import org.springframework.stereotype.Component
 
 @Component
-class Spoiler (
+class Spoiler(
     userBlockService: UserBlockService
-): CommandModule(
-        arrayOf("Spoiler"),
-        "[text/attachments attach spoiler]",
-        "Will take message and all its contents and spoiler tag it and send it back.",
-        ignoreWhitelist = true,
-        userBlockService = userBlockService
+) : CommandModule(
+    arrayOf("Spoiler"),
+    "[text/attachments attach spoiler]",
+    "Will take message and all its contents and spoiler tag it and send it back.",
+    ignoreWhitelist = true,
+    userBlockService = userBlockService
 ) {
     override fun commandExec(event: MessageReceivedEvent, command: String, arguments: String?) {
         // TODO: Use a webhook trick in order to send messages "as" the user.
@@ -27,14 +27,10 @@ class Spoiler (
             "||${it.url}||\n"
         }
 
-        // delete message
-        event.message.delete().complete()
-
-        // return messsage
         val returnMessageBuilder = MessageBuilder()
-                .append("From: ${event.message.author.asMention}\n")
-                .append(spoilerTaggedStringMessage)
-                .append(embedLinkList.joinToString { it })
+            .append("From: ${event.message.author.asMention}\n")
+            .append(spoilerTaggedStringMessage)
+            .append(embedLinkList.joinToString { it })
         event.textChannel.sendMessage(returnMessageBuilder.build()).queue()
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/bot/commands/Spoiler.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/bot/commands/Spoiler.kt
@@ -1,0 +1,40 @@
+package be.duncanc.discordmodbot.bot.commands
+
+import be.duncanc.discordmodbot.data.services.UserBlockService
+import net.dv8tion.jda.api.MessageBuilder
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import org.springframework.stereotype.Component
+
+@Component
+class Spoiler (
+    userBlockService: UserBlockService
+): CommandModule(
+        arrayOf("Spoiler"),
+        "[text/attachments attach spoiler]",
+        "Will take message and all its contents and spoiler tag it and send it back.",
+        ignoreWhitelist = true,
+        userBlockService = userBlockService
+) {
+    override fun commandExec(event: MessageReceivedEvent, command: String, arguments: String?) {
+        // TODO: Use a webhook trick in order to send messages "as" the user.
+        // TODO: "properly" tag images as spoilers instead of hijacking discord link embeds
+        if (arguments == null && event.message.attachments.isEmpty()) {
+            throw IllegalArgumentException("This command requires something to spoiler tag.")
+        }
+
+        val spoilerTaggedStringMessage = "||$arguments||\n"
+        val embedLinkList = event.message.attachments.map {
+            "||${it.url}||\n"
+        }
+
+        // delete message
+        event.message.delete().complete()
+
+        // return messsage
+        val returnMessageBuilder = MessageBuilder()
+                .append("From: ${event.message.author.asMention}\n")
+                .append(spoilerTaggedStringMessage)
+                .append(embedLinkList.joinToString { it })
+        event.textChannel.sendMessage(returnMessageBuilder.build()).queue()
+    }
+}


### PR DESCRIPTION
This adds the previously mentioned ability to quote messages by link instead of only by message ID and spoiler tagging for mobile users as discussed in `#feedback`. 
