### PR TITLE
fix(logging): preserve moderator attribution for message deletes

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -188,51 +188,57 @@ class GuildLogger
         if (oldMessage != null) {
             val attachmentString = messageHistory.getAttachmentsString(event.messageIdLong)
 
-            event.jda.retrieveUserById(oldMessage.userId).queue { user ->
+            guildLoggerExecutor.schedule({
+                logDeletedMessage(event, oldMessage, attachmentString)
+            }, 1, TimeUnit.SECONDS)
+        }
+    }
 
-                val name: String = try {
-                    event.jda.getGuildChannelById(oldMessage.channelId)?.guild?.getMember(user)?.nicknameAndUsername
-                        ?: user.name
-                } catch (e: IllegalArgumentException) {
-                    user.name
-                }
-                guildLoggerExecutor.schedule({
-                    val moderator = findModerator(event, oldMessage)
+    internal fun logDeletedMessage(event: MessageDeleteEvent, oldMessage: DiscordMessage, attachmentString: String?) {
+        val guild = event.guild
+        val channel = event.channel
+        val moderator = findModerator(event, oldMessage)
 
-                    if (moderator != null && moderator == event.jda.selfUser) {
-                        return@schedule  //Bot has removed message no need to log, if needed it will be placed in the module that is issuing the remove.
-                    }
+        if (moderator != null && moderator == event.jda.selfUser) {
+            return  //Bot has removed message no need to log, if needed it will be placed in the module that is issuing the remove.
+        }
 
-                    val logEmbed = EmbedBuilder()
-                        .setTitle("#" + channel.name + ": Message was deleted!")
-                        .setDescription("Old message was:\n" + oldMessage.content)
-                    if (attachmentString != null) {
-                        logEmbed.addField("Attachment(s)", attachmentString, false)
-                    }
-                    logEmbed.addField("Author", name, true)
-                    if (moderator != null) {
-                        logEmbed.addField(
-                            "Deleted by",
-                            event.guild.getMember(moderator)?.nicknameAndUsername ?: "Unkown",
-                            true
-                        )
-                            .setColor(Color.YELLOW)
-                    } else {
-                        logEmbed.setColor(LIGHT_BLUE)
-                    }
-                    logEmbed.addField("Message URL", "[Link](${oldMessage.jumpUrl})", false)
-                    oldMessage.emotes?.let {
-                        logEmbed.addField("Emote(s)", oldMessage.emotes, false)
-                    }
-                    log(
-                        logEmbed,
-                        user,
-                        guild,
-                        null,
-                        if (moderator == null) LogTypeAction.USER else LogTypeAction.MODERATOR
-                    )
-                }, 1, TimeUnit.SECONDS)
+        event.jda.retrieveUserById(oldMessage.userId).queue { user ->
+            val name: String = try {
+                event.jda.getGuildChannelById(oldMessage.channelId)?.guild?.getMember(user)?.nicknameAndUsername
+                    ?: user.name
+            } catch (e: IllegalArgumentException) {
+                user.name
             }
+
+            val logEmbed = EmbedBuilder()
+                .setTitle("#" + channel.name + ": Message was deleted!")
+                .setDescription("Old message was:\n" + oldMessage.content)
+            if (attachmentString != null) {
+                logEmbed.addField("Attachment(s)", attachmentString, false)
+            }
+            logEmbed.addField("Author", name, true)
+            if (moderator != null) {
+                logEmbed.addField(
+                    "Deleted by",
+                    event.guild.getMember(moderator)?.nicknameAndUsername ?: "Unkown",
+                    true
+                )
+                    .setColor(Color.YELLOW)
+            } else {
+                logEmbed.setColor(LIGHT_BLUE)
+            }
+            logEmbed.addField("Message URL", "[Link](${oldMessage.jumpUrl})", false)
+            oldMessage.emotes?.let {
+                logEmbed.addField("Emote(s)", oldMessage.emotes, false)
+            }
+            log(
+                logEmbed,
+                user,
+                guild,
+                null,
+                if (moderator == null) LogTypeAction.USER else LogTypeAction.MODERATOR
+            )
         }
     }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -1,7 +1,6 @@
 package be.duncanc.discordmodbot.logging
 
 import be.duncanc.discordmodbot.discord.nicknameAndUsername
-import be.duncanc.discordmodbot.logging.persistence.DiscordMessage
 import be.duncanc.discordmodbot.logging.persistence.LoggingSettings
 import be.duncanc.discordmodbot.logging.persistence.LoggingSettingsRepository
 import net.dv8tion.jda.api.EmbedBuilder
@@ -80,6 +79,7 @@ class GuildLogger
     }
     private val lastCheckedLogEntries: HashMap<Long, AuditLogEntry?> =
         HashMap() //Long key is the guild id and the value is the last checked log entry.
+    private val messageDeleteAuditStates: HashMap<Pair<Long, Long>, MessageDeleteAuditState> = HashMap()
 
     @Transactional(readOnly = true)
     override fun onMessageReceived(event: MessageReceivedEvent) {
@@ -197,7 +197,7 @@ class GuildLogger
                     user.name
                 }
                 guildLoggerExecutor.schedule({
-                    val moderator = findModerator(event, oldMessage)
+                    val moderator = findModerator(event)
 
                     if (moderator != null && moderator == event.jda.selfUser) {
                         return@schedule  //Bot has removed message no need to log, if needed it will be placed in the module that is issuing the remove.
@@ -236,39 +236,31 @@ class GuildLogger
         }
     }
 
-    private fun findModerator(event: MessageDeleteEvent, oldMessage: DiscordMessage): User? {
-        var foundModerator: User? = null
+    private fun findModerator(event: MessageDeleteEvent): User? {
+        val auditStateKey = event.guild.idLong to event.channel.idLong
         var i = 0
-        for (logEntry in event.guild.retrieveAuditLogs().cache(false).limit(LOG_ENTRY_CHECK_LIMIT)) {
-            if (i == 0) {
-                guildLoggerExecutor.execute {
-                    lastCheckedLogEntries[event.guild.idLong] = logEntry
-                }
-            }
-            if (!lastCheckedLogEntries.containsKey(event.guild.idLong)) {
-                i = LOG_ENTRY_CHECK_LIMIT
-            } else {
-                val cachedAuditLogEntry = lastCheckedLogEntries[event.guild.idLong]
-                if (logEntry.idLong == cachedAuditLogEntry?.idLong) {
-                    if (logEntry.type == ActionType.MESSAGE_DELETE && logEntry.targetIdLong == oldMessage.userId && logEntry.getOption<Any>(
-                            AuditLogOption.COUNT
-                        ) != cachedAuditLogEntry.getOption<Any>(AuditLogOption.COUNT)
-                    ) {
-                        foundModerator = logEntry.user
-                    }
+        for (logEntry in event.guild.retrieveAuditLogs().type(ActionType.MESSAGE_DELETE).cache(false).limit(LOG_ENTRY_CHECK_LIMIT)) {
+            val channelId = logEntry.getOption<String>(AuditLogOption.CHANNEL)?.toLongOrNull()
+            if (channelId != event.channel.idLong) {
+                i++
+                if (i >= LOG_ENTRY_CHECK_LIMIT) {
                     break
                 }
+                continue
             }
-            if (logEntry.type == ActionType.MESSAGE_DELETE && logEntry.targetIdLong == oldMessage.userId) {
-                foundModerator = logEntry.user
-                break
+
+            val count = logEntry.getOption<String>(AuditLogOption.COUNT)?.toIntOrNull() ?: 1
+            val consumeResult = MessageDeleteAuditTracker.consume(messageDeleteAuditStates[auditStateKey], logEntry.idLong, count)
+            messageDeleteAuditStates[auditStateKey] = consumeResult.nextState
+
+            if (consumeResult.matched) {
+                return logEntry.user
             }
-            i++
-            if (i >= LOG_ENTRY_CHECK_LIMIT) {
-                break
-            }
+
+            break
         }
-        return foundModerator
+
+        return null
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -238,16 +238,44 @@ class GuildLogger
 
     private fun findModerator(event: MessageDeleteEvent, oldMessage: DiscordMessage): User? {
         val auditStateKey = MessageDeleteAuditKey(event.guild.idLong, event.channel.idLong, oldMessage.userId)
+        val previousLatestLogEntry = lastCheckedLogEntries[event.guild.idLong]
         val relevantEntries = mutableListOf<Pair<AuditLogEntry, MessageDeleteAuditCandidate>>()
+        var latestLogEntry: AuditLogEntry? = null
 
-        for (logEntry in event.guild.retrieveAuditLogs().type(ActionType.MESSAGE_DELETE).cache(false).limit(LOG_ENTRY_CHECK_LIMIT)) {
-            val channelId = logEntry.getOption<String>(AuditLogOption.CHANNEL)?.toLongOrNull()
-            if (channelId != event.channel.idLong || logEntry.targetIdLong != oldMessage.userId) {
+        for (logEntry in event.guild.retrieveAuditLogs().cache(false).limit(LOG_ENTRY_CHECK_LIMIT)) {
+            if (latestLogEntry == null) {
+                latestLogEntry = logEntry
+            }
+
+            if (logEntry.type != ActionType.MESSAGE_DELETE) {
+                if (logEntry.idLong == previousLatestLogEntry?.idLong) {
+                    break
+                }
                 continue
             }
 
-            val count = logEntry.getOption<String>(AuditLogOption.COUNT)?.toIntOrNull() ?: 1
-            relevantEntries += logEntry to MessageDeleteAuditCandidate(logEntry.idLong, count)
+            val channelId = logEntry.getOption<String>(AuditLogOption.CHANNEL)?.toLongOrNull()
+            if (channelId == event.channel.idLong && logEntry.targetIdLong == oldMessage.userId) {
+                val count = logEntry.getOption<String>(AuditLogOption.COUNT)?.toIntOrNull() ?: 1
+                relevantEntries += logEntry to MessageDeleteAuditCandidate(logEntry.idLong, count)
+            }
+
+            if (logEntry.idLong == previousLatestLogEntry?.idLong) {
+                break
+            }
+        }
+
+        latestLogEntry?.let { lastCheckedLogEntries[event.guild.idLong] = it }
+
+        val startupWatermark = previousLatestLogEntry?.let { logEntry ->
+            MessageDeleteAuditWatermark(
+                entryId = logEntry.idLong,
+                count = if (logEntry.type == ActionType.MESSAGE_DELETE) {
+                    logEntry.getOption<String>(AuditLogOption.COUNT)?.toIntOrNull() ?: 1
+                } else {
+                    0
+                }
+            )
         }
 
         val consumeResult = MessageDeleteAuditTracker.consume(
@@ -256,7 +284,8 @@ class GuildLogger
                 auditStateKey.channelId,
                 auditStateKey.targetUserId
             ),
-            candidates = relevantEntries.map { it.second }
+            candidates = relevantEntries.map { it.second },
+            watermark = startupWatermark
         )
 
         messageDeleteAuditStateRegistry.remember(

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -1,6 +1,7 @@
 package be.duncanc.discordmodbot.logging
 
 import be.duncanc.discordmodbot.discord.nicknameAndUsername
+import be.duncanc.discordmodbot.logging.persistence.DiscordMessage
 import be.duncanc.discordmodbot.logging.persistence.LoggingSettings
 import be.duncanc.discordmodbot.logging.persistence.LoggingSettingsRepository
 import net.dv8tion.jda.api.EmbedBuilder
@@ -79,7 +80,7 @@ class GuildLogger
     }
     private val lastCheckedLogEntries: HashMap<Long, AuditLogEntry?> =
         HashMap() //Long key is the guild id and the value is the last checked log entry.
-    private val messageDeleteAuditStates: HashMap<Pair<Long, Long>, MessageDeleteAuditState> = HashMap()
+    private val messageDeleteAuditStates: HashMap<MessageDeleteAuditKey, MessageDeleteAuditState> = HashMap()
 
     @Transactional(readOnly = true)
     override fun onMessageReceived(event: MessageReceivedEvent) {
@@ -197,7 +198,7 @@ class GuildLogger
                     user.name
                 }
                 guildLoggerExecutor.schedule({
-                    val moderator = findModerator(event)
+                    val moderator = findModerator(event, oldMessage)
 
                     if (moderator != null && moderator == event.jda.selfUser) {
                         return@schedule  //Bot has removed message no need to log, if needed it will be placed in the module that is issuing the remove.
@@ -236,31 +237,32 @@ class GuildLogger
         }
     }
 
-    private fun findModerator(event: MessageDeleteEvent): User? {
-        val auditStateKey = event.guild.idLong to event.channel.idLong
-        var i = 0
+    private fun findModerator(event: MessageDeleteEvent, oldMessage: DiscordMessage): User? {
+        val auditStateKey = MessageDeleteAuditKey(event.guild.idLong, event.channel.idLong, oldMessage.userId)
+        val relevantEntries = mutableListOf<Pair<AuditLogEntry, MessageDeleteAuditCandidate>>()
+
         for (logEntry in event.guild.retrieveAuditLogs().type(ActionType.MESSAGE_DELETE).cache(false).limit(LOG_ENTRY_CHECK_LIMIT)) {
             val channelId = logEntry.getOption<String>(AuditLogOption.CHANNEL)?.toLongOrNull()
-            if (channelId != event.channel.idLong) {
-                i++
-                if (i >= LOG_ENTRY_CHECK_LIMIT) {
-                    break
-                }
+            if (channelId != event.channel.idLong || logEntry.targetIdLong != oldMessage.userId) {
                 continue
             }
 
             val count = logEntry.getOption<String>(AuditLogOption.COUNT)?.toIntOrNull() ?: 1
-            val consumeResult = MessageDeleteAuditTracker.consume(messageDeleteAuditStates[auditStateKey], logEntry.idLong, count)
-            messageDeleteAuditStates[auditStateKey] = consumeResult.nextState
-
-            if (consumeResult.matched) {
-                return logEntry.user
-            }
-
-            break
+            relevantEntries += logEntry to MessageDeleteAuditCandidate(logEntry.idLong, count)
         }
 
-        return null
+        val consumeResult = MessageDeleteAuditTracker.consume(
+            previousState = messageDeleteAuditStates[auditStateKey],
+            candidates = relevantEntries.map { it.second }
+        )
+
+        if (consumeResult.nextState.consumedCounts.isEmpty()) {
+            messageDeleteAuditStates.remove(auditStateKey)
+        } else {
+            messageDeleteAuditStates[auditStateKey] = consumeResult.nextState
+        }
+
+        return relevantEntries.firstOrNull { it.first.idLong == consumeResult.matchedEntryId }?.first?.user
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -62,7 +62,8 @@ import kotlin.concurrent.thread
 class GuildLogger
 @Autowired constructor(
     val messageHistory: MessageHistory,
-    val loggingSettingsRepository: LoggingSettingsRepository
+    val loggingSettingsRepository: LoggingSettingsRepository,
+    private val messageDeleteAuditStateRegistry: MessageDeleteAuditStateRegistry
 ) : ListenerAdapter() {
 
     companion object {
@@ -80,8 +81,6 @@ class GuildLogger
     }
     private val lastCheckedLogEntries: HashMap<Long, AuditLogEntry?> =
         HashMap() //Long key is the guild id and the value is the last checked log entry.
-    private val messageDeleteAuditStates: HashMap<MessageDeleteAuditKey, MessageDeleteAuditState> = HashMap()
-
     @Transactional(readOnly = true)
     override fun onMessageReceived(event: MessageReceivedEvent) {
         if (!event.isFromGuild) {
@@ -252,15 +251,20 @@ class GuildLogger
         }
 
         val consumeResult = MessageDeleteAuditTracker.consume(
-            previousState = messageDeleteAuditStates[auditStateKey],
+            previousState = messageDeleteAuditStateRegistry.get(
+                auditStateKey.guildId,
+                auditStateKey.channelId,
+                auditStateKey.targetUserId
+            ),
             candidates = relevantEntries.map { it.second }
         )
 
-        if (consumeResult.nextState.consumedCounts.isEmpty()) {
-            messageDeleteAuditStates.remove(auditStateKey)
-        } else {
-            messageDeleteAuditStates[auditStateKey] = consumeResult.nextState
-        }
+        messageDeleteAuditStateRegistry.remember(
+            auditStateKey.guildId,
+            auditStateKey.channelId,
+            auditStateKey.targetUserId,
+            consumeResult.nextState
+        )
 
         return relevantEntries.firstOrNull { it.first.idLong == consumeResult.matchedEntryId }?.first?.user
     }

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditStateRegistry.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditStateRegistry.kt
@@ -1,0 +1,43 @@
+package be.duncanc.discordmodbot.logging
+
+import be.duncanc.discordmodbot.logging.persistence.MessageDeleteAuditStateEntry
+import be.duncanc.discordmodbot.logging.persistence.MessageDeleteAuditStateRepository
+import org.springframework.stereotype.Component
+
+@Component
+class MessageDeleteAuditStateRegistry(
+    private val messageDeleteAuditStateRepository: MessageDeleteAuditStateRepository
+) {
+    internal fun remember(guildId: Long, channelId: Long, targetUserId: Long, state: MessageDeleteAuditState) {
+        if (state.consumedCounts.isEmpty()) {
+            forget(guildId, channelId, targetUserId)
+            return
+        }
+
+        messageDeleteAuditStateRepository.save(
+            MessageDeleteAuditStateEntry(
+                id = MessageDeleteAuditStateEntry.createId(guildId, channelId, targetUserId),
+                guildId = guildId,
+                channelId = channelId,
+                targetUserId = targetUserId,
+                consumedCounts = state.consumedCounts
+            )
+        )
+    }
+
+    internal fun get(guildId: Long, channelId: Long, targetUserId: Long): MessageDeleteAuditState? {
+        return messageDeleteAuditStateRepository.findById(
+            MessageDeleteAuditStateEntry.createId(guildId, channelId, targetUserId)
+        ).orElse(null)?.toState()
+    }
+
+    internal fun forget(guildId: Long, channelId: Long, targetUserId: Long) {
+        messageDeleteAuditStateRepository.deleteById(
+            MessageDeleteAuditStateEntry.createId(guildId, channelId, targetUserId)
+        )
+    }
+
+    private fun MessageDeleteAuditStateEntry.toState(): MessageDeleteAuditState {
+        return MessageDeleteAuditState(consumedCounts = consumedCounts)
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTracker.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTracker.kt
@@ -1,36 +1,50 @@
 package be.duncanc.discordmodbot.logging
 
-internal data class MessageDeleteAuditState(
+internal data class MessageDeleteAuditKey(
+    val guildId: Long,
+    val channelId: Long,
+    val targetUserId: Long
+)
+
+internal data class MessageDeleteAuditCandidate(
     val entryId: Long,
-    val count: Int,
-    val consumedCount: Int
+    val count: Int
+)
+
+internal data class MessageDeleteAuditState(
+    val consumedCounts: Map<Long, Int>
 )
 
 internal data class MessageDeleteAuditConsumeResult(
-    val matched: Boolean,
+    val matchedEntryId: Long?,
     val nextState: MessageDeleteAuditState
 )
 
 internal object MessageDeleteAuditTracker {
     fun consume(
         previousState: MessageDeleteAuditState?,
-        entryId: Long,
-        count: Int
+        candidates: List<MessageDeleteAuditCandidate>
     ): MessageDeleteAuditConsumeResult {
-        val consumedCount = if (previousState?.entryId == entryId) {
-            previousState.consumedCount.coerceAtMost(count)
-        } else {
-            0
+        val visibleEntryIds = candidates.asSequence().map { it.entryId }.toSet()
+        val nextConsumedCounts = previousState?.consumedCounts
+            ?.filterKeys { it in visibleEntryIds }
+            ?.toMutableMap()
+            ?: mutableMapOf()
+
+        for (candidate in candidates.asReversed()) {
+            val consumedCount = nextConsumedCounts[candidate.entryId] ?: 0
+            if (candidate.count > consumedCount) {
+                nextConsumedCounts[candidate.entryId] = consumedCount + 1
+                return MessageDeleteAuditConsumeResult(
+                    matchedEntryId = candidate.entryId,
+                    nextState = MessageDeleteAuditState(nextConsumedCounts.toMap())
+                )
+            }
         }
 
-        val matched = count > consumedCount
         return MessageDeleteAuditConsumeResult(
-            matched,
-            MessageDeleteAuditState(
-                entryId = entryId,
-                count = count,
-                consumedCount = if (matched) consumedCount + 1 else consumedCount
-            )
+            matchedEntryId = null,
+            nextState = MessageDeleteAuditState(nextConsumedCounts.toMap())
         )
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTracker.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTracker.kt
@@ -11,6 +11,11 @@ internal data class MessageDeleteAuditCandidate(
     val count: Int
 )
 
+internal data class MessageDeleteAuditWatermark(
+    val entryId: Long,
+    val count: Int
+)
+
 internal data class MessageDeleteAuditState(
     val consumedCounts: Map<Long, Int>
 )
@@ -23,13 +28,28 @@ internal data class MessageDeleteAuditConsumeResult(
 internal object MessageDeleteAuditTracker {
     fun consume(
         previousState: MessageDeleteAuditState?,
-        candidates: List<MessageDeleteAuditCandidate>
+        candidates: List<MessageDeleteAuditCandidate>,
+        watermark: MessageDeleteAuditWatermark? = null
     ): MessageDeleteAuditConsumeResult {
         val visibleEntryIds = candidates.asSequence().map { it.entryId }.toSet()
         val nextConsumedCounts = previousState?.consumedCounts
             ?.filterKeys { it in visibleEntryIds }
             ?.toMutableMap()
             ?: mutableMapOf()
+
+        watermark?.let { currentWatermark ->
+            for (candidate in candidates) {
+                val seededCount = when {
+                    candidate.entryId < currentWatermark.entryId -> candidate.count
+                    candidate.entryId == currentWatermark.entryId -> minOf(candidate.count, currentWatermark.count)
+                    else -> null
+                }
+
+                if (seededCount != null) {
+                    nextConsumedCounts[candidate.entryId] = maxOf(nextConsumedCounts[candidate.entryId] ?: 0, seededCount)
+                }
+            }
+        }
 
         for (candidate in candidates.asReversed()) {
             val consumedCount = nextConsumedCounts[candidate.entryId] ?: 0

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTracker.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTracker.kt
@@ -1,0 +1,36 @@
+package be.duncanc.discordmodbot.logging
+
+internal data class MessageDeleteAuditState(
+    val entryId: Long,
+    val count: Int,
+    val consumedCount: Int
+)
+
+internal data class MessageDeleteAuditConsumeResult(
+    val matched: Boolean,
+    val nextState: MessageDeleteAuditState
+)
+
+internal object MessageDeleteAuditTracker {
+    fun consume(
+        previousState: MessageDeleteAuditState?,
+        entryId: Long,
+        count: Int
+    ): MessageDeleteAuditConsumeResult {
+        val consumedCount = if (previousState?.entryId == entryId) {
+            previousState.consumedCount.coerceAtMost(count)
+        } else {
+            0
+        }
+
+        val matched = count > consumedCount
+        return MessageDeleteAuditConsumeResult(
+            matched,
+            MessageDeleteAuditState(
+                entryId = entryId,
+                count = count,
+                consumedCount = if (matched) consumedCount + 1 else consumedCount
+            )
+        )
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/DiscordMessage.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/DiscordMessage.kt
@@ -5,7 +5,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.Transient
 import org.springframework.data.redis.core.RedisHash
 
-@RedisHash("discordMessage", timeToLive = 86400L)
+@RedisHash("discordMessage", timeToLive = LOGGING_REDIS_TTL_SECONDS)
 data class DiscordMessage(
     @Id
     val messageId: Long,

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/LoggingRedisTtl.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/LoggingRedisTtl.kt
@@ -1,0 +1,3 @@
+package be.duncanc.discordmodbot.logging.persistence
+
+internal const val LOGGING_REDIS_TTL_SECONDS = 86400L

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/MessageDeleteAuditStateEntry.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/MessageDeleteAuditStateEntry.kt
@@ -1,0 +1,18 @@
+package be.duncanc.discordmodbot.logging.persistence
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+
+@RedisHash("messageDeleteAuditState", timeToLive = LOGGING_REDIS_TTL_SECONDS)
+data class MessageDeleteAuditStateEntry(
+    @Id
+    val id: String,
+    val guildId: Long,
+    val channelId: Long,
+    val targetUserId: Long,
+    val consumedCounts: Map<Long, Int>
+) {
+    companion object {
+        fun createId(guildId: Long, channelId: Long, targetUserId: Long): String = "$guildId:$channelId:$targetUserId"
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/MessageDeleteAuditStateRepository.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/MessageDeleteAuditStateRepository.kt
@@ -1,0 +1,7 @@
+package be.duncanc.discordmodbot.logging.persistence
+
+import org.springframework.data.keyvalue.repository.KeyValueRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MessageDeleteAuditStateRepository : KeyValueRepository<MessageDeleteAuditStateEntry, String>

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/GuildLoggerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/GuildLoggerTest.kt
@@ -1,0 +1,119 @@
+package be.duncanc.discordmodbot.logging
+
+import be.duncanc.discordmodbot.logging.persistence.DiscordMessage
+import be.duncanc.discordmodbot.logging.persistence.LoggingSettingsRepository
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.audit.ActionType
+import net.dv8tion.jda.api.audit.AuditLogEntry
+import net.dv8tion.jda.api.audit.AuditLogOption
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.SelfUser
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion
+import net.dv8tion.jda.api.events.message.MessageDeleteEvent
+import net.dv8tion.jda.api.requests.restaction.CacheRestAction
+import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction
+import net.dv8tion.jda.api.requests.restaction.pagination.PaginationAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class GuildLoggerTest {
+    @Mock
+    private lateinit var messageHistory: MessageHistory
+
+    @Mock
+    private lateinit var loggingSettingsRepository: LoggingSettingsRepository
+
+    @Mock
+    private lateinit var messageDeleteAuditStateRegistry: MessageDeleteAuditStateRegistry
+
+    @Mock
+    private lateinit var event: MessageDeleteEvent
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var channel: MessageChannelUnion
+
+    @Mock
+    private lateinit var jda: JDA
+
+    @Mock
+    private lateinit var selfUser: SelfUser
+
+    @Mock
+    private lateinit var moderator: User
+
+    @Mock
+    private lateinit var auditLogEntry: AuditLogEntry
+
+    @Mock
+    private lateinit var auditLogPaginationAction: AuditLogPaginationAction
+
+    @Mock
+    private lateinit var auditLogIterator: PaginationAction.PaginationIterator<AuditLogEntry>
+
+    @Mock
+    private lateinit var userLookup: CacheRestAction<User>
+
+    private lateinit var guildLogger: GuildLogger
+
+    @BeforeEach
+    fun setUp() {
+        guildLogger = GuildLogger(messageHistory, loggingSettingsRepository, messageDeleteAuditStateRegistry)
+    }
+
+    @Test
+    fun `log deleted message resolves audit state before starting user lookup`() {
+        val deletedMessage = DiscordMessage(
+            messageId = 100L,
+            guildId = 1L,
+            channelId = 10L,
+            userId = 20L,
+            content = "deleted content"
+        )
+
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.channel).thenReturn(channel)
+        whenever(event.jda).thenReturn(jda)
+        whenever(channel.idLong).thenReturn(10L)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guild.retrieveAuditLogs()).thenReturn(auditLogPaginationAction)
+        whenever(auditLogPaginationAction.cache(false)).thenReturn(auditLogPaginationAction)
+        whenever(auditLogPaginationAction.limit(5)).thenReturn(auditLogPaginationAction)
+        whenever(auditLogPaginationAction.iterator()).thenReturn(auditLogIterator)
+        whenever(auditLogIterator.hasNext()).thenReturn(true, false)
+        whenever(auditLogIterator.next()).thenReturn(auditLogEntry)
+        whenever(auditLogEntry.idLong).thenReturn(42L)
+        whenever(auditLogEntry.type).thenReturn(ActionType.MESSAGE_DELETE)
+        whenever(auditLogEntry.targetIdLong).thenReturn(20L)
+        whenever(auditLogEntry.user).thenReturn(moderator)
+        whenever(auditLogEntry.getOption<String>(AuditLogOption.CHANNEL)).thenReturn("10")
+        whenever(auditLogEntry.getOption<String>(AuditLogOption.COUNT)).thenReturn("1")
+        whenever(messageDeleteAuditStateRegistry.get(1L, 10L, 20L)).thenReturn(null)
+        whenever(jda.selfUser).thenReturn(selfUser)
+        whenever(jda.retrieveUserById(20L)).thenReturn(userLookup)
+
+        guildLogger.logDeletedMessage(event, deletedMessage, attachmentString = null)
+
+        val stateCaptor = argumentCaptor<MessageDeleteAuditState>()
+        val inOrder = inOrder(messageDeleteAuditStateRegistry, jda)
+        inOrder.verify(messageDeleteAuditStateRegistry).get(1L, 10L, 20L)
+        inOrder.verify(messageDeleteAuditStateRegistry).remember(eq(1L), eq(10L), eq(20L), stateCaptor.capture())
+        inOrder.verify(jda).retrieveUserById(20L)
+        verify(userLookup).queue(any())
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(42L to 1)), stateCaptor.firstValue)
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditStateRegistryTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditStateRegistryTest.kt
@@ -1,0 +1,87 @@
+package be.duncanc.discordmodbot.logging
+
+import be.duncanc.discordmodbot.logging.persistence.MessageDeleteAuditStateEntry
+import be.duncanc.discordmodbot.logging.persistence.MessageDeleteAuditStateRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class MessageDeleteAuditStateRegistryTest {
+    @Mock
+    private lateinit var messageDeleteAuditStateRepository: MessageDeleteAuditStateRepository
+
+    private lateinit var messageDeleteAuditStateRegistry: MessageDeleteAuditStateRegistry
+
+    @BeforeEach
+    fun setUp() {
+        messageDeleteAuditStateRegistry = MessageDeleteAuditStateRegistry(messageDeleteAuditStateRepository)
+    }
+
+    @Test
+    fun `remember stores audit state in redis repository`() {
+        messageDeleteAuditStateRegistry.remember(
+            guildId = 1L,
+            channelId = 2L,
+            targetUserId = 3L,
+            state = MessageDeleteAuditState(consumedCounts = mapOf(42L to 1))
+        )
+
+        verify(messageDeleteAuditStateRepository).save(
+            MessageDeleteAuditStateEntry(
+                id = MessageDeleteAuditStateEntry.createId(1L, 2L, 3L),
+                guildId = 1L,
+                channelId = 2L,
+                targetUserId = 3L,
+                consumedCounts = mapOf(42L to 1)
+            )
+        )
+    }
+
+    @Test
+    fun `remember deletes empty audit state`() {
+        messageDeleteAuditStateRegistry.remember(
+            guildId = 1L,
+            channelId = 2L,
+            targetUserId = 3L,
+            state = MessageDeleteAuditState(consumedCounts = emptyMap())
+        )
+
+        verify(messageDeleteAuditStateRepository).deleteById(MessageDeleteAuditStateEntry.createId(1L, 2L, 3L))
+    }
+
+    @Test
+    fun `get recreates state from redis entry`() {
+        whenever(messageDeleteAuditStateRepository.findById(MessageDeleteAuditStateEntry.createId(1L, 2L, 3L))).thenReturn(
+            Optional.of(
+                MessageDeleteAuditStateEntry(
+                    id = MessageDeleteAuditStateEntry.createId(1L, 2L, 3L),
+                    guildId = 1L,
+                    channelId = 2L,
+                    targetUserId = 3L,
+                    consumedCounts = mapOf(42L to 1, 43L to 2)
+                )
+            )
+        )
+
+        val state = messageDeleteAuditStateRegistry.get(1L, 2L, 3L)
+
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(42L to 1, 43L to 2)), state)
+    }
+
+    @Test
+    fun `get returns null when redis state is missing`() {
+        whenever(messageDeleteAuditStateRepository.findById(MessageDeleteAuditStateEntry.createId(1L, 2L, 3L))).thenReturn(
+            Optional.empty()
+        )
+
+        assertNull(messageDeleteAuditStateRegistry.get(1L, 2L, 3L))
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTrackerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTrackerTest.kt
@@ -79,7 +79,36 @@ class MessageDeleteAuditTrackerTest {
         assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(43L to 1, 42L to 1)), result.nextState)
     }
 
+    @Test
+    fun `consume should ignore historical entries at or before the watermark`() {
+        val result = MessageDeleteAuditTracker.consume(
+            previousState = null,
+            candidates = listOf(candidate(43L, 1), candidate(42L, 1)),
+            watermark = watermark(43L, 1)
+        )
+
+        assertEquals(null, result.matchedEntryId)
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(43L to 1, 42L to 1)), result.nextState)
+    }
+
+    @Test
+    fun `consume should still match newly increased count on the watermark entry`() {
+        val result = MessageDeleteAuditTracker.consume(
+            previousState = null,
+            candidates = listOf(candidate(43L, 2)),
+            watermark = watermark(43L, 1)
+        )
+
+        assertEquals(43L, result.matchedEntryId)
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(43L to 2)), result.nextState)
+    }
+
     private fun candidate(entryId: Long, count: Int): MessageDeleteAuditCandidate = MessageDeleteAuditCandidate(
+        entryId = entryId,
+        count = count
+    )
+
+    private fun watermark(entryId: Long, count: Int): MessageDeleteAuditWatermark = MessageDeleteAuditWatermark(
         entryId = entryId,
         count = count
     )

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTrackerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTrackerTest.kt
@@ -1,0 +1,58 @@
+package be.duncanc.discordmodbot.logging
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MessageDeleteAuditTrackerTest {
+    @Test
+    fun `consume should match the first delete for a new audit log entry`() {
+        val result = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 1)
+
+        assertTrue(result.matched)
+        assertEquals(MessageDeleteAuditState(entryId = 42L, count = 1, consumedCount = 1), result.nextState)
+    }
+
+    @Test
+    fun `consume should match repeated deletes from the same audit log entry`() {
+        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 2)
+        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, entryId = 42L, count = 2)
+
+        assertTrue(firstResult.matched)
+        assertTrue(secondResult.matched)
+        assertEquals(MessageDeleteAuditState(entryId = 42L, count = 2, consumedCount = 2), secondResult.nextState)
+    }
+
+    @Test
+    fun `consume should use newly increased count on the same audit log entry`() {
+        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 2)
+        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, entryId = 42L, count = 3)
+        val thirdResult = MessageDeleteAuditTracker.consume(previousState = secondResult.nextState, entryId = 42L, count = 3)
+
+        assertTrue(firstResult.matched)
+        assertTrue(secondResult.matched)
+        assertTrue(thirdResult.matched)
+        assertEquals(MessageDeleteAuditState(entryId = 42L, count = 3, consumedCount = 3), thirdResult.nextState)
+    }
+
+    @Test
+    fun `consume should stop matching once the known count is exhausted`() {
+        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 1)
+        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, entryId = 42L, count = 1)
+
+        assertTrue(firstResult.matched)
+        assertFalse(secondResult.matched)
+        assertEquals(MessageDeleteAuditState(entryId = 42L, count = 1, consumedCount = 1), secondResult.nextState)
+    }
+
+    @Test
+    fun `consume should reset consumption for a newer audit log entry`() {
+        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 2)
+        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, entryId = 43L, count = 1)
+
+        assertTrue(firstResult.matched)
+        assertTrue(secondResult.matched)
+        assertEquals(MessageDeleteAuditState(entryId = 43L, count = 1, consumedCount = 1), secondResult.nextState)
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTrackerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageDeleteAuditTrackerTest.kt
@@ -2,57 +2,85 @@ package be.duncanc.discordmodbot.logging
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class MessageDeleteAuditTrackerTest {
     @Test
     fun `consume should match the first delete for a new audit log entry`() {
-        val result = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 1)
+        val result = MessageDeleteAuditTracker.consume(previousState = null, candidates = listOf(candidate(42L, 1)))
 
-        assertTrue(result.matched)
-        assertEquals(MessageDeleteAuditState(entryId = 42L, count = 1, consumedCount = 1), result.nextState)
+        assertEquals(42L, result.matchedEntryId)
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(42L to 1)), result.nextState)
     }
 
     @Test
     fun `consume should match repeated deletes from the same audit log entry`() {
-        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 2)
-        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, entryId = 42L, count = 2)
+        val candidates = listOf(candidate(42L, 2))
+        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, candidates = candidates)
+        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, candidates = candidates)
 
-        assertTrue(firstResult.matched)
-        assertTrue(secondResult.matched)
-        assertEquals(MessageDeleteAuditState(entryId = 42L, count = 2, consumedCount = 2), secondResult.nextState)
+        assertEquals(42L, firstResult.matchedEntryId)
+        assertEquals(42L, secondResult.matchedEntryId)
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(42L to 2)), secondResult.nextState)
     }
 
     @Test
     fun `consume should use newly increased count on the same audit log entry`() {
-        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 2)
-        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, entryId = 42L, count = 3)
-        val thirdResult = MessageDeleteAuditTracker.consume(previousState = secondResult.nextState, entryId = 42L, count = 3)
+        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, candidates = listOf(candidate(42L, 2)))
+        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, candidates = listOf(candidate(42L, 3)))
+        val thirdResult = MessageDeleteAuditTracker.consume(previousState = secondResult.nextState, candidates = listOf(candidate(42L, 3)))
 
-        assertTrue(firstResult.matched)
-        assertTrue(secondResult.matched)
-        assertTrue(thirdResult.matched)
-        assertEquals(MessageDeleteAuditState(entryId = 42L, count = 3, consumedCount = 3), thirdResult.nextState)
+        assertEquals(42L, firstResult.matchedEntryId)
+        assertEquals(42L, secondResult.matchedEntryId)
+        assertEquals(42L, thirdResult.matchedEntryId)
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(42L to 3)), thirdResult.nextState)
     }
 
     @Test
     fun `consume should stop matching once the known count is exhausted`() {
-        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 1)
-        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, entryId = 42L, count = 1)
+        val candidates = listOf(candidate(42L, 1))
+        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, candidates = candidates)
+        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, candidates = candidates)
 
-        assertTrue(firstResult.matched)
-        assertFalse(secondResult.matched)
-        assertEquals(MessageDeleteAuditState(entryId = 42L, count = 1, consumedCount = 1), secondResult.nextState)
+        assertEquals(42L, firstResult.matchedEntryId)
+        assertEquals(null, secondResult.matchedEntryId)
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(42L to 1)), secondResult.nextState)
     }
 
     @Test
     fun `consume should reset consumption for a newer audit log entry`() {
-        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, entryId = 42L, count = 2)
-        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, entryId = 43L, count = 1)
+        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, candidates = listOf(candidate(42L, 2)))
+        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, candidates = listOf(candidate(43L, 1)))
 
-        assertTrue(firstResult.matched)
-        assertTrue(secondResult.matched)
-        assertEquals(MessageDeleteAuditState(entryId = 43L, count = 1, consumedCount = 1), secondResult.nextState)
+        assertEquals(42L, firstResult.matchedEntryId)
+        assertEquals(43L, secondResult.matchedEntryId)
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(43L to 1)), secondResult.nextState)
     }
+
+    @Test
+    fun `consume should prefer the oldest remaining audit log entry`() {
+        val candidates = listOf(candidate(43L, 1), candidate(42L, 1))
+
+        val firstResult = MessageDeleteAuditTracker.consume(previousState = null, candidates = candidates)
+        val secondResult = MessageDeleteAuditTracker.consume(previousState = firstResult.nextState, candidates = candidates)
+
+        assertEquals(42L, firstResult.matchedEntryId)
+        assertEquals(43L, secondResult.matchedEntryId)
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(42L to 1, 43L to 1)), secondResult.nextState)
+    }
+
+    @Test
+    fun `consume should fall back to an older audit log entry when the newest is exhausted`() {
+        val result = MessageDeleteAuditTracker.consume(
+            previousState = MessageDeleteAuditState(consumedCounts = mapOf(43L to 1)),
+            candidates = listOf(candidate(43L, 1), candidate(42L, 1))
+        )
+
+        assertEquals(42L, result.matchedEntryId)
+        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(43L to 1, 42L to 1)), result.nextState)
+    }
+
+    private fun candidate(entryId: Long, count: Int): MessageDeleteAuditCandidate = MessageDeleteAuditCandidate(
+        entryId = entryId,
+        count = count
+    )
 }


### PR DESCRIPTION
## Summary
- keep message delete audit attribution stable by storing consumed audit counts in Redis and restoring the startup watermark
- resolve the out-of-order callback case by matching moderators on the guild logger executor before starting async user lookups
- add focused tests for the tracker, state registry, and GuildLogger ordering regression