### PR TITLE
feat(moderation): add sticky role restoration on rejoin

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/StickyRoleService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/StickyRoleService.kt
@@ -89,8 +89,6 @@ class StickyRoleService(
             .filter { role -> member.roles.none { it.idLong == role.idLong } }
             .toList()
 
-        stickyRoleSnapshotRepository.delete(snapshot)
-
         if (rolesToRestore.isEmpty()) {
             return
         }
@@ -104,6 +102,7 @@ class StickyRoleService(
             .reason(RESTORE_REASON)
             .queue(
                 {
+                    deleteSnapshot(guild.idLong, member.idLong)
                     logStickyRoleRestore(guild, member, rolesToRestore)
                 },
                 { throwable ->

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/StickyRoleService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/StickyRoleService.kt
@@ -1,0 +1,164 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.discord.nicknameAndUsername
+import be.duncanc.discordmodbot.logging.GuildLogger
+import be.duncanc.discordmodbot.moderation.persistence.StickyRoleConfig
+import be.duncanc.discordmodbot.moderation.persistence.StickyRoleConfigRepository
+import be.duncanc.discordmodbot.moderation.persistence.StickyRoleSnapshot
+import be.duncanc.discordmodbot.moderation.persistence.StickyRoleSnapshotRepository
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.awt.Color
+
+@Service
+@Transactional(readOnly = true)
+class StickyRoleService(
+    private val stickyRoleConfigRepository: StickyRoleConfigRepository,
+    private val stickyRoleSnapshotRepository: StickyRoleSnapshotRepository,
+    private val guildLogger: GuildLogger
+) {
+    companion object {
+        private val LOG = LoggerFactory.getLogger(StickyRoleService::class.java)
+        private const val RESTORE_REASON = "Restoring previously saved sticky roles on rejoin"
+    }
+
+    fun getConfiguredRoleIds(guildId: Long): Set<Long> {
+        return stickyRoleConfigRepository.findById(guildId).orElse(null)?.roleIds ?: emptySet()
+    }
+
+    @Transactional
+    fun addConfiguredRole(guildId: Long, roleId: Long) {
+        val config = stickyRoleConfigRepository.findById(guildId).orElse(StickyRoleConfig(guildId))
+        config.roleIds.add(roleId)
+        stickyRoleConfigRepository.save(config)
+    }
+
+    @Transactional
+    fun removeConfiguredRole(guildId: Long, roleId: Long) {
+        stickyRoleConfigRepository.findById(guildId).ifPresent { config ->
+            config.roleIds.remove(roleId)
+            if (config.roleIds.isEmpty()) {
+                stickyRoleConfigRepository.delete(config)
+            } else {
+                stickyRoleConfigRepository.save(config)
+            }
+        }
+
+        removeRoleFromSnapshots(guildId, roleId)
+    }
+
+    @Transactional
+    fun clearConfiguredRoles(guildId: Long) {
+        stickyRoleConfigRepository.deleteById(guildId)
+        stickyRoleSnapshotRepository.deleteAllByGuildId(guildId)
+    }
+
+    @Transactional
+    fun captureRolesOnLeave(guildId: Long, userId: Long, memberRoleIds: Collection<Long>) {
+        val configuredRoleIds = getConfiguredRoleIds(guildId)
+        if (configuredRoleIds.isEmpty()) {
+            deleteSnapshot(guildId, userId)
+            return
+        }
+
+        val savedRoleIds = memberRoleIds.filterTo(linkedSetOf()) { it in configuredRoleIds }
+        if (savedRoleIds.isEmpty()) {
+            deleteSnapshot(guildId, userId)
+            return
+        }
+
+        stickyRoleSnapshotRepository.save(StickyRoleSnapshot(guildId, userId, savedRoleIds))
+    }
+
+    @Transactional
+    fun restoreRolesOnJoin(guild: Guild, member: Member) {
+        val snapshotId = StickyRoleSnapshot.StickyRoleSnapshotId(guild.idLong, member.idLong)
+        val snapshot = stickyRoleSnapshotRepository.findById(snapshotId).orElse(null) ?: return
+        val configuredRoleIds = getConfiguredRoleIds(guild.idLong)
+        val rolesToRestore = snapshot.roleIds
+            .asSequence()
+            .filter { it in configuredRoleIds }
+            .mapNotNull(guild::getRoleById)
+            .filter(::isRestorableRole)
+            .filter { role -> member.roles.none { it.idLong == role.idLong } }
+            .toList()
+
+        stickyRoleSnapshotRepository.delete(snapshot)
+
+        if (rolesToRestore.isEmpty()) {
+            return
+        }
+
+        if (!guild.selfMember.hasPermission(Permission.MANAGE_ROLES)) {
+            LOG.warn("Unable to restore sticky roles for {} in guild {} due to missing manage roles permission", member.id, guild.id)
+            return
+        }
+
+        guild.modifyMemberRoles(member, rolesToRestore, null)
+            .reason(RESTORE_REASON)
+            .queue(
+                {
+                    logStickyRoleRestore(guild, member, rolesToRestore)
+                },
+                { throwable ->
+                    LOG.warn("Failed to restore sticky roles for {} in guild {}", member.id, guild.id, throwable)
+                }
+            )
+    }
+
+    @Transactional
+    fun removeDeletedRole(guildId: Long, roleId: Long) {
+        removeConfiguredRole(guildId, roleId)
+    }
+
+    @Transactional
+    fun clearGuildState(guildId: Long) {
+        stickyRoleConfigRepository.deleteById(guildId)
+        stickyRoleSnapshotRepository.deleteAllByGuildId(guildId)
+    }
+
+    private fun isRestorableRole(role: Role): Boolean {
+        return !role.isPublicRole && !role.isManaged && role.guild.selfMember.canInteract(role)
+    }
+
+    @Transactional
+    fun deleteSnapshot(guildId: Long, userId: Long) {
+        stickyRoleSnapshotRepository.deleteById(StickyRoleSnapshot.StickyRoleSnapshotId(guildId, userId))
+    }
+
+    private fun removeRoleFromSnapshots(guildId: Long, roleId: Long) {
+        stickyRoleSnapshotRepository.findAllByGuildId(guildId).forEach { snapshot ->
+            if (!snapshot.roleIds.remove(roleId)) {
+                return@forEach
+            }
+
+            if (snapshot.roleIds.isEmpty()) {
+                stickyRoleSnapshotRepository.delete(snapshot)
+            } else {
+                stickyRoleSnapshotRepository.save(snapshot)
+            }
+        }
+    }
+
+    private fun logStickyRoleRestore(guild: Guild, member: Member, restoredRoles: List<Role>) {
+        val logEmbed = EmbedBuilder()
+            .setColor(Color.YELLOW)
+            .setTitle("Sticky roles restored")
+            .addField("User", member.nicknameAndUsername, true)
+            .addField("Roles", restoredRoles.joinToString("\n") { it.asMention }, false)
+            .addField("Reason", "Previously saved sticky roles were restored on rejoin", false)
+
+        guildLogger.log(
+            guild = guild,
+            associatedUser = member.user,
+            logEmbed = logEmbed,
+            actionType = GuildLogger.LogTypeAction.MODERATOR
+        )
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/StickyRolesCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/StickyRolesCommand.kt
@@ -1,0 +1,157 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.discord.SlashCommand
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
+import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.events.role.RoleDeleteEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import net.dv8tion.jda.api.interactions.InteractionContextType
+import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.stereotype.Component
+
+@Component
+class StickyRolesCommand(
+    private val stickyRoleService: StickyRoleService
+) : ListenerAdapter(), SlashCommand {
+    companion object {
+        private const val COMMAND = "stickyroles"
+        private const val DESCRIPTION = "Configure which roles are restored when users rejoin."
+
+        private const val SUBCOMMAND_SHOW = "show"
+        private const val SUBCOMMAND_ADD = "add"
+        private const val SUBCOMMAND_REMOVE = "remove"
+        private const val SUBCOMMAND_CLEAR = "clear"
+
+        private const val OPTION_ROLE = "role"
+    }
+
+    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+        if (event.name != COMMAND) {
+            return
+        }
+
+        val guild = event.guild
+        val member = event.member
+        if (guild == null || member == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.hasPermission(Permission.MANAGE_ROLES)) {
+            event.reply("You need manage roles permission to use this command.").setEphemeral(true).queue()
+            return
+        }
+
+        when (event.subcommandName) {
+            null, SUBCOMMAND_SHOW -> showCurrentSettings(event, guild)
+            SUBCOMMAND_ADD -> addRole(event, guild)
+            SUBCOMMAND_REMOVE -> removeRole(event, guild)
+            SUBCOMMAND_CLEAR -> {
+                stickyRoleService.clearConfiguredRoles(guild.idLong)
+                event.reply("Sticky roles cleared.").setEphemeral(true).queue()
+            }
+
+            else -> event.reply("Please choose a valid /stickyroles subcommand.").setEphemeral(true).queue()
+        }
+    }
+
+    override fun onGuildMemberRemove(event: GuildMemberRemoveEvent) {
+        val member = event.member ?: return
+        stickyRoleService.captureRolesOnLeave(event.guild.idLong, event.user.idLong, member.roles.map { it.idLong })
+    }
+
+    override fun onGuildMemberJoin(event: GuildMemberJoinEvent) {
+        stickyRoleService.restoreRolesOnJoin(event.guild, event.member)
+    }
+
+    override fun onRoleDelete(event: RoleDeleteEvent) {
+        stickyRoleService.removeDeletedRole(event.guild.idLong, event.role.idLong)
+    }
+
+    override fun onGuildLeave(event: GuildLeaveEvent) {
+        stickyRoleService.clearGuildState(event.guild.idLong)
+    }
+
+    override fun getCommandsData(): List<SlashCommandData> {
+        return listOf(
+            Commands.slash(COMMAND, DESCRIPTION)
+                .setContexts(InteractionContextType.GUILD)
+                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
+                .addSubcommands(
+                    SubcommandData(SUBCOMMAND_SHOW, "Show the configured sticky roles"),
+                    SubcommandData(SUBCOMMAND_ADD, "Add a sticky role")
+                        .addOptions(OptionData(OptionType.ROLE, OPTION_ROLE, "Role to restore on rejoin", true)),
+                    SubcommandData(SUBCOMMAND_REMOVE, "Remove a sticky role")
+                        .addOptions(OptionData(OptionType.ROLE, OPTION_ROLE, "Role to stop restoring", true)),
+                    SubcommandData(SUBCOMMAND_CLEAR, "Clear all sticky role configuration")
+                )
+        )
+    }
+
+    private fun showCurrentSettings(event: SlashCommandInteractionEvent, guild: Guild) {
+        val configuredRoles = stickyRoleService.getConfiguredRoleIds(guild.idLong)
+        val message = buildString {
+            appendLine("Sticky role settings for ${guild.name}")
+            appendLine()
+            if (configuredRoles.isEmpty()) {
+                appendLine("- Sticky roles: Not configured")
+            } else {
+                appendLine("- Sticky roles:")
+                configuredRoles
+                    .map { roleId -> guild.getRoleById(roleId)?.asMention ?: "Missing role (ID: $roleId)" }
+                    .sorted()
+                    .forEach { appendLine("  $it") }
+            }
+        }
+
+        event.reply(message).setEphemeral(true).queue()
+    }
+
+    private fun addRole(event: SlashCommandInteractionEvent, guild: Guild) {
+        val role = getRequiredRole(event) ?: return
+        val validationError = validateStickyRole(role)
+        if (validationError != null) {
+            event.reply(validationError).setEphemeral(true).queue()
+            return
+        }
+
+        stickyRoleService.addConfiguredRole(guild.idLong, role.idLong)
+        event.reply("Added ${role.asMention} to sticky roles.").setEphemeral(true).queue()
+    }
+
+    private fun removeRole(event: SlashCommandInteractionEvent, guild: Guild) {
+        val role = getRequiredRole(event) ?: return
+        stickyRoleService.removeConfiguredRole(guild.idLong, role.idLong)
+        event.reply("Removed ${role.asMention} from sticky roles.").setEphemeral(true).queue()
+    }
+
+    internal fun getRequiredRole(event: SlashCommandInteractionEvent): Role? {
+        val role = event.getOption(OPTION_ROLE)?.asRole
+        if (role == null) {
+            event.reply("Please choose a role.").setEphemeral(true).queue()
+            return null
+        }
+
+        return role
+    }
+
+    private fun validateStickyRole(role: Role): String? {
+        return when {
+            role.isPublicRole -> "The @everyone role cannot be made sticky."
+            role.isManaged -> "Managed roles cannot be made sticky."
+            !role.guild.selfMember.hasPermission(Permission.MANAGE_ROLES) -> "I need manage roles permission to restore sticky roles."
+            !role.guild.selfMember.canInteract(role) -> "I can't restore that role because it is above my highest role."
+            else -> null
+        }
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/StickyRoleConfig.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/StickyRoleConfig.kt
@@ -1,0 +1,26 @@
+package be.duncanc.discordmodbot.moderation.persistence
+
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "sticky_role_configs")
+data class StickyRoleConfig(
+    @Id
+    @Column(name = "guild_id", updatable = false)
+    val guildId: Long,
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "sticky_role_config_roles",
+        joinColumns = [JoinColumn(name = "sticky_role_config_guild_id")]
+    )
+    @Column(name = "role_id", nullable = false)
+    var roleIds: MutableSet<Long> = HashSet()
+)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/StickyRoleConfigRepository.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/StickyRoleConfigRepository.kt
@@ -1,0 +1,7 @@
+package be.duncanc.discordmodbot.moderation.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface StickyRoleConfigRepository : JpaRepository<StickyRoleConfig, Long>

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/StickyRoleSnapshot.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/StickyRoleSnapshot.kt
@@ -1,0 +1,40 @@
+package be.duncanc.discordmodbot.moderation.persistence
+
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+import java.io.Serializable
+
+@Entity
+@Table(name = "sticky_role_snapshots")
+@IdClass(StickyRoleSnapshot.StickyRoleSnapshotId::class)
+data class StickyRoleSnapshot(
+    @Id
+    @Column(name = "guild_id", updatable = false)
+    val guildId: Long,
+    @Id
+    @Column(name = "user_id", updatable = false)
+    val userId: Long,
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "sticky_role_snapshot_roles",
+        joinColumns = [
+            JoinColumn(name = "sticky_role_snapshot_guild_id", referencedColumnName = "guild_id"),
+            JoinColumn(name = "sticky_role_snapshot_user_id", referencedColumnName = "user_id")
+        ]
+    )
+    @Column(name = "role_id", nullable = false)
+    var roleIds: MutableSet<Long> = HashSet()
+) {
+    data class StickyRoleSnapshotId(
+        val guildId: Long? = null,
+        val userId: Long? = null
+    ) : Serializable
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/StickyRoleSnapshotRepository.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/StickyRoleSnapshotRepository.kt
@@ -1,0 +1,11 @@
+package be.duncanc.discordmodbot.moderation.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface StickyRoleSnapshotRepository : JpaRepository<StickyRoleSnapshot, StickyRoleSnapshot.StickyRoleSnapshotId> {
+    fun findAllByGuildId(guildId: Long): List<StickyRoleSnapshot>
+
+    fun deleteAllByGuildId(guildId: Long)
+}

--- a/src/main/resources/db/migration/V10__add_sticky_roles.sql
+++ b/src/main/resources/db/migration/V10__add_sticky_roles.sql
@@ -1,0 +1,36 @@
+create table sticky_role_configs
+(
+    guild_id bigint not null,
+    primary key (guild_id)
+);
+
+create table sticky_role_config_roles
+(
+    sticky_role_config_guild_id bigint not null,
+    role_id                     bigint not null,
+    primary key (sticky_role_config_guild_id, role_id)
+);
+
+create table sticky_role_snapshots
+(
+    guild_id bigint not null,
+    user_id  bigint not null,
+    primary key (guild_id, user_id)
+);
+
+create table sticky_role_snapshot_roles
+(
+    sticky_role_snapshot_guild_id bigint not null,
+    sticky_role_snapshot_user_id  bigint not null,
+    role_id                       bigint not null,
+    primary key (sticky_role_snapshot_guild_id, sticky_role_snapshot_user_id, role_id)
+);
+
+alter table sticky_role_config_roles
+    add constraint fk_sticky_role_config_roles
+        foreign key (sticky_role_config_guild_id) references sticky_role_configs (guild_id);
+
+alter table sticky_role_snapshot_roles
+    add constraint fk_sticky_role_snapshot_roles
+        foreign key (sticky_role_snapshot_guild_id, sticky_role_snapshot_user_id)
+            references sticky_role_snapshots (guild_id, user_id);

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/StickyRoleServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/StickyRoleServiceTest.kt
@@ -1,0 +1,152 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.logging.GuildLogger
+import be.duncanc.discordmodbot.moderation.persistence.StickyRoleConfig
+import be.duncanc.discordmodbot.moderation.persistence.StickyRoleConfigRepository
+import be.duncanc.discordmodbot.moderation.persistence.StickyRoleSnapshot
+import be.duncanc.discordmodbot.moderation.persistence.StickyRoleSnapshotRepository
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class StickyRoleServiceTest {
+    @Mock
+    private lateinit var stickyRoleConfigRepository: StickyRoleConfigRepository
+
+    @Mock
+    private lateinit var stickyRoleSnapshotRepository: StickyRoleSnapshotRepository
+
+    @Mock
+    private lateinit var guildLogger: GuildLogger
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var member: Member
+
+    @Mock
+    private lateinit var selfMember: SelfMember
+
+    @Mock
+    private lateinit var role: Role
+
+    @Mock
+    private lateinit var user: User
+
+    @Mock
+    private lateinit var roleUpdateAction: AuditableRestAction<Void>
+
+    private lateinit var service: StickyRoleService
+
+    @BeforeEach
+    fun setUp() {
+        service = StickyRoleService(stickyRoleConfigRepository, stickyRoleSnapshotRepository, guildLogger)
+    }
+
+    @Test
+    fun `capture roles on leave stores configured roles only`() {
+        whenever(stickyRoleConfigRepository.findById(1L)).thenReturn(
+            Optional.of(StickyRoleConfig(1L, mutableSetOf(11L, 12L)))
+        )
+
+        service.captureRolesOnLeave(1L, 99L, listOf(10L, 11L, 13L))
+
+        val snapshotCaptor = argumentCaptor<StickyRoleSnapshot>()
+        verify(stickyRoleSnapshotRepository).save(snapshotCaptor.capture())
+        assertEquals(1L, snapshotCaptor.firstValue.guildId)
+        assertEquals(99L, snapshotCaptor.firstValue.userId)
+        assertEquals(setOf(11L), snapshotCaptor.firstValue.roleIds)
+    }
+
+    @Test
+    fun `capture roles on leave deletes snapshot when no roles match`() {
+        whenever(stickyRoleConfigRepository.findById(1L)).thenReturn(
+            Optional.of(StickyRoleConfig(1L, mutableSetOf(11L)))
+        )
+
+        service.captureRolesOnLeave(1L, 99L, listOf(10L))
+
+        verify(stickyRoleSnapshotRepository).deleteById(StickyRoleSnapshot.StickyRoleSnapshotId(1L, 99L))
+        verify(stickyRoleSnapshotRepository, never()).save(any())
+    }
+
+    @Test
+    fun `restore roles on join reapplies restorable sticky roles and logs action`() {
+        val snapshotId = StickyRoleSnapshot.StickyRoleSnapshotId(1L, 99L)
+        whenever(stickyRoleSnapshotRepository.findById(snapshotId)).thenReturn(
+            Optional.of(StickyRoleSnapshot(1L, 99L, mutableSetOf(11L, 12L)))
+        )
+        whenever(stickyRoleConfigRepository.findById(1L)).thenReturn(
+            Optional.of(StickyRoleConfig(1L, mutableSetOf(11L, 12L)))
+        )
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(member.idLong).thenReturn(99L)
+        whenever(member.roles).thenReturn(emptyList())
+        whenever(guild.getRoleById(11L)).thenReturn(role)
+        whenever(guild.getRoleById(12L)).thenReturn(null)
+        whenever(role.isPublicRole).thenReturn(false)
+        whenever(role.isManaged).thenReturn(false)
+        whenever(role.guild).thenReturn(guild)
+        whenever(guild.selfMember).thenReturn(selfMember)
+        whenever(selfMember.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(selfMember.canInteract(role)).thenReturn(true)
+        whenever(guild.modifyMemberRoles(member, listOf(role), null)).thenReturn(roleUpdateAction)
+        whenever(roleUpdateAction.reason(any())).thenReturn(roleUpdateAction)
+
+        service.restoreRolesOnJoin(guild, member)
+
+        verify(stickyRoleSnapshotRepository).delete(StickyRoleSnapshot(1L, 99L, mutableSetOf(11L, 12L)))
+        verify(guild).modifyMemberRoles(member, listOf(role), null)
+        verify(roleUpdateAction).queue(any(), any())
+    }
+
+    @Test
+    fun `remove configured role also strips it from saved snapshots`() {
+        whenever(stickyRoleConfigRepository.findById(1L)).thenReturn(
+            Optional.of(StickyRoleConfig(1L, mutableSetOf(11L, 12L)))
+        )
+        whenever(stickyRoleSnapshotRepository.findAllByGuildId(1L)).thenReturn(
+            listOf(
+                StickyRoleSnapshot(1L, 99L, mutableSetOf(11L, 13L)),
+                StickyRoleSnapshot(1L, 100L, mutableSetOf(11L))
+            )
+        )
+
+        service.removeConfiguredRole(1L, 11L)
+
+        val configCaptor = argumentCaptor<StickyRoleConfig>()
+        verify(stickyRoleConfigRepository).save(configCaptor.capture())
+        assertEquals(setOf(12L), configCaptor.firstValue.roleIds)
+
+        val snapshotCaptor = argumentCaptor<StickyRoleSnapshot>()
+        verify(stickyRoleSnapshotRepository).save(snapshotCaptor.capture())
+        assertEquals(setOf(13L), snapshotCaptor.firstValue.roleIds)
+        verify(stickyRoleSnapshotRepository).delete(StickyRoleSnapshot(1L, 100L, mutableSetOf()))
+    }
+
+    @Test
+    fun `clear configured roles removes config and snapshots`() {
+        service.clearConfiguredRoles(1L)
+
+        verify(stickyRoleConfigRepository).deleteById(1L)
+        verify(stickyRoleSnapshotRepository).deleteAllByGuildId(1L)
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/StickyRoleServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/StickyRoleServiceTest.kt
@@ -19,9 +19,11 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.function.Consumer
 import java.util.Optional
 import kotlin.test.assertEquals
 
@@ -113,9 +115,43 @@ class StickyRoleServiceTest {
 
         service.restoreRolesOnJoin(guild, member)
 
-        verify(stickyRoleSnapshotRepository).delete(StickyRoleSnapshot(1L, 99L, mutableSetOf(11L, 12L)))
         verify(guild).modifyMemberRoles(member, listOf(role), null)
-        verify(roleUpdateAction).queue(any(), any())
+        val successCaptor = argumentCaptor<Consumer<Void>>()
+        val failureCaptor = argumentCaptor<Consumer<Throwable>>()
+        verify(roleUpdateAction).queue(successCaptor.capture(), failureCaptor.capture())
+        verify(stickyRoleSnapshotRepository, never()).deleteById(snapshotId)
+    }
+
+    @Test
+    fun `restore roles on join keeps snapshot when role restore fails`() {
+        val snapshotId = StickyRoleSnapshot.StickyRoleSnapshotId(1L, 99L)
+        whenever(stickyRoleSnapshotRepository.findById(snapshotId)).thenReturn(
+            Optional.of(StickyRoleSnapshot(1L, 99L, mutableSetOf(11L)))
+        )
+        whenever(stickyRoleConfigRepository.findById(1L)).thenReturn(
+            Optional.of(StickyRoleConfig(1L, mutableSetOf(11L)))
+        )
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(member.idLong).thenReturn(99L)
+        whenever(member.roles).thenReturn(emptyList())
+        whenever(guild.getRoleById(11L)).thenReturn(role)
+        whenever(role.isPublicRole).thenReturn(false)
+        whenever(role.isManaged).thenReturn(false)
+        whenever(role.guild).thenReturn(guild)
+        whenever(guild.selfMember).thenReturn(selfMember)
+        whenever(selfMember.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(selfMember.canInteract(role)).thenReturn(true)
+        whenever(guild.modifyMemberRoles(member, listOf(role), null)).thenReturn(roleUpdateAction)
+        whenever(roleUpdateAction.reason(any())).thenReturn(roleUpdateAction)
+
+        service.restoreRolesOnJoin(guild, member)
+
+        val failureCaptor = argumentCaptor<Consumer<Throwable>>()
+        verify(roleUpdateAction).queue(any(), failureCaptor.capture())
+
+        failureCaptor.firstValue.accept(RuntimeException("restore failed"))
+
+        verify(stickyRoleSnapshotRepository, never()).deleteById(snapshotId)
     }
 
     @Test

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/StickyRolesCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/StickyRolesCommandTest.kt
@@ -1,0 +1,218 @@
+package be.duncanc.discordmodbot.moderation
+
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionContextType
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class StickyRolesCommandTest {
+    @Mock
+    private lateinit var stickyRoleService: StickyRoleService
+
+    @Mock
+    private lateinit var slashEvent: SlashCommandInteractionEvent
+
+    @Mock
+    private lateinit var guildLeaveEvent: GuildLeaveEvent
+
+    @Mock
+    private lateinit var guildMemberRemoveEvent: GuildMemberRemoveEvent
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var member: Member
+
+    @Mock
+    private lateinit var selfMember: SelfMember
+
+    @Mock
+    private lateinit var role: Role
+
+    @Mock
+    private lateinit var user: User
+
+    @Mock
+    private lateinit var replyAction: ReplyCallbackAction
+
+    private lateinit var command: TestStickyRolesCommand
+
+    @BeforeEach
+    fun setUp() {
+        command = TestStickyRolesCommand(stickyRoleService)
+    }
+
+    @Test
+    fun `non matching command returns early`() {
+        whenever(slashEvent.name).thenReturn("othercommand")
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent, never()).reply(any<String>())
+    }
+
+    @Test
+    fun `missing manage roles permission returns error`() {
+        stubSlashCommandContext()
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(false)
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).reply("You need manage roles permission to use this command.")
+    }
+
+    @Test
+    fun `show displays configured sticky roles`() {
+        stubAuthorizedSlashCommand("show")
+        whenever(guild.name).thenReturn("Test Guild")
+        whenever(stickyRoleService.getConfiguredRoleIds(1L)).thenReturn(setOf(11L, 12L))
+        whenever(guild.getRoleById(11L)).thenReturn(role)
+        whenever(guild.getRoleById(12L)).thenReturn(null)
+        whenever(role.asMention).thenReturn("<@&11>")
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val replyCaptor = argumentCaptor<String>()
+        verify(slashEvent).reply(replyCaptor.capture())
+        assertTrue(replyCaptor.firstValue.contains("Sticky role settings for Test Guild"))
+        assertTrue(replyCaptor.firstValue.contains("<@&11>"))
+        assertTrue(replyCaptor.firstValue.contains("Missing role (ID: 12)"))
+    }
+
+    @Test
+    fun `add stores sticky role`() {
+        stubAuthorizedSlashCommand("add")
+        whenever(guild.selfMember).thenReturn(selfMember)
+        whenever(selfMember.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(selfMember.canInteract(role)).thenReturn(true)
+        whenever(role.guild).thenReturn(guild)
+        whenever(role.idLong).thenReturn(11L)
+        whenever(role.asMention).thenReturn("<@&11>")
+        whenever(role.isPublicRole).thenReturn(false)
+        whenever(role.isManaged).thenReturn(false)
+        command.selectedRole = role
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(stickyRoleService).addConfiguredRole(1L, 11L)
+        verify(slashEvent).reply("Added <@&11> to sticky roles.")
+    }
+
+    @Test
+    fun `managed role cannot be added`() {
+        stubSlashCommandContext()
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(slashEvent.subcommandName).thenReturn("add")
+        whenever(role.isManaged).thenReturn(true)
+        whenever(role.isPublicRole).thenReturn(false)
+        command.selectedRole = role
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).reply("Managed roles cannot be made sticky.")
+    }
+
+    @Test
+    fun `remove deletes sticky role`() {
+        stubAuthorizedSlashCommand("remove")
+        whenever(role.idLong).thenReturn(11L)
+        whenever(role.asMention).thenReturn("<@&11>")
+        command.selectedRole = role
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(stickyRoleService).removeConfiguredRole(1L, 11L)
+        verify(slashEvent).reply("Removed <@&11> from sticky roles.")
+    }
+
+    @Test
+    fun `clear removes sticky role state`() {
+        stubAuthorizedSlashCommand("clear")
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(stickyRoleService).clearConfiguredRoles(1L)
+        verify(slashEvent).reply("Sticky roles cleared.")
+    }
+
+    @Test
+    fun `guild member remove stores member role ids`() {
+        whenever(guildMemberRemoveEvent.guild).thenReturn(guild)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guildMemberRemoveEvent.user).thenReturn(user)
+        whenever(user.idLong).thenReturn(99L)
+        whenever(guildMemberRemoveEvent.member).thenReturn(member)
+        whenever(member.roles).thenReturn(listOf(role))
+        whenever(role.idLong).thenReturn(11L)
+
+        command.onGuildMemberRemove(guildMemberRemoveEvent)
+
+        verify(stickyRoleService).captureRolesOnLeave(1L, 99L, listOf(11L))
+    }
+
+    @Test
+    fun `guild leave clears guild state`() {
+        whenever(guildLeaveEvent.guild).thenReturn(guild)
+        whenever(guild.idLong).thenReturn(1L)
+
+        command.onGuildLeave(guildLeaveEvent)
+
+        verify(stickyRoleService).clearGuildState(1L)
+    }
+
+    @Test
+    fun `command data exposes expected metadata`() {
+        val commandData = command.getCommandsData().single()
+
+        assertEquals("stickyroles", commandData.name)
+        assertEquals(setOf(InteractionContextType.GUILD), commandData.contexts)
+        assertEquals(listOf("show", "add", "remove", "clear"), commandData.subcommands.map(SubcommandData::getName))
+    }
+
+    private fun stubSlashCommandContext(member: Member? = this.member) {
+        whenever(slashEvent.name).thenReturn("stickyroles")
+        whenever(slashEvent.guild).thenReturn(guild)
+        whenever(slashEvent.member).thenReturn(member)
+        whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+    }
+
+    private fun stubAuthorizedSlashCommand(subcommandName: String) {
+        stubSlashCommandContext()
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(slashEvent.subcommandName).thenReturn(subcommandName)
+    }
+
+    private class TestStickyRolesCommand(
+        stickyRoleService: StickyRoleService
+    ) : StickyRolesCommand(stickyRoleService) {
+        var selectedRole: Role? = null
+
+        override fun getRequiredRole(event: SlashCommandInteractionEvent): Role? {
+            return selectedRole ?: super.getRequiredRole(event)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add sticky role configuration, persistence, and restore-on-rejoin handling for moderation
- clean up sticky role state when roles or guilds are removed
- preserve saved sticky role snapshots when role restoration fails and cover the failure path in tests