### PR TITLE
fix(moderation): align warn command permissions with manage roles

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/WarnCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/WarnCommand.kt
@@ -42,8 +42,8 @@ class WarnCommand(
         }
 
         val moderator = event.member!!
-        if (!moderator.hasPermission(Permission.KICK_MEMBERS)) {
-            event.reply("You need kick members permission to use this command.").setEphemeral(true).queue()
+        if (!moderator.hasPermission(Permission.MANAGE_ROLES)) {
+            event.reply("You need manage roles permission to use this command.").setEphemeral(true).queue()
             return
         }
 
@@ -127,7 +127,7 @@ class WarnCommand(
                     OptionData(OptionType.USER, OPTION_USER, "The user to warn").setRequired(true),
                     OptionData(OptionType.STRING, OPTION_REASON, "The reason for the warning").setRequired(true)
                 )
-                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.KICK_MEMBERS))
+                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
         )
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/WarnPointsListCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/WarnPointsListCommand.kt
@@ -35,8 +35,8 @@ class WarnPointsListCommand(
         }
 
         val moderator = event.member!!
-        if (!moderator.hasPermission(Permission.KICK_MEMBERS)) {
-            event.reply("You need kick members permission to use this command.").setEphemeral(true).queue()
+        if (!moderator.hasPermission(Permission.MANAGE_ROLES)) {
+            event.reply("You need manage roles permission to use this command.").setEphemeral(true).queue()
             return
         }
 
@@ -80,7 +80,7 @@ class WarnPointsListCommand(
     override fun getCommandsData(): List<SlashCommandData> {
         return listOf(
             Commands.slash(COMMAND, DESCRIPTION)
-                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.KICK_MEMBERS))
+                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
         )
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/WarnCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/WarnCommandTest.kt
@@ -1,0 +1,55 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettingsRepository
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class WarnCommandTest {
+    @Mock
+    private lateinit var guildWarnPointsSettingsRepository: GuildWarnPointsSettingsRepository
+
+    @Mock
+    private lateinit var slashEvent: SlashCommandInteractionEvent
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var member: Member
+
+    @Mock
+    private lateinit var replyAction: ReplyCallbackAction
+
+    private lateinit var command: WarnCommand
+
+    @BeforeEach
+    fun setUp() {
+        command = WarnCommand(guildWarnPointsSettingsRepository)
+    }
+
+    @Test
+    fun `missing manage roles permission returns error`() {
+        whenever(slashEvent.name).thenReturn("warn")
+        whenever(slashEvent.guild).thenReturn(guild)
+        whenever(slashEvent.member).thenReturn(member)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(false)
+        whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).reply("You need manage roles permission to use this command.")
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/WarnPointsListCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/WarnPointsListCommandTest.kt
@@ -1,0 +1,55 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsRepository
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class WarnPointsListCommandTest {
+    @Mock
+    private lateinit var guildWarnPointsRepository: GuildWarnPointsRepository
+
+    @Mock
+    private lateinit var slashEvent: SlashCommandInteractionEvent
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var member: Member
+
+    @Mock
+    private lateinit var replyAction: ReplyCallbackAction
+
+    private lateinit var command: WarnPointsListCommand
+
+    @BeforeEach
+    fun setUp() {
+        command = WarnPointsListCommand(guildWarnPointsRepository)
+    }
+
+    @Test
+    fun `missing manage roles permission returns error`() {
+        whenever(slashEvent.name).thenReturn("warnpointslist")
+        whenever(slashEvent.guild).thenReturn(guild)
+        whenever(slashEvent.member).thenReturn(member)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(false)
+        whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).reply("You need manage roles permission to use this command.")
+    }
+}


### PR DESCRIPTION
## Summary
- switch `/warn` and `/warnpointslist` from `KICK_MEMBERS` to `MANAGE_ROLES` for both runtime checks and default slash permissions
- update the permission error message shown by both commands to match the new requirement
- add focused tests covering the missing `MANAGE_ROLES` guard for both commands

## Testing
- `./gradlew.bat test --tests "be.duncanc.discordmodbot.moderation.WarnCommandTest" --tests "be.duncanc.discordmodbot.moderation.WarnPointsListCommandTest"`