### PR TITLE
feat(narouNovelApi): add Narou novel update alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-flyway")
+    implementation("org.springframework.boot:spring-boot-starter-restclient")
     implementation("org.flywaydb:flyway-mysql")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("net.dv8tion:JDA:$jdaVersion") {
@@ -51,6 +52,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-data-redis-test")
     testImplementation("org.springframework.boot:spring-boot-starter-flyway-test")
     testImplementation("org.springframework.boot:spring-boot-starter-data-redis-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-restclient-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion")
     testImplementation("org.springframework.modulith:spring-modulith-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/ModuleMetadata.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/ModuleMetadata.kt
@@ -1,0 +1,8 @@
+package be.duncanc.discordmodbot.narou.novel.api
+
+import org.springframework.modulith.ApplicationModule
+import org.springframework.modulith.PackageInfo
+
+@PackageInfo
+@ApplicationModule(allowedDependencies = ["discord"])
+class ModuleMetadata

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClient.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClient.kt
@@ -1,0 +1,25 @@
+package be.duncanc.discordmodbot.narou.novel.api
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.web.service.annotation.GetExchange
+
+interface NarouNovelApiClient {
+    @GetExchange("/novelapi/api/?ncode=n2267be&out=json&of=l-ti-gl-ga-nu-ua")
+    fun fetchNovel(): List<NarouNovelApiResponseEntry>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class NarouNovelApiResponseEntry(
+    val allcount: Int? = null,
+    @JsonProperty("general_lastup")
+    val generalLastup: String? = null,
+    @JsonProperty("general_all_no")
+    val generalAllNo: Int? = null,
+    val length: Long? = null,
+    val time: Int? = null,
+    @JsonProperty("novelupdated_at")
+    val novelUpdatedAt: String? = null,
+    @JsonProperty("updated_at")
+    val updatedAt: String? = null
+)

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClient.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClient.kt
@@ -11,7 +11,6 @@ interface NarouNovelApiClient {
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class NarouNovelApiResponseEntry(
-    val allcount: Int? = null,
     @JsonProperty("general_lastup")
     val generalLastup: String? = null,
     @JsonProperty("general_all_no")

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClientConfig.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClientConfig.kt
@@ -2,7 +2,6 @@ package be.duncanc.discordmodbot.narou.novel.api
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.support.RestClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
@@ -15,17 +14,16 @@ class NarouNovelApiClientConfig {
     }
 
     @Bean
-    fun narouNovelApiClient(properties: NarouNovelApiProperties): NarouNovelApiClient {
-        val timeoutMillis = properties.requestTimeout.toMillis().toInt()
-        val requestFactory = SimpleClientHttpRequestFactory().apply {
-            setConnectTimeout(timeoutMillis)
-            setReadTimeout(timeoutMillis)
-        }
-        val restClient = RestClient.builder()
+    fun narouNovelApiClient(restClientBuilder: RestClient.Builder): NarouNovelApiClient {
+        val restClient = restClientBuilder
             .baseUrl(BASE_URL)
-            .requestFactory(requestFactory)
             .build()
-        val proxyFactory = HttpServiceProxyFactory.builderFor(RestClientAdapter.create(restClient)).build()
+
+        val proxyFactory = HttpServiceProxyFactory
+            .builderFor(
+                RestClientAdapter.create(restClient)
+            )
+            .build()
 
         return proxyFactory.createClient<NarouNovelApiClient>()
     }

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClientConfig.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClientConfig.kt
@@ -7,7 +7,6 @@ import org.springframework.web.client.RestClient
 import org.springframework.web.client.support.RestClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
 import org.springframework.web.service.invoker.createClient
-import java.time.Duration
 
 @Configuration
 class NarouNovelApiClientConfig {
@@ -16,10 +15,14 @@ class NarouNovelApiClientConfig {
     }
 
     @Bean
-    fun narouNovelApiClient(restClientBuilder: RestClient.Builder): NarouNovelApiClient {
+    fun narouNovelApiClient(
+        narouNovelApiProperties: NarouNovelApiProperties,
+        restClientBuilder: RestClient.Builder
+    ): NarouNovelApiClient {
+
         val requestFactory = JdkClientHttpRequestFactory()
 
-        requestFactory.setReadTimeout(Duration.ofSeconds(10))
+        requestFactory.setReadTimeout(narouNovelApiProperties.readTimeout)
 
         val restClient = restClientBuilder
             .baseUrl(BASE_URL)

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClientConfig.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClientConfig.kt
@@ -1,0 +1,32 @@
+package be.duncanc.discordmodbot.narou.novel.api
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.support.RestClientAdapter
+import org.springframework.web.service.invoker.HttpServiceProxyFactory
+import org.springframework.web.service.invoker.createClient
+
+@Configuration
+class NarouNovelApiClientConfig {
+    companion object {
+        private const val BASE_URL = "https://api.syosetu.com"
+    }
+
+    @Bean
+    fun narouNovelApiClient(properties: NarouNovelApiProperties): NarouNovelApiClient {
+        val timeoutMillis = properties.requestTimeout.toMillis().toInt()
+        val requestFactory = SimpleClientHttpRequestFactory().apply {
+            setConnectTimeout(timeoutMillis)
+            setReadTimeout(timeoutMillis)
+        }
+        val restClient = RestClient.builder()
+            .baseUrl(BASE_URL)
+            .requestFactory(requestFactory)
+            .build()
+        val proxyFactory = HttpServiceProxyFactory.builderFor(RestClientAdapter.create(restClient)).build()
+
+        return proxyFactory.createClient<NarouNovelApiClient>()
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClientConfig.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClientConfig.kt
@@ -2,10 +2,12 @@ package be.duncanc.discordmodbot.narou.novel.api
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.JdkClientHttpRequestFactory
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.support.RestClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
 import org.springframework.web.service.invoker.createClient
+import java.time.Duration
 
 @Configuration
 class NarouNovelApiClientConfig {
@@ -15,8 +17,13 @@ class NarouNovelApiClientConfig {
 
     @Bean
     fun narouNovelApiClient(restClientBuilder: RestClient.Builder): NarouNovelApiClient {
+        val requestFactory = JdkClientHttpRequestFactory()
+
+        requestFactory.setReadTimeout(Duration.ofSeconds(10))
+
         val restClient = restClientBuilder
             .baseUrl(BASE_URL)
+            .requestFactory(requestFactory)
             .build()
 
         val proxyFactory = HttpServiceProxyFactory

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiProperties.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiProperties.kt
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 import org.springframework.validation.annotation.Validated
+import java.time.Duration
 
 @Validated
 @ConfigurationProperties("discord-mod-bot.narou-novel-api")
@@ -11,4 +12,6 @@ data class NarouNovelApiProperties(
     @NotEmpty
     @DefaultValue("0/15 * * * * *")
     val pollCron: String,
+    @DefaultValue("10s")
+    val readTimeout: Duration
 )

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiProperties.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiProperties.kt
@@ -1,15 +1,14 @@
 package be.duncanc.discordmodbot.narou.novel.api
 
+import jakarta.validation.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
-import java.time.Duration
+import org.springframework.boot.context.properties.bind.DefaultValue
+import org.springframework.validation.annotation.Validated
 
+@Validated
 @ConfigurationProperties("discord-mod-bot.narou-novel-api")
-class NarouNovelApiProperties(
-    val pollCron: String = DEFAULT_POLL_CRON,
-    val requestTimeout: Duration = DEFAULT_REQUEST_TIMEOUT
-) {
-    companion object {
-        const val DEFAULT_POLL_CRON = "0/15 * * * * *"
-        val DEFAULT_REQUEST_TIMEOUT: Duration = Duration.ofSeconds(5)
-    }
-}
+data class NarouNovelApiProperties(
+    @NotEmpty
+    @DefaultValue("0/15 * * * * *")
+    val pollCron: String,
+)

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiProperties.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiProperties.kt
@@ -1,0 +1,15 @@
+package be.duncanc.discordmodbot.narou.novel.api
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties("discord-mod-bot.narou-novel-api")
+class NarouNovelApiProperties(
+    val pollCron: String = DEFAULT_POLL_CRON,
+    val requestTimeout: Duration = DEFAULT_REQUEST_TIMEOUT
+) {
+    companion object {
+        const val DEFAULT_POLL_CRON = "0/15 * * * * *"
+        val DEFAULT_REQUEST_TIMEOUT: Duration = Duration.ofSeconds(5)
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
@@ -3,6 +3,7 @@ package be.duncanc.discordmodbot.narou.novel.api
 import be.duncanc.discordmodbot.discord.SlashCommand
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettings
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettingsRepository
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelPendingAlertRepository
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component
 @Component
 class NarouNovelConfigCommand(
     private val narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository,
+    private val narouNovelPendingAlertRepository: NarouNovelPendingAlertRepository,
     private val narouNovelSnapshotRepository: NarouNovelSnapshotRepository
 ) : ListenerAdapter(), SlashCommand {
     companion object {
@@ -38,7 +40,7 @@ class NarouNovelConfigCommand(
     }
 
     override fun onGuildLeave(event: GuildLeaveEvent) {
-        narouNovelAlertSettingsRepository.deleteById(event.guild.idLong)
+        clearAlertConfiguration(event.guild.idLong)
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
@@ -89,7 +91,7 @@ class NarouNovelConfigCommand(
             }
 
             SUBCOMMAND_DISABLE -> {
-                narouNovelAlertSettingsRepository.deleteById(guild.idLong)
+                clearAlertConfiguration(guild.idLong)
                 event.reply("Narou novel alerts disabled.").setEphemeral(true).queue()
             }
 
@@ -152,6 +154,11 @@ class NarouNovelConfigCommand(
         if (settings.lastAlertedGeneralAllNo == null) {
             settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
         }
+    }
+
+    private fun clearAlertConfiguration(guildId: Long) {
+        narouNovelAlertSettingsRepository.deleteById(guildId)
+        narouNovelPendingAlertRepository.deleteById(guildId)
     }
 
     private fun showCurrentSettings(event: SlashCommandInteractionEvent, guild: Guild) {

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
@@ -1,0 +1,181 @@
+package be.duncanc.discordmodbot.narou.novel.api
+
+import be.duncanc.discordmodbot.discord.SlashCommand
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettings
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettingsRepository
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import net.dv8tion.jda.api.interactions.InteractionContextType
+import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.stereotype.Component
+
+@Component
+class NarouNovelConfigCommand(
+    private val narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository,
+    private val narouNovelSnapshotRepository: NarouNovelSnapshotRepository
+) : ListenerAdapter(), SlashCommand {
+    companion object {
+        private const val COMMAND = "narounovelapi"
+        private const val DESCRIPTION = "Configure Narou novel update alerts for this server."
+        private const val OPTION_CHANNEL = "channel"
+        private const val OPTION_THRESHOLD = "threshold"
+        private const val SUBCOMMAND_SHOW = "show"
+        private const val SUBCOMMAND_SET_CHANNEL = "set-channel"
+        private const val SUBCOMMAND_SET_THRESHOLD = "set-threshold"
+        private const val SUBCOMMAND_DISABLE = "disable"
+        internal const val MINIMUM_THRESHOLD = 50L
+    }
+
+    override fun onGuildLeave(event: GuildLeaveEvent) {
+        narouNovelAlertSettingsRepository.deleteById(event.guild.idLong)
+    }
+
+    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+        if (event.name != COMMAND) {
+            return
+        }
+
+        val guild = event.guild
+        val member = event.member
+        if (guild == null || member == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.hasPermission(Permission.MANAGE_CHANNEL)) {
+            event.reply("You need manage channel permission to use this command.").setEphemeral(true).queue()
+            return
+        }
+
+        when (event.subcommandName) {
+            null, SUBCOMMAND_SHOW -> showCurrentSettings(event, guild)
+            SUBCOMMAND_SET_CHANNEL -> {
+                val channel = getRequiredTextChannel(event) ?: return
+                val settings = narouNovelAlertSettingsRepository.findById(guild.idLong).orElseGet {
+                    NarouNovelAlertSettings(guildId = guild.idLong, channelId = channel.idLong)
+                }
+                settings.channelId = channel.idLong
+                initializeBaselines(settings)
+                narouNovelAlertSettingsRepository.save(settings)
+                event.reply("Narou novel alerts will be sent to ${channel.asMention}.").setEphemeral(true).queue()
+            }
+
+            SUBCOMMAND_SET_THRESHOLD -> {
+                val threshold = getRequiredThreshold(event) ?: return
+                if (threshold < MINIMUM_THRESHOLD) {
+                    event.reply("The length threshold must be at least 50.").setEphemeral(true).queue()
+                    return
+                }
+                val settings = narouNovelAlertSettingsRepository.findById(guild.idLong).orElseGet {
+                    NarouNovelAlertSettings(guildId = guild.idLong)
+                }
+                settings.lengthThreshold = threshold
+                initializeBaselines(settings)
+                narouNovelAlertSettingsRepository.save(settings)
+                event.reply("Narou novel length alerts now require at least $threshold characters.")
+                    .setEphemeral(true)
+                    .queue()
+            }
+
+            SUBCOMMAND_DISABLE -> {
+                narouNovelAlertSettingsRepository.deleteById(guild.idLong)
+                event.reply("Narou novel alerts disabled.").setEphemeral(true).queue()
+            }
+
+            else -> event.reply("Please choose a valid /narounovelapi subcommand.").setEphemeral(true).queue()
+        }
+    }
+
+    override fun getCommandsData(): List<SlashCommandData> {
+        return listOf(
+            Commands.slash(COMMAND, DESCRIPTION)
+                .setContexts(InteractionContextType.GUILD)
+                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_CHANNEL))
+                .addSubcommands(
+                    SubcommandData(SUBCOMMAND_SHOW, "Show the current Narou novel alert settings"),
+                    SubcommandData(SUBCOMMAND_SET_CHANNEL, "Set the channel that receives Narou novel alerts")
+                        .addOptions(textChannelOption("The channel used for Narou novel alerts")),
+                    SubcommandData(SUBCOMMAND_SET_THRESHOLD, "Set the character growth threshold for alerts")
+                        .addOptions(
+                            OptionData(
+                                OptionType.INTEGER,
+                                OPTION_THRESHOLD,
+                                "Minimum character growth required before an alert is sent",
+                                true
+                            ).setMinValue(MINIMUM_THRESHOLD)
+                        ),
+                    SubcommandData(SUBCOMMAND_DISABLE, "Disable Narou novel alerts for this server")
+                )
+        )
+    }
+
+    internal fun getRequiredTextChannel(event: SlashCommandInteractionEvent): TextChannel? {
+        val channel = event.getOption(OPTION_CHANNEL)?.asChannel?.asTextChannel()
+        if (channel == null) {
+            event.reply("Please choose a text channel.").setEphemeral(true).queue()
+            return null
+        }
+
+        return channel
+    }
+
+    internal fun getRequiredThreshold(event: SlashCommandInteractionEvent): Long? {
+        val threshold = event.getOption(OPTION_THRESHOLD)?.asLong
+        if (threshold == null) {
+            event.reply("Please provide a length threshold.").setEphemeral(true).queue()
+            return null
+        }
+        if (threshold < MINIMUM_THRESHOLD) {
+            event.reply("The length threshold must be at least 50.").setEphemeral(true).queue()
+            return null
+        }
+
+        return threshold
+    }
+
+    private fun initializeBaselines(settings: NarouNovelAlertSettings) {
+        val snapshot = narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE).orElse(null) ?: return
+        if (settings.lastAlertedLength == null) {
+            settings.lastAlertedLength = snapshot.length
+        }
+        if (settings.lastAlertedGeneralAllNo == null) {
+            settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
+        }
+    }
+
+    private fun showCurrentSettings(event: SlashCommandInteractionEvent, guild: Guild) {
+        val settings = narouNovelAlertSettingsRepository.findById(guild.idLong).orElse(null)
+        val message = buildString {
+            appendLine("Narou novel alert settings for ${guild.name}")
+            appendLine()
+            appendLine("- Alert channel: ${formatChannel(guild, settings?.channelId)}")
+            appendLine("- Character growth threshold: ${settings?.lengthThreshold ?: NarouNovelAlertSettings.DEFAULT_LENGTH_THRESHOLD}")
+        }
+
+        event.reply(message).setEphemeral(true).queue()
+    }
+
+    private fun formatChannel(guild: Guild, channelId: Long?): String {
+        if (channelId == null) {
+            return "Disabled"
+        }
+
+        return guild.getTextChannelById(channelId)?.asMention ?: "Channel not found (ID: $channelId)"
+    }
+
+    private fun textChannelOption(description: String): OptionData {
+        return OptionData(OptionType.CHANNEL, OPTION_CHANNEL, description, true)
+            .setChannelTypes(ChannelType.TEXT)
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -102,17 +102,18 @@ class NarouNovelPollingService(
             }
 
             val message = buildAlertMessage(lengthTriggered, lengthDelta, chapterTriggered, chapterDelta, snapshot)
-            if (lengthTriggered) {
-                settings.lastAlertedLength = snapshot.length
-            }
-            if (chapterTriggered) {
-                settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
-            }
-
             sendAlertMessage(
                 channel = channel,
                 message = message,
-                onSuccess = { narouNovelAlertSettingsRepository.save(settings) },
+                onSuccess = {
+                    if (lengthTriggered) {
+                        settings.lastAlertedLength = snapshot.length
+                    }
+                    if (chapterTriggered) {
+                        settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
+                    }
+                    narouNovelAlertSettingsRepository.save(settings)
+                },
                 onFailure = { exception ->
                     LOG.warn("Failed to send Narou novel alert for guild {}", settings.guildId, exception)
                 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -3,6 +3,8 @@ package be.duncanc.discordmodbot.narou.novel.api
 import be.duncanc.discordmodbot.narou.novel.api.persistence.*
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.exceptions.ErrorResponseException
+import net.dv8tion.jda.api.requests.ErrorResponse
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -90,6 +92,15 @@ class NarouNovelPollingService(
 
             val pendingAlert = narouNovelPendingAlertRepository.findById(settings.guildId).orElse(null)
             if (pendingAlert != null) {
+                if (pendingAlert.snapshotGeneralAllNo == snapshot.generalAllNo && pendingAlert.snapshotLength == snapshot.length) {
+                    LOG.debug(
+                        "Skipping Narou novel alert for guild {} because snapshot {}:{} was already sent or is still being finalized",
+                        settings.guildId,
+                        pendingAlert.snapshotGeneralAllNo,
+                        pendingAlert.snapshotLength
+                    )
+                    return@forEach
+                }
                 LOG.debug(
                     "Skipping Narou novel alert for guild {} because a pending alert lock exists for snapshot {}:{}",
                     settings.guildId,
@@ -131,11 +142,40 @@ class NarouNovelPollingService(
                                 settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
                             }
                             narouNovelAlertSettingsRepository.save(settings)
-                        } finally {
                             narouNovelPendingAlertRepository.deleteById(settings.guildId)
+                        } catch (exception: Exception) {
+                            LOG.warn(
+                                "Failed to persist Narou novel alert baselines for guild {} after sending snapshot {}:{}",
+                                settings.guildId,
+                                snapshot.generalAllNo,
+                                snapshot.length,
+                                exception
+                            )
                         }
                     },
                     onFailure = { exception ->
+                        if (isTerminalChannelFailure(exception)) {
+                            try {
+                                settings.channelId = null
+                                narouNovelAlertSettingsRepository.save(settings)
+                                narouNovelPendingAlertRepository.deleteById(settings.guildId)
+                                LOG.warn(
+                                    "Disabled Narou novel alerts for guild {} because the bot can no longer post in channel {}",
+                                    settings.guildId,
+                                    channelId,
+                                    exception
+                                )
+                            } catch (persistenceException: Exception) {
+                                LOG.warn(
+                                    "Failed to disable Narou novel alerts for guild {} after terminal send failure in channel {}",
+                                    settings.guildId,
+                                    channelId,
+                                    persistenceException
+                                )
+                            }
+                            return@sendAlertMessage
+                        }
+
                         try {
                             LOG.warn("Failed to send Narou novel alert for guild {}", settings.guildId, exception)
                         } finally {
@@ -191,6 +231,16 @@ class NarouNovelPollingService(
         onFailure: (Throwable) -> Unit
     ) {
         channel.sendMessage(message).queue({ onSuccess() }, onFailure)
+    }
+
+    internal open fun isTerminalChannelFailure(exception: Throwable): Boolean {
+        val errorResponseException = exception as? ErrorResponseException ?: return false
+        return when (errorResponseException.errorResponse) {
+            ErrorResponse.MISSING_PERMISSIONS,
+            ErrorResponse.MISSING_ACCESS,
+            ErrorResponse.UNKNOWN_CHANNEL -> true
+            else -> false
+        }
     }
 
     private fun buildAlertMessage(

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -182,7 +182,7 @@ class NarouNovelPollingService(
         }
 
         return buildString {
-            append("Narou update for ")
+            append("@everyone Narou update for ")
             append(NOVEL_CODE)
             append(": ")
             append(updates.joinToString(" and "))

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -113,10 +113,10 @@ class NarouNovelPollingService(
             val channelId = settings.channelId ?: return@forEach
             val channel = jda.getTextChannelById(channelId)
             if (channel == null) {
-                LOG.warn(
-                    "Narou novel alert channel {} for guild {} no longer exists",
-                    settings.channelId,
-                    settings.guildId
+                disableAlertChannel(
+                    settings = settings,
+                    channelId = channelId,
+                    reason = "channel {} no longer exists"
                 )
                 return@forEach
             }
@@ -155,24 +155,12 @@ class NarouNovelPollingService(
                     },
                     onFailure = { exception ->
                         if (isTerminalChannelFailure(exception)) {
-                            try {
-                                settings.channelId = null
-                                narouNovelAlertSettingsRepository.save(settings)
-                                narouNovelPendingAlertRepository.deleteById(settings.guildId)
-                                LOG.warn(
-                                    "Disabled Narou novel alerts for guild {} because the bot can no longer post in channel {}",
-                                    settings.guildId,
-                                    channelId,
-                                    exception
-                                )
-                            } catch (persistenceException: Exception) {
-                                LOG.warn(
-                                    "Failed to disable Narou novel alerts for guild {} after terminal send failure in channel {}",
-                                    settings.guildId,
-                                    channelId,
-                                    persistenceException
-                                )
-                            }
+                            disableAlertChannel(
+                                settings = settings,
+                                channelId = channelId,
+                                reason = "the bot can no longer post in channel {}",
+                                cause = exception
+                            )
                             return@sendAlertMessage
                         }
 
@@ -187,6 +175,40 @@ class NarouNovelPollingService(
                 narouNovelPendingAlertRepository.deleteById(settings.guildId)
                 throw exception
             }
+        }
+    }
+
+    private fun disableAlertChannel(
+        settings: NarouNovelAlertSettings,
+        channelId: Long,
+        reason: String,
+        cause: Throwable? = null
+    ) {
+        try {
+            settings.channelId = null
+            narouNovelAlertSettingsRepository.save(settings)
+            narouNovelPendingAlertRepository.deleteById(settings.guildId)
+            if (cause == null) {
+                LOG.warn(
+                    "Disabled Narou novel alerts for guild {} because $reason",
+                    settings.guildId,
+                    channelId
+                )
+            } else {
+                LOG.warn(
+                    "Disabled Narou novel alerts for guild {} because $reason",
+                    settings.guildId,
+                    channelId,
+                    cause
+                )
+            }
+        } catch (persistenceException: Exception) {
+            LOG.warn(
+                "Failed to disable Narou novel alerts for guild {} after channel failure in channel {}",
+                settings.guildId,
+                channelId,
+                persistenceException
+            )
         }
     }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -1,9 +1,6 @@
 package be.duncanc.discordmodbot.narou.novel.api
 
-import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettings
-import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettingsRepository
-import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshot
-import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
+import be.duncanc.discordmodbot.narou.novel.api.persistence.*
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import org.slf4j.LoggerFactory
@@ -16,6 +13,7 @@ class NarouNovelPollingService(
     private val narouNovelApiClient: NarouNovelApiClient,
     private val narouNovelSnapshotRepository: NarouNovelSnapshotRepository,
     private val narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository,
+    private val narouNovelPendingAlertRepository: NarouNovelPendingAlertRepository,
     private val jda: JDA
 ) {
     companion object {
@@ -90,6 +88,17 @@ class NarouNovelPollingService(
                 return@forEach
             }
 
+            val pendingAlert = narouNovelPendingAlertRepository.findById(settings.guildId).orElse(null)
+            if (pendingAlert != null) {
+                LOG.debug(
+                    "Skipping Narou novel alert for guild {} because a pending alert lock exists for snapshot {}:{}",
+                    settings.guildId,
+                    pendingAlert.snapshotGeneralAllNo,
+                    pendingAlert.snapshotLength
+                )
+                return@forEach
+            }
+
             val channelId = settings.channelId ?: return@forEach
             val channel = jda.getTextChannelById(channelId)
             if (channel == null) {
@@ -102,22 +111,42 @@ class NarouNovelPollingService(
             }
 
             val message = buildAlertMessage(lengthTriggered, lengthDelta, chapterTriggered, chapterDelta, snapshot)
-            sendAlertMessage(
-                channel = channel,
-                message = message,
-                onSuccess = {
-                    if (lengthTriggered) {
-                        settings.lastAlertedLength = snapshot.length
-                    }
-                    if (chapterTriggered) {
-                        settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
-                    }
-                    narouNovelAlertSettingsRepository.save(settings)
-                },
-                onFailure = { exception ->
-                    LOG.warn("Failed to send Narou novel alert for guild {}", settings.guildId, exception)
-                }
+            narouNovelPendingAlertRepository.save(
+                NarouNovelPendingAlert(
+                    guildId = settings.guildId,
+                    snapshotLength = snapshot.length,
+                    snapshotGeneralAllNo = snapshot.generalAllNo
+                )
             )
+            try {
+                sendAlertMessage(
+                    channel = channel,
+                    message = message,
+                    onSuccess = {
+                        try {
+                            if (lengthTriggered) {
+                                settings.lastAlertedLength = snapshot.length
+                            }
+                            if (chapterTriggered) {
+                                settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
+                            }
+                            narouNovelAlertSettingsRepository.save(settings)
+                        } finally {
+                            narouNovelPendingAlertRepository.deleteById(settings.guildId)
+                        }
+                    },
+                    onFailure = { exception ->
+                        try {
+                            LOG.warn("Failed to send Narou novel alert for guild {}", settings.guildId, exception)
+                        } finally {
+                            narouNovelPendingAlertRepository.deleteById(settings.guildId)
+                        }
+                    }
+                )
+            } catch (exception: Exception) {
+                narouNovelPendingAlertRepository.deleteById(settings.guildId)
+                throw exception
+            }
         }
     }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -100,18 +100,18 @@ class NarouNovelPollingService(
             }
 
             val message = buildAlertMessage(lengthTriggered, lengthDelta, chapterTriggered, chapterDelta, snapshot)
+            if (lengthTriggered) {
+                settings.lastAlertedLength = snapshot.length
+            }
+            if (chapterTriggered) {
+                settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
+            }
+            narouNovelAlertSettingsRepository.save(settings)
+
             sendAlertMessage(
                 channel = channel,
                 message = message,
-                onSuccess = {
-                    if (lengthTriggered) {
-                        settings.lastAlertedLength = snapshot.length
-                    }
-                    if (chapterTriggered) {
-                        settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
-                    }
-                    narouNovelAlertSettingsRepository.save(settings)
-                },
+                onSuccess = {},
                 onFailure = { exception ->
                     LOG.warn("Failed to send Narou novel alert for guild {}", settings.guildId, exception)
                 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class NarouNovelPollingService(
@@ -24,6 +25,7 @@ class NarouNovelPollingService(
     }
 
     @Scheduled(cron = $$"${discord-mod-bot.narou-novel-api.poll-cron:0/15 * * * * *}")
+    @Transactional
     fun pollNovel() {
         val payload = try {
             fetchPayload()
@@ -63,11 +65,11 @@ class NarouNovelPollingService(
     internal fun fetchPayload(): NarouNovelApiResponseEntry {
         return narouNovelApiClient.fetchNovel().firstOrNull {
             it.generalLastup != null &&
-                it.generalAllNo != null &&
-                it.length != null &&
-                it.time != null &&
-                it.novelUpdatedAt != null &&
-                it.updatedAt != null
+                    it.generalAllNo != null &&
+                    it.length != null &&
+                    it.time != null &&
+                    it.novelUpdatedAt != null &&
+                    it.updatedAt != null
         } ?: throw IllegalStateException("Narou novel API response did not contain a novel payload")
     }
 
@@ -106,12 +108,11 @@ class NarouNovelPollingService(
             if (chapterTriggered) {
                 settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
             }
-            narouNovelAlertSettingsRepository.save(settings)
 
             sendAlertMessage(
                 channel = channel,
                 message = message,
-                onSuccess = {},
+                onSuccess = { narouNovelAlertSettingsRepository.save(settings) },
                 onFailure = { exception ->
                     LOG.warn("Failed to send Narou novel alert for guild {}", settings.guildId, exception)
                 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -1,0 +1,197 @@
+package be.duncanc.discordmodbot.narou.novel.api
+
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettings
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettingsRepository
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshot
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class NarouNovelPollingService(
+    private val narouNovelApiClient: NarouNovelApiClient,
+    private val narouNovelSnapshotRepository: NarouNovelSnapshotRepository,
+    private val narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository,
+    private val jda: JDA
+) {
+    companion object {
+        internal const val NOVEL_CODE = "n2267be"
+        private const val NOVEL_URL = "https://ncode.syosetu.com/n2267be/"
+        private val LOG = LoggerFactory.getLogger(NarouNovelPollingService::class.java)
+    }
+
+    @Scheduled(cron = $$"${discord-mod-bot.narou-novel-api.poll-cron:0/15 * * * * *}")
+    fun pollNovel() {
+        val payload = try {
+            fetchPayload()
+        } catch (exception: Exception) {
+            LOG.warn("Failed to poll Narou novel API", exception)
+            return
+        }
+
+        val snapshot = narouNovelSnapshotRepository.findById(NOVEL_CODE).orElse(null)
+        if (snapshot == null) {
+            narouNovelSnapshotRepository.save(
+                NarouNovelSnapshot(
+                    ncode = NOVEL_CODE,
+                    generalLastup = payload.generalLastup!!,
+                    generalAllNo = payload.generalAllNo!!,
+                    length = payload.length!!,
+                    time = payload.time!!,
+                    novelUpdatedAt = payload.novelUpdatedAt!!,
+                    updatedAt = payload.updatedAt!!
+                )
+            )
+            initializeMissingBaselines(payload.length, payload.generalAllNo)
+            return
+        }
+
+        snapshot.generalLastup = payload.generalLastup!!
+        snapshot.generalAllNo = payload.generalAllNo!!
+        snapshot.length = payload.length!!
+        snapshot.time = payload.time!!
+        snapshot.novelUpdatedAt = payload.novelUpdatedAt!!
+        snapshot.updatedAt = payload.updatedAt!!
+        narouNovelSnapshotRepository.save(snapshot)
+
+        processAlerts(snapshot)
+    }
+
+    internal fun fetchPayload(): NarouNovelApiResponseEntry {
+        return narouNovelApiClient.fetchNovel().firstOrNull {
+            it.generalLastup != null &&
+                it.generalAllNo != null &&
+                it.length != null &&
+                it.time != null &&
+                it.novelUpdatedAt != null &&
+                it.updatedAt != null
+        } ?: throw IllegalStateException("Narou novel API response did not contain a novel payload")
+    }
+
+    private fun processAlerts(snapshot: NarouNovelSnapshot) {
+        narouNovelAlertSettingsRepository.findAll().forEach { settings ->
+            val updatedSettings = initializeOrRebaseBaselines(settings, snapshot)
+            if (updatedSettings) {
+                return@forEach
+            }
+
+            val lastAlertedLength = settings.lastAlertedLength ?: return@forEach
+            val lastAlertedGeneralAllNo = settings.lastAlertedGeneralAllNo ?: return@forEach
+            val lengthDelta = snapshot.length - lastAlertedLength
+            val chapterDelta = snapshot.generalAllNo - lastAlertedGeneralAllNo
+            val lengthTriggered = lengthDelta >= settings.lengthThreshold
+            val chapterTriggered = chapterDelta > 0
+            if (!lengthTriggered && !chapterTriggered) {
+                return@forEach
+            }
+
+            val channelId = settings.channelId ?: return@forEach
+            val channel = jda.getTextChannelById(channelId)
+            if (channel == null) {
+                LOG.warn(
+                    "Narou novel alert channel {} for guild {} no longer exists",
+                    settings.channelId,
+                    settings.guildId
+                )
+                return@forEach
+            }
+
+            val message = buildAlertMessage(lengthTriggered, lengthDelta, chapterTriggered, chapterDelta, snapshot)
+            sendAlertMessage(
+                channel = channel,
+                message = message,
+                onSuccess = {
+                    if (lengthTriggered) {
+                        settings.lastAlertedLength = snapshot.length
+                    }
+                    if (chapterTriggered) {
+                        settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
+                    }
+                    narouNovelAlertSettingsRepository.save(settings)
+                },
+                onFailure = { exception ->
+                    LOG.warn("Failed to send Narou novel alert for guild {}", settings.guildId, exception)
+                }
+            )
+        }
+    }
+
+    private fun initializeMissingBaselines(length: Long, generalAllNo: Int) {
+        narouNovelAlertSettingsRepository.findAll().forEach { settings ->
+            var changed = false
+            if (settings.lastAlertedLength == null) {
+                settings.lastAlertedLength = length
+                changed = true
+            }
+            if (settings.lastAlertedGeneralAllNo == null) {
+                settings.lastAlertedGeneralAllNo = generalAllNo
+                changed = true
+            }
+            if (changed) {
+                narouNovelAlertSettingsRepository.save(settings)
+            }
+        }
+    }
+
+    private fun initializeOrRebaseBaselines(settings: NarouNovelAlertSettings, snapshot: NarouNovelSnapshot): Boolean {
+        var changed = false
+        if (settings.lastAlertedLength == null || settings.lastAlertedLength!! > snapshot.length) {
+            settings.lastAlertedLength = snapshot.length
+            changed = true
+        }
+        if (settings.lastAlertedGeneralAllNo == null || settings.lastAlertedGeneralAllNo!! > snapshot.generalAllNo) {
+            settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
+            changed = true
+        }
+        if (changed) {
+            narouNovelAlertSettingsRepository.save(settings)
+        }
+
+        return changed
+    }
+
+    internal fun sendAlertMessage(
+        channel: TextChannel,
+        message: String,
+        onSuccess: () -> Unit,
+        onFailure: (Throwable) -> Unit
+    ) {
+        channel.sendMessage(message).queue({ onSuccess() }, onFailure)
+    }
+
+    private fun buildAlertMessage(
+        lengthTriggered: Boolean,
+        lengthDelta: Long,
+        chapterTriggered: Boolean,
+        chapterDelta: Int,
+        snapshot: NarouNovelSnapshot
+    ): String {
+        val updates = mutableListOf<String>()
+        if (chapterTriggered) {
+            updates += if (chapterDelta == 1) {
+                "1 new chapter was published"
+            } else {
+                "$chapterDelta new chapters were published"
+            }
+        }
+        if (lengthTriggered) {
+            updates += "the novel grew by $lengthDelta characters"
+        }
+
+        return buildString {
+            append("Narou update for ")
+            append(NOVEL_CODE)
+            append(": ")
+            append(updates.joinToString(" and "))
+            append(". Total chapters: ")
+            append(snapshot.generalAllNo)
+            append(". Total characters: ")
+            append(snapshot.length)
+            append(". ")
+            append(NOVEL_URL)
+        }
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettings.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettings.kt
@@ -1,0 +1,26 @@
+package be.duncanc.discordmodbot.narou.novel.api.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "narou_novel_alert_settings")
+data class NarouNovelAlertSettings(
+    @Id
+    @Column(updatable = false)
+    val guildId: Long,
+    @Column(nullable = true)
+    var channelId: Long? = null,
+    @Column(nullable = false)
+    var lengthThreshold: Long = DEFAULT_LENGTH_THRESHOLD,
+    @Column(nullable = true)
+    var lastAlertedLength: Long? = null,
+    @Column(nullable = true)
+    var lastAlertedGeneralAllNo: Int? = null
+) {
+    companion object {
+        const val DEFAULT_LENGTH_THRESHOLD = 1000L
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettingsRepository.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettingsRepository.kt
@@ -1,0 +1,7 @@
+package be.duncanc.discordmodbot.narou.novel.api.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface NarouNovelAlertSettingsRepository : JpaRepository<NarouNovelAlertSettings, Long>

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelPendingAlert.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelPendingAlert.kt
@@ -1,0 +1,12 @@
+package be.duncanc.discordmodbot.narou.novel.api.persistence
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+
+@RedisHash("narouNovelPendingAlert", timeToLive = 900)
+data class NarouNovelPendingAlert(
+    @Id
+    val guildId: Long,
+    val snapshotLength: Long,
+    val snapshotGeneralAllNo: Int
+)

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelPendingAlertRepository.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelPendingAlertRepository.kt
@@ -1,0 +1,7 @@
+package be.duncanc.discordmodbot.narou.novel.api.persistence
+
+import org.springframework.data.keyvalue.repository.KeyValueRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface NarouNovelPendingAlertRepository : KeyValueRepository<NarouNovelPendingAlert, Long>

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelSnapshot.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelSnapshot.kt
@@ -1,0 +1,26 @@
+package be.duncanc.discordmodbot.narou.novel.api.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "narou_novel_snapshots")
+data class NarouNovelSnapshot(
+    @Id
+    @Column(updatable = false)
+    val ncode: String,
+    @Column(name = "general_lastup", nullable = false)
+    var generalLastup: String,
+    @Column(name = "general_all_no", nullable = false)
+    var generalAllNo: Int,
+    @Column(name = "length_value", nullable = false)
+    var length: Long,
+    @Column(name = "reading_time", nullable = false)
+    var time: Int,
+    @Column(name = "novel_updated_at", nullable = false)
+    var novelUpdatedAt: String,
+    @Column(name = "api_updated_at", nullable = false)
+    var updatedAt: String
+)

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelSnapshotRepository.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelSnapshotRepository.kt
@@ -1,0 +1,7 @@
+package be.duncanc.discordmodbot.narou.novel.api.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface NarouNovelSnapshotRepository : JpaRepository<NarouNovelSnapshot, String>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,5 +11,8 @@ spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
 # Hibernate
 spring.jpa.hibernate.ddl-auto=none
+# Narou Novel API
+discord-mod-bot.narou-novel-api.poll-cron=0/15 * * * * *
+discord-mod-bot.narou-novel-api.request-timeout=5s
 # Modulith
 spring.modulith.detection-strategy=explicitly-annotated

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,8 +11,5 @@ spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
 # Hibernate
 spring.jpa.hibernate.ddl-auto=none
-# Narou Novel API
-discord-mod-bot.narou-novel-api.poll-cron=0/15 * * * * *
-discord-mod-bot.narou-novel-api.request-timeout=5s
 # Modulith
 spring.modulith.detection-strategy=explicitly-annotated

--- a/src/main/resources/db/migration/V11__add_narou_novel_api.sql
+++ b/src/main/resources/db/migration/V11__add_narou_novel_api.sql
@@ -1,0 +1,21 @@
+create table narou_novel_snapshots
+(
+    ncode            varchar(255) not null,
+    general_lastup   varchar(32)  not null,
+    general_all_no   integer      not null,
+    length_value     bigint       not null,
+    reading_time     integer      not null,
+    novel_updated_at varchar(32)  not null,
+    api_updated_at   varchar(32)  not null,
+    primary key (ncode)
+);
+
+create table narou_novel_alert_settings
+(
+    guild_id                    bigint not null,
+    channel_id                  bigint,
+    length_threshold            bigint not null,
+    last_alerted_length         bigint,
+    last_alerted_general_all_no integer,
+    primary key (guild_id)
+);

--- a/src/test/kotlin/be/duncanc/discordmodbot/ApplicationModulesTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/ApplicationModulesTest.kt
@@ -17,6 +17,7 @@ class ApplicationModulesTest {
                 "logging",
                 "member.gate",
                 "moderation",
+                "narou.novel.api",
                 "reporting",
                 "roles",
                 "server.config",

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
@@ -1,0 +1,191 @@
+package be.duncanc.discordmodbot.narou.novel.api
+
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettings
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettingsRepository
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshot
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionContextType
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class NarouNovelConfigCommandTest {
+    @Mock
+    private lateinit var narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository
+
+    @Mock
+    private lateinit var narouNovelSnapshotRepository: NarouNovelSnapshotRepository
+
+    @Mock
+    private lateinit var slashEvent: SlashCommandInteractionEvent
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var member: Member
+
+    @Mock
+    private lateinit var textChannel: TextChannel
+
+    @Mock
+    private lateinit var replyAction: ReplyCallbackAction
+
+    private lateinit var command: TestNarouNovelConfigCommand
+
+    @BeforeEach
+    fun setUp() {
+        command = TestNarouNovelConfigCommand(narouNovelAlertSettingsRepository, narouNovelSnapshotRepository)
+    }
+
+    @Test
+    fun `missing manage channel permission returns error`() {
+        stubSlashCommandContext()
+        whenever(member.hasPermission(Permission.MANAGE_CHANNEL)).thenReturn(false)
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).reply("You need manage channel permission to use this command.")
+    }
+
+    @Test
+    fun `show displays disabled state with default threshold`() {
+        stubAuthorizedSlashCommand("show")
+        whenever(guild.name).thenReturn("Test Guild")
+        whenever(narouNovelAlertSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val replyCaptor = argumentCaptor<String>()
+        verify(slashEvent).reply(replyCaptor.capture())
+        assertEquals(true, replyCaptor.firstValue.contains("- Alert channel: Disabled"))
+        assertEquals(true, replyCaptor.firstValue.contains("- Character growth threshold: 1000"))
+    }
+
+    @Test
+    fun `set channel stores selected channel and initializes baselines from snapshot`() {
+        stubAuthorizedSlashCommand("set-channel")
+        whenever(textChannel.idLong).thenReturn(11L)
+        whenever(textChannel.asMention).thenReturn("<#11>")
+        whenever(narouNovelAlertSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(
+            Optional.of(
+                NarouNovelSnapshot(
+                    ncode = NarouNovelPollingService.NOVEL_CODE,
+                    generalLastup = "2026-05-15 07:00:00",
+                    generalAllNo = 778,
+                    length = 9_445_269,
+                    time = 18_891,
+                    novelUpdatedAt = "2026-05-15 07:00:36",
+                    updatedAt = "2026-05-15 20:14:23"
+                )
+            )
+        )
+        command.selectedChannel = textChannel
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(11L, settingsCaptor.firstValue.channelId)
+        assertEquals(9_445_269L, settingsCaptor.firstValue.lastAlertedLength)
+        assertEquals(778, settingsCaptor.firstValue.lastAlertedGeneralAllNo)
+        verify(slashEvent).reply("Narou novel alerts will be sent to <#11>.")
+    }
+
+    @Test
+    fun `set threshold rejects small values`() {
+        stubSlashCommandContext()
+        whenever(member.hasPermission(Permission.MANAGE_CHANNEL)).thenReturn(true)
+        whenever(slashEvent.subcommandName).thenReturn("set-threshold")
+        command.threshold = 49L
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).reply("The length threshold must be at least 50.")
+    }
+
+    @Test
+    fun `set threshold stores configured value`() {
+        stubAuthorizedSlashCommand("set-threshold")
+        command.threshold = 500L
+        whenever(narouNovelAlertSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.empty())
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(500L, settingsCaptor.firstValue.lengthThreshold)
+        verify(slashEvent).reply("Narou novel length alerts now require at least 500 characters.")
+    }
+
+    @Test
+    fun `disable removes narou novel configuration`() {
+        stubAuthorizedSlashCommand("disable")
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(narouNovelAlertSettingsRepository).deleteById(1L)
+        verify(slashEvent).reply("Narou novel alerts disabled.")
+    }
+
+    @Test
+    fun `command data exposes expected subcommands`() {
+        val commandData = command.getCommandsData().single()
+
+        assertEquals("narounovelapi", commandData.name)
+        assertEquals(setOf(InteractionContextType.GUILD), commandData.contexts)
+        assertEquals(
+            listOf("show", "set-channel", "set-threshold", "disable"),
+            commandData.subcommands.map(SubcommandData::getName)
+        )
+    }
+
+    private fun stubSlashCommandContext() {
+        whenever(slashEvent.name).thenReturn("narounovelapi")
+        whenever(slashEvent.guild).thenReturn(guild)
+        whenever(slashEvent.member).thenReturn(member)
+        whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+    }
+
+    private fun stubAuthorizedSlashCommand(subcommandName: String) {
+        stubSlashCommandContext()
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(member.hasPermission(Permission.MANAGE_CHANNEL)).thenReturn(true)
+        whenever(slashEvent.subcommandName).thenReturn(subcommandName)
+    }
+
+    private class TestNarouNovelConfigCommand(
+        narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository,
+        narouNovelSnapshotRepository: NarouNovelSnapshotRepository
+    ) : NarouNovelConfigCommand(narouNovelAlertSettingsRepository, narouNovelSnapshotRepository) {
+        var selectedChannel: TextChannel? = null
+        var threshold: Long? = null
+
+        override fun getRequiredTextChannel(event: SlashCommandInteractionEvent): TextChannel? {
+            return selectedChannel ?: super.getRequiredTextChannel(event)
+        }
+
+        override fun getRequiredThreshold(event: SlashCommandInteractionEvent): Long? {
+            return threshold ?: super.getRequiredThreshold(event)
+        }
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
@@ -2,12 +2,14 @@ package be.duncanc.discordmodbot.narou.novel.api
 
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettings
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettingsRepository
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelPendingAlertRepository
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshot
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
@@ -33,6 +35,9 @@ class NarouNovelConfigCommandTest {
     private lateinit var narouNovelSnapshotRepository: NarouNovelSnapshotRepository
 
     @Mock
+    private lateinit var narouNovelPendingAlertRepository: NarouNovelPendingAlertRepository
+
+    @Mock
     private lateinit var slashEvent: SlashCommandInteractionEvent
 
     @Mock
@@ -47,11 +52,18 @@ class NarouNovelConfigCommandTest {
     @Mock
     private lateinit var replyAction: ReplyCallbackAction
 
+    @Mock
+    private lateinit var guildLeaveEvent: GuildLeaveEvent
+
     private lateinit var command: TestNarouNovelConfigCommand
 
     @BeforeEach
     fun setUp() {
-        command = TestNarouNovelConfigCommand(narouNovelAlertSettingsRepository, narouNovelSnapshotRepository)
+        command = TestNarouNovelConfigCommand(
+            narouNovelAlertSettingsRepository,
+            narouNovelPendingAlertRepository,
+            narouNovelSnapshotRepository
+        )
     }
 
     @Test
@@ -143,7 +155,19 @@ class NarouNovelConfigCommandTest {
         command.onSlashCommandInteraction(slashEvent)
 
         verify(narouNovelAlertSettingsRepository).deleteById(1L)
+        verify(narouNovelPendingAlertRepository).deleteById(1L)
         verify(slashEvent).reply("Narou novel alerts disabled.")
+    }
+
+    @Test
+    fun `guild leave removes narou novel configuration and pending alert`() {
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guildLeaveEvent.guild).thenReturn(guild)
+
+        command.onGuildLeave(guildLeaveEvent)
+
+        verify(narouNovelAlertSettingsRepository).deleteById(1L)
+        verify(narouNovelPendingAlertRepository).deleteById(1L)
     }
 
     @Test
@@ -175,8 +199,13 @@ class NarouNovelConfigCommandTest {
 
     private class TestNarouNovelConfigCommand(
         narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository,
+        narouNovelPendingAlertRepository: NarouNovelPendingAlertRepository,
         narouNovelSnapshotRepository: NarouNovelSnapshotRepository
-    ) : NarouNovelConfigCommand(narouNovelAlertSettingsRepository, narouNovelSnapshotRepository) {
+    ) : NarouNovelConfigCommand(
+        narouNovelAlertSettingsRepository,
+        narouNovelPendingAlertRepository,
+        narouNovelSnapshotRepository
+    ) {
         var selectedChannel: TextChannel? = null
         var threshold: Long? = null
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -9,6 +9,7 @@ import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRe
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -200,6 +201,26 @@ class NarouNovelPollingServiceTest {
     }
 
     @Test
+    fun `poll skips resend when matching pending snapshot already exists`() {
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 780)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        pendingAlerts[1L] = NarouNovelPendingAlert(1L, 9_446_500L, 780)
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+
+        service.pollNovel()
+
+        assertEquals(emptyList<String>(), service.sentMessages)
+        verify(jda, never()).getTextChannelById(any<Long>())
+    }
+
+    @Test
     fun `poll retries after alert failure callback clears pending lock`() {
         stubPendingAlertRepository()
         service = TestNarouNovelPollingService(
@@ -230,6 +251,37 @@ class NarouNovelPollingServiceTest {
         assertEquals(2, service.sentMessages.size)
         verify(narouNovelAlertSettingsRepository, never()).save(settings)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
+    }
+
+    @Test
+    fun `poll keeps matching pending alert after baseline save failure to avoid duplicate resend`() {
+        stubPendingAlertRepository(includeDeleteById = false)
+        service = TestNarouNovelPollingService(
+            narouNovelApiClient,
+            narouNovelSnapshotRepository,
+            narouNovelAlertSettingsRepository,
+            narouNovelPendingAlertRepository,
+            jda
+        )
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 780)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+        whenever(narouNovelAlertSettingsRepository.save(settings)).thenThrow(IllegalStateException("db down"))
+
+        service.pollNovel()
+        service.pollNovel()
+
+        assertEquals(1, service.sentMessages.size)
+        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 780), pendingAlerts[1L])
     }
 
     @Test
@@ -266,6 +318,39 @@ class NarouNovelPollingServiceTest {
         assertEquals("boom", firstFailure.message)
         assertEquals("boom", secondFailure.message)
         assertEquals(2, service.sentMessages.size)
+        assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
+    }
+
+    @Test
+    fun `terminal send failure disables configured channel`() {
+        stubPendingAlertRepository()
+        service = TestNarouNovelPollingService(
+            narouNovelApiClient,
+            narouNovelSnapshotRepository,
+            narouNovelAlertSettingsRepository,
+            narouNovelPendingAlertRepository,
+            jda,
+            failWith = IllegalStateException("missing access"),
+            terminalFailurePredicate = { true }
+        )
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 780)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        service.pollNovel()
+        service.pollNovel()
+
+        assertEquals(1, service.sentMessages.size)
+        assertNull(settings.channelId)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
 
@@ -333,6 +418,8 @@ class NarouNovelPollingServiceTest {
         private val completeSendsImmediately: Boolean = true,
         private val failSendsImmediately: Boolean = false,
         private val throwOnSend: RuntimeException? = null,
+        private val failWith: Throwable? = null,
+        private val terminalFailurePredicate: (Throwable) -> Boolean = { false },
         private val onSend: (() -> Unit)? = null
     ) : NarouNovelPollingService(
         narouNovelApiClient,
@@ -343,6 +430,10 @@ class NarouNovelPollingServiceTest {
     ) {
         val sentMessages = mutableListOf<String>()
 
+        override fun isTerminalChannelFailure(exception: Throwable): Boolean {
+            return terminalFailurePredicate(exception)
+        }
+
         override fun sendAlertMessage(
             channel: TextChannel,
             message: String,
@@ -352,6 +443,10 @@ class NarouNovelPollingServiceTest {
             sentMessages += message
             onSend?.invoke()
             throwOnSend?.let { throw it }
+            failWith?.let {
+                onFailure(it)
+                return
+            }
             if (failSendsImmediately) {
                 onFailure(IllegalStateException("send failed"))
                 return

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -210,14 +210,16 @@ class NarouNovelPollingServiceTest {
             lastAlertedLength = 9_445_269L,
             lastAlertedGeneralAllNo = 778
         )
-        pendingAlerts[1L] = NarouNovelPendingAlert(1L, 9_446_500L, 780)
+        whenever(narouNovelPendingAlertRepository.findById(1L)).thenReturn(Optional.of(NarouNovelPendingAlert(1L, 9_446_500L, 780)))
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
         whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
 
         service.pollNovel()
 
         assertEquals(emptyList<String>(), service.sentMessages)
         verify(jda, never()).getTextChannelById(any<Long>())
+        verify(narouNovelPendingAlertRepository).findById(1L)
     }
 
     @Test

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -144,7 +144,7 @@ class NarouNovelPollingServiceTest {
     }
 
     @Test
-    fun `alert baseline updates before Discord send callback to prevent duplicate alerts`() {
+    fun `alert baseline updates only after Discord send callback`() {
         service = TestNarouNovelPollingService(
             narouNovelApiClient,
             narouNovelSnapshotRepository,
@@ -170,14 +170,14 @@ class NarouNovelPollingServiceTest {
 
         assertEquals(
             listOf(
+                "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/",
                 "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
             ),
             service.sentMessages
         )
-        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
-        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
-        assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
-        assertEquals(780, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+        verify(narouNovelAlertSettingsRepository, never()).save(settings)
+        assertEquals(9_445_269L, settings.lastAlertedLength)
+        assertEquals(778, settings.lastAlertedGeneralAllNo)
     }
 
     @Test

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -83,7 +83,7 @@ class NarouNovelPollingServiceTest {
 
         service.pollNovel()
 
-        assertEquals(listOf("Narou update for n2267be: 1 new chapter was published. Total chapters: 779. Total characters: 9445500. https://ncode.syosetu.com/n2267be/"), service.sentMessages)
+        assertEquals(listOf("@everyone Narou update for n2267be: 1 new chapter was published. Total chapters: 779. Total characters: 9445500. https://ncode.syosetu.com/n2267be/"), service.sentMessages)
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_445_269L, settingsCaptor.lastValue.lastAlertedLength)
@@ -107,7 +107,7 @@ class NarouNovelPollingServiceTest {
 
         service.pollNovel()
 
-        assertEquals(listOf("Narou update for n2267be: the novel grew by 1231 characters. Total chapters: 778. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"), service.sentMessages)
+        assertEquals(listOf("@everyone Narou update for n2267be: the novel grew by 1231 characters. Total chapters: 778. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"), service.sentMessages)
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
@@ -133,7 +133,7 @@ class NarouNovelPollingServiceTest {
 
         assertEquals(
             listOf(
-                "Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
+                "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
             ),
             service.sentMessages
         )
@@ -170,7 +170,7 @@ class NarouNovelPollingServiceTest {
 
         assertEquals(
             listOf(
-                "Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
+                "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
             ),
             service.sentMessages
         )

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -48,10 +48,10 @@ class NarouNovelPollingServiceTest {
     }
 
     @Test
-    fun `first poll ignores allcount and stores latest payload`() {
+    fun `first poll ignores incomplete entries and stores latest payload`() {
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(
             listOf(
-                NarouNovelApiResponseEntry(allcount = 1),
+                NarouNovelApiResponseEntry(),
                 payload(length = 9_445_269, generalAllNo = 778)
             )
         )
@@ -144,6 +144,43 @@ class NarouNovelPollingServiceTest {
     }
 
     @Test
+    fun `alert baseline updates before Discord send callback to prevent duplicate alerts`() {
+        service = TestNarouNovelPollingService(
+            narouNovelApiClient,
+            narouNovelSnapshotRepository,
+            narouNovelAlertSettingsRepository,
+            jda,
+            completeSendsImmediately = false
+        )
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 780)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        service.pollNovel()
+        service.pollNovel()
+
+        assertEquals(
+            listOf(
+                "Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
+            ),
+            service.sentMessages
+        )
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(780, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+    }
+
+    @Test
     fun `missing baselines are initialized without alerting`() {
         val snapshot = snapshot(length = 9_445_500, generalAllNo = 779)
         val settings = NarouNovelAlertSettings(guildId = 1L, channelId = 11L, lastAlertedLength = null, lastAlertedGeneralAllNo = null)
@@ -187,7 +224,8 @@ class NarouNovelPollingServiceTest {
         narouNovelApiClient: NarouNovelApiClient,
         narouNovelSnapshotRepository: NarouNovelSnapshotRepository,
         narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository,
-        jda: JDA
+        jda: JDA,
+        private val completeSendsImmediately: Boolean = true
     ) : NarouNovelPollingService(
         narouNovelApiClient,
         narouNovelSnapshotRepository,
@@ -203,7 +241,9 @@ class NarouNovelPollingServiceTest {
             onFailure: (Throwable) -> Unit
         ) {
             sentMessages += message
-            onSuccess()
+            if (completeSendsImmediately) {
+                onSuccess()
+            }
         }
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -2,17 +2,22 @@ package be.duncanc.discordmodbot.narou.novel.api
 
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettings
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettingsRepository
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelPendingAlert
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelPendingAlertRepository
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshot
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -30,19 +35,25 @@ class NarouNovelPollingServiceTest {
     private lateinit var narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository
 
     @Mock
+    private lateinit var narouNovelPendingAlertRepository: NarouNovelPendingAlertRepository
+
+    @Mock
     private lateinit var jda: JDA
 
     @Mock
     private lateinit var textChannel: TextChannel
 
     private lateinit var service: TestNarouNovelPollingService
+    private val pendingAlerts = mutableMapOf<Long, NarouNovelPendingAlert>()
 
     @BeforeEach
     fun setUp() {
+        pendingAlerts.clear()
         service = TestNarouNovelPollingService(
             narouNovelApiClient,
             narouNovelSnapshotRepository,
             narouNovelAlertSettingsRepository,
+            narouNovelPendingAlertRepository,
             jda
         )
     }
@@ -68,6 +79,7 @@ class NarouNovelPollingServiceTest {
 
     @Test
     fun `chapter alert does not reset length baseline when threshold not met`() {
+        stubPendingAlertRepository()
         val snapshot = snapshot(length = 9_445_500, generalAllNo = 779)
         val settings = NarouNovelAlertSettings(
             guildId = 1L,
@@ -88,10 +100,12 @@ class NarouNovelPollingServiceTest {
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_445_269L, settingsCaptor.lastValue.lastAlertedLength)
         assertEquals(779, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+        assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
 
     @Test
     fun `length alert triggers when threshold is reached`() {
+        stubPendingAlertRepository()
         val snapshot = snapshot(length = 9_446_500, generalAllNo = 778)
         val settings = NarouNovelAlertSettings(
             guildId = 1L,
@@ -112,10 +126,12 @@ class NarouNovelPollingServiceTest {
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
         assertEquals(778, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+        assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
 
     @Test
     fun `combined alert updates both baselines`() {
+        stubPendingAlertRepository()
         val snapshot = snapshot(length = 9_446_500, generalAllNo = 780)
         val settings = NarouNovelAlertSettings(
             guildId = 1L,
@@ -141,14 +157,17 @@ class NarouNovelPollingServiceTest {
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
         assertEquals(780, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+        assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
 
     @Test
-    fun `alert baseline updates only after Discord send callback`() {
+    fun `poll skips duplicate guild alert while Discord send callback is still pending`() {
+        stubPendingAlertRepository(includeDeleteById = false)
         service = TestNarouNovelPollingService(
             narouNovelApiClient,
             narouNovelSnapshotRepository,
             narouNovelAlertSettingsRepository,
+            narouNovelPendingAlertRepository,
             jda,
             completeSendsImmediately = false
         )
@@ -170,14 +189,84 @@ class NarouNovelPollingServiceTest {
 
         assertEquals(
             listOf(
-                "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/",
                 "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
             ),
             service.sentMessages
         )
+        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 780), pendingAlerts[1L])
         verify(narouNovelAlertSettingsRepository, never()).save(settings)
         assertEquals(9_445_269L, settings.lastAlertedLength)
         assertEquals(778, settings.lastAlertedGeneralAllNo)
+    }
+
+    @Test
+    fun `poll retries after alert failure callback clears pending lock`() {
+        stubPendingAlertRepository()
+        service = TestNarouNovelPollingService(
+            narouNovelApiClient,
+            narouNovelSnapshotRepository,
+            narouNovelAlertSettingsRepository,
+            narouNovelPendingAlertRepository,
+            jda,
+            completeSendsImmediately = false,
+            failSendsImmediately = true
+        )
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 780)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        service.pollNovel()
+        service.pollNovel()
+
+        assertEquals(2, service.sentMessages.size)
+        verify(narouNovelAlertSettingsRepository, never()).save(settings)
+        assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
+    }
+
+    @Test
+    fun `poll retries after synchronous send exception clears pending lock`() {
+        stubPendingAlertRepository()
+        service = TestNarouNovelPollingService(
+            narouNovelApiClient,
+            narouNovelSnapshotRepository,
+            narouNovelAlertSettingsRepository,
+            narouNovelPendingAlertRepository,
+            jda,
+            throwOnSend = IllegalStateException("boom")
+        )
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 780)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        val firstFailure = assertThrows(IllegalStateException::class.java) {
+            service.pollNovel()
+        }
+        val secondFailure = assertThrows(IllegalStateException::class.java) {
+            service.pollNovel()
+        }
+
+        assertEquals("boom", firstFailure.message)
+        assertEquals("boom", secondFailure.message)
+        assertEquals(2, service.sentMessages.size)
+        assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
 
     @Test
@@ -220,16 +309,36 @@ class NarouNovelPollingServiceTest {
         )
     }
 
+    private fun stubPendingAlertRepository(includeDeleteById: Boolean = true) {
+        whenever(narouNovelPendingAlertRepository.findById(any<Long>())).thenAnswer { invocation ->
+            Optional.ofNullable(pendingAlerts[invocation.getArgument(0)])
+        }
+        whenever(narouNovelPendingAlertRepository.save(any<NarouNovelPendingAlert>())).thenAnswer { invocation ->
+            invocation.getArgument<NarouNovelPendingAlert>(0).also { pendingAlerts[it.guildId] = it }
+        }
+        if (includeDeleteById) {
+            doAnswer { invocation ->
+                pendingAlerts.remove(invocation.getArgument(0))
+                null
+            }.whenever(narouNovelPendingAlertRepository).deleteById(any<Long>())
+        }
+    }
+
     private class TestNarouNovelPollingService(
         narouNovelApiClient: NarouNovelApiClient,
         narouNovelSnapshotRepository: NarouNovelSnapshotRepository,
         narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository,
+        narouNovelPendingAlertRepository: NarouNovelPendingAlertRepository,
         jda: JDA,
-        private val completeSendsImmediately: Boolean = true
+        private val completeSendsImmediately: Boolean = true,
+        private val failSendsImmediately: Boolean = false,
+        private val throwOnSend: RuntimeException? = null,
+        private val onSend: (() -> Unit)? = null
     ) : NarouNovelPollingService(
         narouNovelApiClient,
         narouNovelSnapshotRepository,
         narouNovelAlertSettingsRepository,
+        narouNovelPendingAlertRepository,
         jda
     ) {
         val sentMessages = mutableListOf<String>()
@@ -241,6 +350,12 @@ class NarouNovelPollingServiceTest {
             onFailure: (Throwable) -> Unit
         ) {
             sentMessages += message
+            onSend?.invoke()
+            throwOnSend?.let { throw it }
+            if (failSendsImmediately) {
+                onFailure(IllegalStateException("send failed"))
+                return
+            }
             if (completeSendsImmediately) {
                 onSuccess()
             }

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -355,6 +355,29 @@ class NarouNovelPollingServiceTest {
     }
 
     @Test
+    fun `missing channel disables configured channel`() {
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 780)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(null)
+
+        service.pollNovel()
+        service.pollNovel()
+
+        assertEquals(emptyList<String>(), service.sentMessages)
+        assertNull(settings.channelId)
+        assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
+    }
+
+    @Test
     fun `missing baselines are initialized without alerting`() {
         val snapshot = snapshot(length = 9_445_500, generalAllNo = 779)
         val settings = NarouNovelAlertSettings(guildId = 1L, channelId = 11L, lastAlertedLength = null, lastAlertedGeneralAllNo = null)

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -1,0 +1,209 @@
+package be.duncanc.discordmodbot.narou.novel.api
+
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettings
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelAlertSettingsRepository
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshot
+import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class NarouNovelPollingServiceTest {
+    @Mock
+    private lateinit var narouNovelApiClient: NarouNovelApiClient
+
+    @Mock
+    private lateinit var narouNovelSnapshotRepository: NarouNovelSnapshotRepository
+
+    @Mock
+    private lateinit var narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository
+
+    @Mock
+    private lateinit var jda: JDA
+
+    @Mock
+    private lateinit var textChannel: TextChannel
+
+    private lateinit var service: TestNarouNovelPollingService
+
+    @BeforeEach
+    fun setUp() {
+        service = TestNarouNovelPollingService(
+            narouNovelApiClient,
+            narouNovelSnapshotRepository,
+            narouNovelAlertSettingsRepository,
+            jda
+        )
+    }
+
+    @Test
+    fun `first poll ignores allcount and stores latest payload`() {
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(
+            listOf(
+                NarouNovelApiResponseEntry(allcount = 1),
+                payload(length = 9_445_269, generalAllNo = 778)
+            )
+        )
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.empty())
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(emptyList())
+
+        service.pollNovel()
+
+        val snapshotCaptor = argumentCaptor<NarouNovelSnapshot>()
+        verify(narouNovelSnapshotRepository).save(snapshotCaptor.capture())
+        assertEquals(9_445_269L, snapshotCaptor.firstValue.length)
+        assertEquals(778, snapshotCaptor.firstValue.generalAllNo)
+    }
+
+    @Test
+    fun `chapter alert does not reset length baseline when threshold not met`() {
+        val snapshot = snapshot(length = 9_445_500, generalAllNo = 779)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_500, generalAllNo = 779)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        service.pollNovel()
+
+        assertEquals(listOf("Narou update for n2267be: 1 new chapter was published. Total chapters: 779. Total characters: 9445500. https://ncode.syosetu.com/n2267be/"), service.sentMessages)
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(9_445_269L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(779, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+    }
+
+    @Test
+    fun `length alert triggers when threshold is reached`() {
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 778)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 778)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        service.pollNovel()
+
+        assertEquals(listOf("Narou update for n2267be: the novel grew by 1231 characters. Total chapters: 778. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"), service.sentMessages)
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(778, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+    }
+
+    @Test
+    fun `combined alert updates both baselines`() {
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 780)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        service.pollNovel()
+
+        assertEquals(
+            listOf(
+                "Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
+            ),
+            service.sentMessages
+        )
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(780, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+    }
+
+    @Test
+    fun `missing baselines are initialized without alerting`() {
+        val snapshot = snapshot(length = 9_445_500, generalAllNo = 779)
+        val settings = NarouNovelAlertSettings(guildId = 1L, channelId = 11L, lastAlertedLength = null, lastAlertedGeneralAllNo = null)
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_500, generalAllNo = 779)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+
+        service.pollNovel()
+
+        verify(jda, never()).getTextChannelById(11L)
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(9_445_500L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(779, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+    }
+
+    private fun payload(length: Long, generalAllNo: Int): NarouNovelApiResponseEntry {
+        return NarouNovelApiResponseEntry(
+            generalLastup = "2026-05-15 07:00:00",
+            generalAllNo = generalAllNo,
+            length = length,
+            time = 18_891,
+            novelUpdatedAt = "2026-05-15 07:00:36",
+            updatedAt = "2026-05-15 20:14:23"
+        )
+    }
+
+    private fun snapshot(length: Long, generalAllNo: Int): NarouNovelSnapshot {
+        return NarouNovelSnapshot(
+            ncode = NarouNovelPollingService.NOVEL_CODE,
+            generalLastup = "2026-05-15 07:00:00",
+            generalAllNo = generalAllNo,
+            length = length,
+            time = 18_891,
+            novelUpdatedAt = "2026-05-15 07:00:36",
+            updatedAt = "2026-05-15 20:14:23"
+        )
+    }
+
+    private class TestNarouNovelPollingService(
+        narouNovelApiClient: NarouNovelApiClient,
+        narouNovelSnapshotRepository: NarouNovelSnapshotRepository,
+        narouNovelAlertSettingsRepository: NarouNovelAlertSettingsRepository,
+        jda: JDA
+    ) : NarouNovelPollingService(
+        narouNovelApiClient,
+        narouNovelSnapshotRepository,
+        narouNovelAlertSettingsRepository,
+        jda
+    ) {
+        val sentMessages = mutableListOf<String>()
+
+        override fun sendAlertMessage(
+            channel: TextChannel,
+            message: String,
+            onSuccess: () -> Unit,
+            onFailure: (Throwable) -> Unit
+        ) {
+            sentMessages += message
+            onSuccess()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Narou Novel API polling, persistence, and scheduling for the configured novel.
- Add `/narounovelapi` guild configuration for alert channel and character-growth threshold.
- Prevent duplicate queued alerts by updating alert baselines before Discord send callbacks complete.

## Tests
- `./gradlew.bat test --tests "be.duncanc.discordmodbot.narou.novel.api.NarouNovelPollingServiceTest"`