### PR TITLE
fix(narouNovelApi): preserve alerts when profile polling fails

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClient.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelApiClient.kt
@@ -7,6 +7,9 @@ import org.springframework.web.service.annotation.GetExchange
 interface NarouNovelApiClient {
     @GetExchange("/novelapi/api/?ncode=n2267be&out=json&of=l-ti-gl-ga-nu-ua")
     fun fetchNovel(): List<NarouNovelApiResponseEntry>
+
+    @GetExchange("/userapi/api/?userid=235132&name1st=%E3%81%AD&of=nl&out=json")
+    fun fetchAuthorProfile(): List<NarouAuthorProfileApiResponseEntry>
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -21,4 +24,10 @@ data class NarouNovelApiResponseEntry(
     val novelUpdatedAt: String? = null,
     @JsonProperty("updated_at")
     val updatedAt: String? = null
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class NarouAuthorProfileApiResponseEntry(
+    @JsonProperty("novel_length")
+    val novelLength: Long? = null
 )

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
@@ -169,7 +169,7 @@ class NarouNovelConfigCommand(
         if (settings.lastAlertedLength == null) {
             settings.lastAlertedLength = snapshot.length
         }
-        if (settings.lastAlertedAuthorProfileLength == null) {
+        if (settings.lastAlertedAuthorProfileLength == null && snapshot.authorProfileLength > 0) {
             settings.lastAlertedAuthorProfileLength = snapshot.authorProfileLength
         }
         if (settings.lastAlertedGeneralAllNo == null) {

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
@@ -35,6 +35,7 @@ class NarouNovelConfigCommand(
         private const val SUBCOMMAND_SHOW = "show"
         private const val SUBCOMMAND_SET_CHANNEL = "set-channel"
         private const val SUBCOMMAND_SET_THRESHOLD = "set-threshold"
+        private const val SUBCOMMAND_SET_PREDICTION_THRESHOLD = "set-prediction-threshold"
         private const val SUBCOMMAND_DISABLE = "disable"
         internal const val MINIMUM_THRESHOLD = 50L
     }
@@ -90,6 +91,23 @@ class NarouNovelConfigCommand(
                     .queue()
             }
 
+            SUBCOMMAND_SET_PREDICTION_THRESHOLD -> {
+                val threshold = getRequiredThreshold(event) ?: return
+                if (threshold < MINIMUM_THRESHOLD) {
+                    event.reply("The length threshold must be at least 50.").setEphemeral(true).queue()
+                    return
+                }
+                val settings = narouNovelAlertSettingsRepository.findById(guild.idLong).orElseGet {
+                    NarouNovelAlertSettings(guildId = guild.idLong)
+                }
+                settings.predictionLengthThreshold = threshold
+                initializeBaselines(settings)
+                narouNovelAlertSettingsRepository.save(settings)
+                event.reply("Narou prediction alerts now require at least $threshold characters of author profile growth.")
+                    .setEphemeral(true)
+                    .queue()
+            }
+
             SUBCOMMAND_DISABLE -> {
                 clearAlertConfiguration(guild.idLong)
                 event.reply("Narou novel alerts disabled.").setEphemeral(true).queue()
@@ -109,13 +127,13 @@ class NarouNovelConfigCommand(
                     SubcommandData(SUBCOMMAND_SET_CHANNEL, "Set the channel that receives Narou novel alerts")
                         .addOptions(textChannelOption("The channel used for Narou novel alerts")),
                     SubcommandData(SUBCOMMAND_SET_THRESHOLD, "Set the character growth threshold for alerts")
+                        .addOptions(thresholdOption("Minimum published novel growth required before an alert is sent")),
+                    SubcommandData(
+                        SUBCOMMAND_SET_PREDICTION_THRESHOLD,
+                        "Set the author profile growth threshold used for prediction alerts"
+                    )
                         .addOptions(
-                            OptionData(
-                                OptionType.INTEGER,
-                                OPTION_THRESHOLD,
-                                "Minimum character growth required before an alert is sent",
-                                true
-                            ).setMinValue(MINIMUM_THRESHOLD)
+                            thresholdOption("Minimum author profile growth required before a prediction alert is sent")
                         ),
                     SubcommandData(SUBCOMMAND_DISABLE, "Disable Narou novel alerts for this server")
                 )
@@ -151,6 +169,9 @@ class NarouNovelConfigCommand(
         if (settings.lastAlertedLength == null) {
             settings.lastAlertedLength = snapshot.length
         }
+        if (settings.lastAlertedAuthorProfileLength == null) {
+            settings.lastAlertedAuthorProfileLength = snapshot.authorProfileLength
+        }
         if (settings.lastAlertedGeneralAllNo == null) {
             settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
         }
@@ -167,7 +188,11 @@ class NarouNovelConfigCommand(
             appendLine("Narou novel alert settings for ${guild.name}")
             appendLine()
             appendLine("- Alert channel: ${formatChannel(guild, settings?.channelId)}")
-            appendLine("- Character growth threshold: ${settings?.lengthThreshold ?: NarouNovelAlertSettings.DEFAULT_LENGTH_THRESHOLD}")
+            appendLine("- Published novel growth threshold: ${settings?.lengthThreshold ?: NarouNovelAlertSettings.DEFAULT_LENGTH_THRESHOLD}")
+            appendLine(
+                "- Author profile prediction threshold: " +
+                    "${settings?.predictionLengthThreshold ?: NarouNovelAlertSettings.DEFAULT_PREDICTION_LENGTH_THRESHOLD}"
+            )
         }
 
         event.reply(message).setEphemeral(true).queue()
@@ -184,5 +209,10 @@ class NarouNovelConfigCommand(
     private fun textChannelOption(description: String): OptionData {
         return OptionData(OptionType.CHANNEL, OPTION_CHANNEL, description, true)
             .setChannelTypes(ChannelType.TEXT)
+    }
+
+    private fun thresholdOption(description: String): OptionData {
+        return OptionData(OptionType.INTEGER, OPTION_THRESHOLD, description, true)
+            .setMinValue(MINIMUM_THRESHOLD)
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -18,9 +18,21 @@ class NarouNovelPollingService(
     private val narouNovelPendingAlertRepository: NarouNovelPendingAlertRepository,
     private val jda: JDA
 ) {
+    data class NarouNovelPollSnapshot(
+        val generalLastup: String,
+        val generalAllNo: Int,
+        val length: Long,
+        val authorProfileLength: Long,
+        val time: Int,
+        val novelUpdatedAt: String,
+        val updatedAt: String
+    )
+
     companion object {
         internal const val NOVEL_CODE = "n2267be"
         private const val NOVEL_URL = "https://ncode.syosetu.com/n2267be/"
+        private const val PREDICTION_ALERT_MESSAGE =
+            "Detected an increase in the author's profile character count. This may indicate that a new chapter is coming soon"
         private val LOG = LoggerFactory.getLogger(NarouNovelPollingService::class.java)
     }
 
@@ -39,31 +51,33 @@ class NarouNovelPollingService(
             narouNovelSnapshotRepository.save(
                 NarouNovelSnapshot(
                     ncode = NOVEL_CODE,
-                    generalLastup = payload.generalLastup!!,
-                    generalAllNo = payload.generalAllNo!!,
-                    length = payload.length!!,
-                    time = payload.time!!,
-                    novelUpdatedAt = payload.novelUpdatedAt!!,
-                    updatedAt = payload.updatedAt!!
+                    generalLastup = payload.generalLastup,
+                    generalAllNo = payload.generalAllNo,
+                    length = payload.length,
+                    authorProfileLength = payload.authorProfileLength,
+                    time = payload.time,
+                    novelUpdatedAt = payload.novelUpdatedAt,
+                    updatedAt = payload.updatedAt
                 )
             )
-            initializeMissingBaselines(payload.length, payload.generalAllNo)
+            initializeMissingBaselines(payload.length, payload.authorProfileLength, payload.generalAllNo)
             return
         }
 
-        snapshot.generalLastup = payload.generalLastup!!
-        snapshot.generalAllNo = payload.generalAllNo!!
-        snapshot.length = payload.length!!
-        snapshot.time = payload.time!!
-        snapshot.novelUpdatedAt = payload.novelUpdatedAt!!
-        snapshot.updatedAt = payload.updatedAt!!
+        snapshot.generalLastup = payload.generalLastup
+        snapshot.generalAllNo = payload.generalAllNo
+        snapshot.length = payload.length
+        snapshot.authorProfileLength = payload.authorProfileLength
+        snapshot.time = payload.time
+        snapshot.novelUpdatedAt = payload.novelUpdatedAt
+        snapshot.updatedAt = payload.updatedAt
         narouNovelSnapshotRepository.save(snapshot)
 
         processAlerts(snapshot)
     }
 
-    internal fun fetchPayload(): NarouNovelApiResponseEntry {
-        return narouNovelApiClient.fetchNovel().firstOrNull {
+    internal fun fetchPayload(): NarouNovelPollSnapshot {
+        val novelPayload = narouNovelApiClient.fetchNovel().firstOrNull {
             it.generalLastup != null &&
                     it.generalAllNo != null &&
                     it.length != null &&
@@ -71,6 +85,19 @@ class NarouNovelPollingService(
                     it.novelUpdatedAt != null &&
                     it.updatedAt != null
         } ?: throw IllegalStateException("Narou novel API response did not contain a novel payload")
+        val authorProfilePayload = narouNovelApiClient.fetchAuthorProfile().firstOrNull {
+            it.novelLength != null
+        } ?: throw IllegalStateException("Narou author profile API response did not contain a profile length payload")
+
+        return NarouNovelPollSnapshot(
+            generalLastup = novelPayload.generalLastup!!,
+            generalAllNo = novelPayload.generalAllNo!!,
+            length = novelPayload.length!!,
+            authorProfileLength = authorProfilePayload.novelLength!!,
+            time = novelPayload.time!!,
+            novelUpdatedAt = novelPayload.novelUpdatedAt!!,
+            updatedAt = novelPayload.updatedAt!!
+        )
     }
 
     private fun processAlerts(snapshot: NarouNovelSnapshot) {
@@ -81,31 +108,40 @@ class NarouNovelPollingService(
             }
 
             val lastAlertedLength = settings.lastAlertedLength ?: return@forEach
+            val lastAlertedAuthorProfileLength = settings.lastAlertedAuthorProfileLength ?: return@forEach
             val lastAlertedGeneralAllNo = settings.lastAlertedGeneralAllNo ?: return@forEach
             val lengthDelta = snapshot.length - lastAlertedLength
+            val predictionLengthDelta = snapshot.authorProfileLength - lastAlertedAuthorProfileLength
             val chapterDelta = snapshot.generalAllNo - lastAlertedGeneralAllNo
             val lengthTriggered = lengthDelta >= settings.lengthThreshold
+            val predictionTriggered = predictionLengthDelta >= settings.predictionLengthThreshold
             val chapterTriggered = chapterDelta > 0
-            if (!lengthTriggered && !chapterTriggered) {
+            if (!lengthTriggered && !predictionTriggered && !chapterTriggered) {
                 return@forEach
             }
 
             val pendingAlert = narouNovelPendingAlertRepository.findById(settings.guildId).orElse(null)
             if (pendingAlert != null) {
-                if (pendingAlert.snapshotGeneralAllNo == snapshot.generalAllNo && pendingAlert.snapshotLength == snapshot.length) {
+                if (
+                    pendingAlert.snapshotGeneralAllNo == snapshot.generalAllNo &&
+                    pendingAlert.snapshotLength == snapshot.length &&
+                    pendingAlert.snapshotAuthorProfileLength == snapshot.authorProfileLength
+                ) {
                     LOG.debug(
-                        "Skipping Narou novel alert for guild {} because snapshot {}:{} was already sent or is still being finalized",
+                        "Skipping Narou novel alert for guild {} because snapshot {}:{}:{} was already sent or is still being finalized",
                         settings.guildId,
                         pendingAlert.snapshotGeneralAllNo,
-                        pendingAlert.snapshotLength
+                        pendingAlert.snapshotLength,
+                        pendingAlert.snapshotAuthorProfileLength
                     )
                     return@forEach
                 }
                 LOG.debug(
-                    "Skipping Narou novel alert for guild {} because a pending alert lock exists for snapshot {}:{}",
+                    "Skipping Narou novel alert for guild {} because a pending alert lock exists for snapshot {}:{}:{}",
                     settings.guildId,
                     pendingAlert.snapshotGeneralAllNo,
-                    pendingAlert.snapshotLength
+                    pendingAlert.snapshotLength,
+                    pendingAlert.snapshotAuthorProfileLength
                 )
                 return@forEach
             }
@@ -121,11 +157,19 @@ class NarouNovelPollingService(
                 return@forEach
             }
 
-            val message = buildAlertMessage(lengthTriggered, lengthDelta, chapterTriggered, chapterDelta, snapshot)
+            val message = buildAlertMessage(
+                lengthTriggered,
+                lengthDelta,
+                predictionTriggered,
+                chapterTriggered,
+                chapterDelta,
+                snapshot
+            )
             narouNovelPendingAlertRepository.save(
                 NarouNovelPendingAlert(
                     guildId = settings.guildId,
                     snapshotLength = snapshot.length,
+                    snapshotAuthorProfileLength = snapshot.authorProfileLength,
                     snapshotGeneralAllNo = snapshot.generalAllNo
                 )
             )
@@ -137,6 +181,9 @@ class NarouNovelPollingService(
                         try {
                             if (lengthTriggered) {
                                 settings.lastAlertedLength = snapshot.length
+                            }
+                            if (predictionTriggered || chapterTriggered) {
+                                settings.lastAlertedAuthorProfileLength = snapshot.authorProfileLength
                             }
                             if (chapterTriggered) {
                                 settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
@@ -212,11 +259,15 @@ class NarouNovelPollingService(
         }
     }
 
-    private fun initializeMissingBaselines(length: Long, generalAllNo: Int) {
+    private fun initializeMissingBaselines(length: Long, authorProfileLength: Long, generalAllNo: Int) {
         narouNovelAlertSettingsRepository.findAll().forEach { settings ->
             var changed = false
             if (settings.lastAlertedLength == null) {
                 settings.lastAlertedLength = length
+                changed = true
+            }
+            if (settings.lastAlertedAuthorProfileLength == null) {
+                settings.lastAlertedAuthorProfileLength = authorProfileLength
                 changed = true
             }
             if (settings.lastAlertedGeneralAllNo == null) {
@@ -233,6 +284,13 @@ class NarouNovelPollingService(
         var changed = false
         if (settings.lastAlertedLength == null || settings.lastAlertedLength!! > snapshot.length) {
             settings.lastAlertedLength = snapshot.length
+            changed = true
+        }
+        if (
+            settings.lastAlertedAuthorProfileLength == null ||
+            settings.lastAlertedAuthorProfileLength!! > snapshot.authorProfileLength
+        ) {
+            settings.lastAlertedAuthorProfileLength = snapshot.authorProfileLength
             changed = true
         }
         if (settings.lastAlertedGeneralAllNo == null || settings.lastAlertedGeneralAllNo!! > snapshot.generalAllNo) {
@@ -255,12 +313,13 @@ class NarouNovelPollingService(
         channel.sendMessage(message).queue({ onSuccess() }, onFailure)
     }
 
-    internal open fun isTerminalChannelFailure(exception: Throwable): Boolean {
+    internal fun isTerminalChannelFailure(exception: Throwable): Boolean {
         val errorResponseException = exception as? ErrorResponseException ?: return false
         return when (errorResponseException.errorResponse) {
             ErrorResponse.MISSING_PERMISSIONS,
             ErrorResponse.MISSING_ACCESS,
             ErrorResponse.UNKNOWN_CHANNEL -> true
+
             else -> false
         }
     }
@@ -268,6 +327,7 @@ class NarouNovelPollingService(
     private fun buildAlertMessage(
         lengthTriggered: Boolean,
         lengthDelta: Long,
+        predictionTriggered: Boolean,
         chapterTriggered: Boolean,
         chapterDelta: Int,
         snapshot: NarouNovelSnapshot
@@ -283,6 +343,9 @@ class NarouNovelPollingService(
         if (lengthTriggered) {
             updates += "the novel grew by $lengthDelta characters"
         }
+        if (predictionTriggered) {
+            updates += PREDICTION_ALERT_MESSAGE
+        }
 
         return buildString {
             append("@everyone Narou update for ")
@@ -294,7 +357,10 @@ class NarouNovelPollingService(
             append(". Total characters: ")
             append(snapshot.length)
             append(". ")
-            append(NOVEL_URL)
+            append("Current chapter: ")
+            append(NOVEL_URL + snapshot.generalAllNo)
+            append("Next chapter: ")
+            append(NOVEL_URL + snapshot.generalAllNo)
         }
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -1,7 +1,9 @@
 package be.duncanc.discordmodbot.narou.novel.api
 
 import be.duncanc.discordmodbot.narou.novel.api.persistence.*
+import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.exceptions.ErrorResponseException
 import net.dv8tion.jda.api.requests.ErrorResponse
@@ -9,6 +11,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.awt.Color
 
 @Service
 class NarouNovelPollingService(
@@ -31,6 +34,8 @@ class NarouNovelPollingService(
     companion object {
         internal const val NOVEL_CODE = "n2267be"
         private const val NOVEL_URL = "https://ncode.syosetu.com/n2267be/"
+        private const val ALERT_MENTION = "@everyone"
+        private const val EMBED_TITLE = "Narou update for $NOVEL_CODE"
         private const val PREDICTION_ALERT_MESSAGE =
             "Detected an increase in the author's profile character count. This may indicate that a new chapter is coming soon"
         private val LOG = LoggerFactory.getLogger(NarouNovelPollingService::class.java)
@@ -157,7 +162,7 @@ class NarouNovelPollingService(
                 return@forEach
             }
 
-            val message = buildAlertMessage(
+            val embed = buildAlertEmbed(
                 lengthTriggered,
                 lengthDelta,
                 predictionTriggered,
@@ -176,7 +181,8 @@ class NarouNovelPollingService(
             try {
                 sendAlertMessage(
                     channel = channel,
-                    message = message,
+                    messageContent = ALERT_MENTION,
+                    embed = embed,
                     onSuccess = {
                         try {
                             if (lengthTriggered) {
@@ -306,11 +312,12 @@ class NarouNovelPollingService(
 
     internal fun sendAlertMessage(
         channel: TextChannel,
-        message: String,
+        messageContent: String,
+        embed: MessageEmbed,
         onSuccess: () -> Unit,
         onFailure: (Throwable) -> Unit
     ) {
-        channel.sendMessage(message).queue({ onSuccess() }, onFailure)
+        channel.sendMessage(messageContent).addEmbeds(embed).queue({ onSuccess() }, onFailure)
     }
 
     internal fun isTerminalChannelFailure(exception: Throwable): Boolean {
@@ -324,14 +331,14 @@ class NarouNovelPollingService(
         }
     }
 
-    private fun buildAlertMessage(
+    private fun buildAlertEmbed(
         lengthTriggered: Boolean,
         lengthDelta: Long,
         predictionTriggered: Boolean,
         chapterTriggered: Boolean,
         chapterDelta: Int,
         snapshot: NarouNovelSnapshot
-    ): String {
+    ): MessageEmbed {
         val updates = mutableListOf<String>()
         if (chapterTriggered) {
             updates += if (chapterDelta == 1) {
@@ -347,20 +354,24 @@ class NarouNovelPollingService(
             updates += PREDICTION_ALERT_MESSAGE
         }
 
-        return buildString {
-            append("@everyone Narou update for ")
-            append(NOVEL_CODE)
-            append(": ")
-            append(updates.joinToString(" and "))
-            append(". Total chapters: ")
-            append(snapshot.generalAllNo)
-            append(". Total characters: ")
-            append(snapshot.length)
-            append(". ")
-            append("Current chapter: ")
-            append(NOVEL_URL + snapshot.generalAllNo)
-            append("Next chapter: ")
-            append(NOVEL_URL + snapshot.generalAllNo)
+        val summary = truncate(updates.joinToString(" and ") + ".", MessageEmbed.DESCRIPTION_MAX_LENGTH)
+        val chapterLink = truncate(NOVEL_URL + snapshot.generalAllNo, MessageEmbed.VALUE_MAX_LENGTH)
+
+        return EmbedBuilder()
+            .setColor(Color.ORANGE)
+            .setTitle(truncate(EMBED_TITLE, MessageEmbed.TITLE_MAX_LENGTH))
+            .setDescription(summary)
+            .addField("Total chapters", snapshot.generalAllNo.toString(), true)
+            .addField("Total characters", snapshot.length.toString(), true)
+            .addField("Chapter link", chapterLink, false)
+            .build()
+    }
+
+    private fun truncate(value: String, maxLength: Int): String {
+        if (value.length <= maxLength) {
+            return value
         }
+
+        return value.take(maxLength - 3) + "..."
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -26,6 +26,7 @@ class NarouNovelPollingService(
         val generalAllNo: Int,
         val length: Long,
         val authorProfileLength: Long,
+        val hasFreshAuthorProfileLength: Boolean,
         val time: Int,
         val novelUpdatedAt: String,
         val updatedAt: String
@@ -44,14 +45,14 @@ class NarouNovelPollingService(
     @Scheduled(cron = $$"${discord-mod-bot.narou-novel-api.poll-cron:0/15 * * * * *}")
     @Transactional
     fun pollNovel() {
+        val snapshot = narouNovelSnapshotRepository.findById(NOVEL_CODE).orElse(null)
         val payload = try {
-            fetchPayload()
+            fetchPayload(snapshot)
         } catch (exception: Exception) {
             LOG.warn("Failed to poll Narou novel API", exception)
             return
         }
 
-        val snapshot = narouNovelSnapshotRepository.findById(NOVEL_CODE).orElse(null)
         if (snapshot == null) {
             narouNovelSnapshotRepository.save(
                 NarouNovelSnapshot(
@@ -65,7 +66,7 @@ class NarouNovelPollingService(
                     updatedAt = payload.updatedAt
                 )
             )
-            initializeMissingBaselines(payload.length, payload.authorProfileLength, payload.generalAllNo)
+            initializeMissingBaselines(payload.length, payload.authorProfileLength, payload.hasFreshAuthorProfileLength, payload.generalAllNo)
             return
         }
 
@@ -78,10 +79,10 @@ class NarouNovelPollingService(
         snapshot.updatedAt = payload.updatedAt
         narouNovelSnapshotRepository.save(snapshot)
 
-        processAlerts(snapshot)
+        processAlerts(snapshot, payload.hasFreshAuthorProfileLength)
     }
 
-    internal fun fetchPayload(): NarouNovelPollSnapshot {
+    internal fun fetchPayload(existingSnapshot: NarouNovelSnapshot?): NarouNovelPollSnapshot {
         val novelPayload = narouNovelApiClient.fetchNovel().firstOrNull {
             it.generalLastup != null &&
                     it.generalAllNo != null &&
@@ -90,24 +91,36 @@ class NarouNovelPollingService(
                     it.novelUpdatedAt != null &&
                     it.updatedAt != null
         } ?: throw IllegalStateException("Narou novel API response did not contain a novel payload")
-        val authorProfilePayload = narouNovelApiClient.fetchAuthorProfile().firstOrNull {
-            it.novelLength != null
-        } ?: throw IllegalStateException("Narou author profile API response did not contain a profile length payload")
+
+        val authorProfileLength = try {
+            narouNovelApiClient.fetchAuthorProfile().firstOrNull {
+                it.novelLength != null
+            }?.novelLength ?: throw IllegalStateException("Narou author profile API response did not contain a profile length payload")
+        } catch (exception: Exception) {
+            if (existingSnapshot == null) {
+                LOG.warn("Failed to poll Narou author profile API; prediction alerts will remain disabled until a profile length is fetched", exception)
+                null
+            } else {
+                LOG.warn("Failed to poll Narou author profile API; continuing with stored author profile length", exception)
+                existingSnapshot.authorProfileLength.takeIf { it > 0 }
+            }
+        }
 
         return NarouNovelPollSnapshot(
             generalLastup = novelPayload.generalLastup!!,
             generalAllNo = novelPayload.generalAllNo!!,
             length = novelPayload.length!!,
-            authorProfileLength = authorProfilePayload.novelLength!!,
+            authorProfileLength = authorProfileLength ?: 0,
+            hasFreshAuthorProfileLength = authorProfileLength != null,
             time = novelPayload.time!!,
             novelUpdatedAt = novelPayload.novelUpdatedAt!!,
             updatedAt = novelPayload.updatedAt!!
         )
     }
 
-    private fun processAlerts(snapshot: NarouNovelSnapshot) {
+    private fun processAlerts(snapshot: NarouNovelSnapshot, hasFreshAuthorProfileLength: Boolean) {
         narouNovelAlertSettingsRepository.findAll().forEach { settings ->
-            val updatedSettings = initializeOrRebaseBaselines(settings, snapshot)
+            val updatedSettings = initializeOrRebaseBaselines(settings, snapshot, hasFreshAuthorProfileLength)
             if (updatedSettings) {
                 return@forEach
             }
@@ -116,10 +129,14 @@ class NarouNovelPollingService(
             val lastAlertedAuthorProfileLength = settings.lastAlertedAuthorProfileLength ?: return@forEach
             val lastAlertedGeneralAllNo = settings.lastAlertedGeneralAllNo ?: return@forEach
             val lengthDelta = snapshot.length - lastAlertedLength
-            val predictionLengthDelta = snapshot.authorProfileLength - lastAlertedAuthorProfileLength
+            val predictionLengthDelta = if (hasFreshAuthorProfileLength) {
+                snapshot.authorProfileLength - lastAlertedAuthorProfileLength
+            } else {
+                0
+            }
             val chapterDelta = snapshot.generalAllNo - lastAlertedGeneralAllNo
             val lengthTriggered = lengthDelta >= settings.lengthThreshold
-            val predictionTriggered = predictionLengthDelta >= settings.predictionLengthThreshold
+            val predictionTriggered = hasFreshAuthorProfileLength && predictionLengthDelta >= settings.predictionLengthThreshold
             val chapterTriggered = chapterDelta > 0
             if (!lengthTriggered && !predictionTriggered && !chapterTriggered) {
                 return@forEach
@@ -188,7 +205,7 @@ class NarouNovelPollingService(
                             if (lengthTriggered) {
                                 settings.lastAlertedLength = snapshot.length
                             }
-                            if (predictionTriggered || chapterTriggered) {
+                            if (predictionTriggered || (chapterTriggered && hasFreshAuthorProfileLength)) {
                                 settings.lastAlertedAuthorProfileLength = snapshot.authorProfileLength
                             }
                             if (chapterTriggered) {
@@ -265,14 +282,19 @@ class NarouNovelPollingService(
         }
     }
 
-    private fun initializeMissingBaselines(length: Long, authorProfileLength: Long, generalAllNo: Int) {
+    private fun initializeMissingBaselines(
+        length: Long,
+        authorProfileLength: Long,
+        hasFreshAuthorProfileLength: Boolean,
+        generalAllNo: Int
+    ) {
         narouNovelAlertSettingsRepository.findAll().forEach { settings ->
             var changed = false
             if (settings.lastAlertedLength == null) {
                 settings.lastAlertedLength = length
                 changed = true
             }
-            if (settings.lastAlertedAuthorProfileLength == null) {
+            if (settings.lastAlertedAuthorProfileLength == null && hasFreshAuthorProfileLength && authorProfileLength > 0) {
                 settings.lastAlertedAuthorProfileLength = authorProfileLength
                 changed = true
             }
@@ -286,15 +308,21 @@ class NarouNovelPollingService(
         }
     }
 
-    private fun initializeOrRebaseBaselines(settings: NarouNovelAlertSettings, snapshot: NarouNovelSnapshot): Boolean {
+    private fun initializeOrRebaseBaselines(
+        settings: NarouNovelAlertSettings,
+        snapshot: NarouNovelSnapshot,
+        hasFreshAuthorProfileLength: Boolean
+    ): Boolean {
         var changed = false
         if (settings.lastAlertedLength == null || settings.lastAlertedLength!! > snapshot.length) {
             settings.lastAlertedLength = snapshot.length
             changed = true
         }
         if (
-            settings.lastAlertedAuthorProfileLength == null ||
-            settings.lastAlertedAuthorProfileLength!! > snapshot.authorProfileLength
+            hasFreshAuthorProfileLength && snapshot.authorProfileLength > 0 && (
+                settings.lastAlertedAuthorProfileLength == null ||
+                    settings.lastAlertedAuthorProfileLength!! > snapshot.authorProfileLength
+            )
         ) {
             settings.lastAlertedAuthorProfileLength = snapshot.authorProfileLength
             changed = true

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettings.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettings.kt
@@ -15,12 +15,17 @@ data class NarouNovelAlertSettings(
     var channelId: Long? = null,
     @Column(nullable = false)
     var lengthThreshold: Long = DEFAULT_LENGTH_THRESHOLD,
+    @Column(nullable = false)
+    var predictionLengthThreshold: Long = DEFAULT_PREDICTION_LENGTH_THRESHOLD,
     @Column(nullable = true)
     var lastAlertedLength: Long? = null,
+    @Column(nullable = true)
+    var lastAlertedAuthorProfileLength: Long? = null,
     @Column(nullable = true)
     var lastAlertedGeneralAllNo: Int? = null
 ) {
     companion object {
         const val DEFAULT_LENGTH_THRESHOLD = 1000L
+        const val DEFAULT_PREDICTION_LENGTH_THRESHOLD = 1000L
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelPendingAlert.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelPendingAlert.kt
@@ -8,5 +8,6 @@ data class NarouNovelPendingAlert(
     @Id
     val guildId: Long,
     val snapshotLength: Long,
+    val snapshotAuthorProfileLength: Long,
     val snapshotGeneralAllNo: Int
 )

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelSnapshot.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelSnapshot.kt
@@ -17,6 +17,8 @@ data class NarouNovelSnapshot(
     var generalAllNo: Int,
     @Column(name = "length_value", nullable = false)
     var length: Long,
+    @Column(name = "author_profile_length", nullable = false)
+    var authorProfileLength: Long,
     @Column(name = "reading_time", nullable = false)
     var time: Int,
     @Column(name = "novel_updated_at", nullable = false)

--- a/src/main/resources/db/migration/V12__extend_narou_novel_alerts.sql
+++ b/src/main/resources/db/migration/V12__extend_narou_novel_alerts.sql
@@ -1,0 +1,8 @@
+alter table narou_novel_snapshots
+    add column author_profile_length bigint not null default 0;
+
+alter table narou_novel_alert_settings
+    add column prediction_length_threshold bigint not null default 1000;
+
+alter table narou_novel_alert_settings
+    add column last_alerted_author_profile_length bigint null;

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
@@ -87,7 +87,8 @@ class NarouNovelConfigCommandTest {
         val replyCaptor = argumentCaptor<String>()
         verify(slashEvent).reply(replyCaptor.capture())
         assertEquals(true, replyCaptor.firstValue.contains("- Alert channel: Disabled"))
-        assertEquals(true, replyCaptor.firstValue.contains("- Character growth threshold: 1000"))
+        assertEquals(true, replyCaptor.firstValue.contains("- Published novel growth threshold: 1000"))
+        assertEquals(true, replyCaptor.firstValue.contains("- Author profile prediction threshold: 1000"))
     }
 
     @Test
@@ -103,6 +104,7 @@ class NarouNovelConfigCommandTest {
                     generalLastup = "2026-05-15 07:00:00",
                     generalAllNo = 778,
                     length = 9_445_269,
+                    authorProfileLength = 9_876_000,
                     time = 18_891,
                     novelUpdatedAt = "2026-05-15 07:00:36",
                     updatedAt = "2026-05-15 20:14:23"
@@ -117,6 +119,7 @@ class NarouNovelConfigCommandTest {
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(11L, settingsCaptor.firstValue.channelId)
         assertEquals(9_445_269L, settingsCaptor.firstValue.lastAlertedLength)
+        assertEquals(9_876_000L, settingsCaptor.firstValue.lastAlertedAuthorProfileLength)
         assertEquals(778, settingsCaptor.firstValue.lastAlertedGeneralAllNo)
         verify(slashEvent).reply("Narou novel alerts will be sent to <#11>.")
     }
@@ -149,6 +152,21 @@ class NarouNovelConfigCommandTest {
     }
 
     @Test
+    fun `set prediction threshold stores configured value`() {
+        stubAuthorizedSlashCommand("set-prediction-threshold")
+        command.threshold = 750L
+        whenever(narouNovelAlertSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.empty())
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(750L, settingsCaptor.firstValue.predictionLengthThreshold)
+        verify(slashEvent).reply("Narou prediction alerts now require at least 750 characters of author profile growth.")
+    }
+
+    @Test
     fun `disable removes narou novel configuration`() {
         stubAuthorizedSlashCommand("disable")
 
@@ -177,7 +195,7 @@ class NarouNovelConfigCommandTest {
         assertEquals("narounovelapi", commandData.name)
         assertEquals(setOf(InteractionContextType.GUILD), commandData.contexts)
         assertEquals(
-            listOf("show", "set-channel", "set-threshold", "disable"),
+            listOf("show", "set-channel", "set-threshold", "set-prediction-threshold", "disable"),
             commandData.subcommands.map(SubcommandData::getName)
         )
     }

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
@@ -125,6 +125,39 @@ class NarouNovelConfigCommandTest {
     }
 
     @Test
+    fun `set channel does not initialize author profile baseline from zero snapshot`() {
+        stubAuthorizedSlashCommand("set-channel")
+        whenever(textChannel.idLong).thenReturn(11L)
+        whenever(textChannel.asMention).thenReturn("<#11>")
+        whenever(narouNovelAlertSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(
+            Optional.of(
+                NarouNovelSnapshot(
+                    ncode = NarouNovelPollingService.NOVEL_CODE,
+                    generalLastup = "2026-05-15 07:00:00",
+                    generalAllNo = 778,
+                    length = 9_445_269,
+                    authorProfileLength = 0,
+                    time = 18_891,
+                    novelUpdatedAt = "2026-05-15 07:00:36",
+                    updatedAt = "2026-05-15 20:14:23"
+                )
+            )
+        )
+        command.selectedChannel = textChannel
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(11L, settingsCaptor.firstValue.channelId)
+        assertEquals(9_445_269L, settingsCaptor.firstValue.lastAlertedLength)
+        assertEquals(null, settingsCaptor.firstValue.lastAlertedAuthorProfileLength)
+        assertEquals(778, settingsCaptor.firstValue.lastAlertedGeneralAllNo)
+        verify(slashEvent).reply("Narou novel alerts will be sent to <#11>.")
+    }
+
+    @Test
     fun `set threshold rejects small values`() {
         stubSlashCommandContext()
         whenever(member.hasPermission(Permission.MANAGE_CHANNEL)).thenReturn(true)

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -57,6 +57,7 @@ class NarouNovelPollingServiceTest {
             narouNovelPendingAlertRepository,
             jda
         )
+        whenever(narouNovelApiClient.fetchAuthorProfile()).thenReturn(listOf(profilePayload(9_876_000)))
     }
 
     @Test
@@ -75,6 +76,7 @@ class NarouNovelPollingServiceTest {
         val snapshotCaptor = argumentCaptor<NarouNovelSnapshot>()
         verify(narouNovelSnapshotRepository).save(snapshotCaptor.capture())
         assertEquals(9_445_269L, snapshotCaptor.firstValue.length)
+        assertEquals(9_876_000L, snapshotCaptor.firstValue.authorProfileLength)
         assertEquals(778, snapshotCaptor.firstValue.generalAllNo)
     }
 
@@ -86,7 +88,9 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_500, generalAllNo = 779)))
@@ -96,10 +100,11 @@ class NarouNovelPollingServiceTest {
 
         service.pollNovel()
 
-        assertEquals(listOf("@everyone Narou update for n2267be: 1 new chapter was published. Total chapters: 779. Total characters: 9445500. https://ncode.syosetu.com/n2267be/"), service.sentMessages)
+        assertEquals(listOf("@everyone Narou update for n2267be: 1 new chapter was published. Total chapters: 779. Total characters: 9445500. https://ncode.syosetu.com/n2267be/779"), service.sentMessages)
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_445_269L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(9_876_000L, settingsCaptor.lastValue.lastAlertedAuthorProfileLength)
         assertEquals(779, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
@@ -112,7 +117,9 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 778)))
@@ -122,10 +129,11 @@ class NarouNovelPollingServiceTest {
 
         service.pollNovel()
 
-        assertEquals(listOf("@everyone Narou update for n2267be: the novel grew by 1231 characters. Total chapters: 778. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"), service.sentMessages)
+        assertEquals(listOf("@everyone Narou update for n2267be: the novel grew by 1231 characters. Total chapters: 778. Total characters: 9446500. https://ncode.syosetu.com/n2267be/778"), service.sentMessages)
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(9_876_000L, settingsCaptor.lastValue.lastAlertedAuthorProfileLength)
         assertEquals(778, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
@@ -138,7 +146,9 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
@@ -151,14 +161,50 @@ class NarouNovelPollingServiceTest {
         assertEquals(
             listOf(
                 "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
+                .replace("https://ncode.syosetu.com/n2267be/", "https://ncode.syosetu.com/n2267be/780")
             ),
             service.sentMessages
         )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(9_876_000L, settingsCaptor.lastValue.lastAlertedAuthorProfileLength)
         assertEquals(780, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
+    }
+
+    @Test
+    fun `prediction alert triggers from author profile growth`() {
+        stubPendingAlertRepository()
+        val snapshot = snapshot(length = 9_445_500, generalAllNo = 779, authorProfileLength = 9_877_250)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_500L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
+            lastAlertedGeneralAllNo = 779
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_500, generalAllNo = 779)))
+        whenever(narouNovelApiClient.fetchAuthorProfile()).thenReturn(listOf(profilePayload(9_877_250)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot(length = 9_445_500, generalAllNo = 779)))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        service.pollNovel()
+
+        assertEquals(
+            listOf(
+                "@everyone Narou update for n2267be: Detected an increase in the author's profile character count. This may indicate that a new chapter is coming soon. Total chapters: 779. Total characters: 9445500. https://ncode.syosetu.com/n2267be/779"
+            ),
+            service.sentMessages
+        )
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(9_445_500L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(9_877_250L, settingsCaptor.lastValue.lastAlertedAuthorProfileLength)
+        assertEquals(779, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
     }
 
     @Test
@@ -177,7 +223,9 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
@@ -191,12 +239,14 @@ class NarouNovelPollingServiceTest {
         assertEquals(
             listOf(
                 "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
+                .replace("https://ncode.syosetu.com/n2267be/", "https://ncode.syosetu.com/n2267be/780")
             ),
             service.sentMessages
         )
-        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 780), pendingAlerts[1L])
+        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 9_876_000L, 780), pendingAlerts[1L])
         verify(narouNovelAlertSettingsRepository, never()).save(settings)
         assertEquals(9_445_269L, settings.lastAlertedLength)
+        assertEquals(9_876_000L, settings.lastAlertedAuthorProfileLength)
         assertEquals(778, settings.lastAlertedGeneralAllNo)
     }
 
@@ -207,10 +257,12 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
-        whenever(narouNovelPendingAlertRepository.findById(1L)).thenReturn(Optional.of(NarouNovelPendingAlert(1L, 9_446_500L, 780)))
+        whenever(narouNovelPendingAlertRepository.findById(1L)).thenReturn(Optional.of(NarouNovelPendingAlert(1L, 9_446_500L, 9_876_000L, 780)))
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
         whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
@@ -239,7 +291,9 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
@@ -270,7 +324,9 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
@@ -283,7 +339,7 @@ class NarouNovelPollingServiceTest {
         service.pollNovel()
 
         assertEquals(1, service.sentMessages.size)
-        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 780), pendingAlerts[1L])
+        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 9_876_000L, 780), pendingAlerts[1L])
     }
 
     @Test
@@ -302,7 +358,9 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
@@ -340,7 +398,9 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
@@ -363,7 +423,9 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
             lastAlertedGeneralAllNo = 778
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
@@ -382,7 +444,13 @@ class NarouNovelPollingServiceTest {
     @Test
     fun `missing baselines are initialized without alerting`() {
         val snapshot = snapshot(length = 9_445_500, generalAllNo = 779)
-        val settings = NarouNovelAlertSettings(guildId = 1L, channelId = 11L, lastAlertedLength = null, lastAlertedGeneralAllNo = null)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lastAlertedLength = null,
+            lastAlertedAuthorProfileLength = null,
+            lastAlertedGeneralAllNo = null
+        )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_500, generalAllNo = 779)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
         whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
@@ -393,7 +461,22 @@ class NarouNovelPollingServiceTest {
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_445_500L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(9_876_000L, settingsCaptor.lastValue.lastAlertedAuthorProfileLength)
         assertEquals(779, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+    }
+
+    @Test
+    fun `poll ignores incomplete author profile entries`() {
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_269, generalAllNo = 778)))
+        whenever(narouNovelApiClient.fetchAuthorProfile()).thenReturn(listOf(NarouAuthorProfileApiResponseEntry(), profilePayload(9_876_000)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.empty())
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(emptyList())
+
+        service.pollNovel()
+
+        val snapshotCaptor = argumentCaptor<NarouNovelSnapshot>()
+        verify(narouNovelSnapshotRepository).save(snapshotCaptor.capture())
+        assertEquals(9_876_000L, snapshotCaptor.firstValue.authorProfileLength)
     }
 
     private fun payload(length: Long, generalAllNo: Int): NarouNovelApiResponseEntry {
@@ -407,12 +490,17 @@ class NarouNovelPollingServiceTest {
         )
     }
 
-    private fun snapshot(length: Long, generalAllNo: Int): NarouNovelSnapshot {
+    private fun profilePayload(novelLength: Long): NarouAuthorProfileApiResponseEntry {
+        return NarouAuthorProfileApiResponseEntry(novelLength = novelLength)
+    }
+
+    private fun snapshot(length: Long, generalAllNo: Int, authorProfileLength: Long = 9_876_000): NarouNovelSnapshot {
         return NarouNovelSnapshot(
             ncode = NarouNovelPollingService.NOVEL_CODE,
             generalLastup = "2026-05-15 07:00:00",
             generalAllNo = generalAllNo,
             length = length,
+            authorProfileLength = authorProfileLength,
             time = 18_891,
             novelUpdatedAt = "2026-05-15 07:00:36",
             updatedAt = "2026-05-15 20:14:23"

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -7,6 +7,7 @@ import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelPendingAle
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshot
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
 import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -100,7 +101,13 @@ class NarouNovelPollingServiceTest {
 
         service.pollNovel()
 
-        assertEquals(listOf("@everyone Narou update for n2267be: 1 new chapter was published. Total chapters: 779. Total characters: 9445500. https://ncode.syosetu.com/n2267be/779"), service.sentMessages)
+        assertAlert(
+            service = service,
+            description = "1 new chapter was published.",
+            totalChapters = 779,
+            totalCharacters = 9_445_500L,
+            chapterLink = "https://ncode.syosetu.com/n2267be/779"
+        )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_445_269L, settingsCaptor.lastValue.lastAlertedLength)
@@ -129,7 +136,13 @@ class NarouNovelPollingServiceTest {
 
         service.pollNovel()
 
-        assertEquals(listOf("@everyone Narou update for n2267be: the novel grew by 1231 characters. Total chapters: 778. Total characters: 9446500. https://ncode.syosetu.com/n2267be/778"), service.sentMessages)
+        assertAlert(
+            service = service,
+            description = "the novel grew by 1231 characters.",
+            totalChapters = 778,
+            totalCharacters = 9_446_500L,
+            chapterLink = "https://ncode.syosetu.com/n2267be/778"
+        )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_446_500L, settingsCaptor.lastValue.lastAlertedLength)
@@ -158,12 +171,12 @@ class NarouNovelPollingServiceTest {
 
         service.pollNovel()
 
-        assertEquals(
-            listOf(
-                "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
-                .replace("https://ncode.syosetu.com/n2267be/", "https://ncode.syosetu.com/n2267be/780")
-            ),
-            service.sentMessages
+        assertAlert(
+            service = service,
+            description = "2 new chapters were published and the novel grew by 1231 characters.",
+            totalChapters = 780,
+            totalCharacters = 9_446_500L,
+            chapterLink = "https://ncode.syosetu.com/n2267be/780"
         )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
@@ -194,11 +207,12 @@ class NarouNovelPollingServiceTest {
 
         service.pollNovel()
 
-        assertEquals(
-            listOf(
-                "@everyone Narou update for n2267be: Detected an increase in the author's profile character count. This may indicate that a new chapter is coming soon. Total chapters: 779. Total characters: 9445500. https://ncode.syosetu.com/n2267be/779"
-            ),
-            service.sentMessages
+        assertAlert(
+            service = service,
+            description = "Detected an increase in the author's profile character count. This may indicate that a new chapter is coming soon.",
+            totalChapters = 779,
+            totalCharacters = 9_445_500L,
+            chapterLink = "https://ncode.syosetu.com/n2267be/779"
         )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
@@ -236,12 +250,12 @@ class NarouNovelPollingServiceTest {
         service.pollNovel()
         service.pollNovel()
 
-        assertEquals(
-            listOf(
-                "@everyone Narou update for n2267be: 2 new chapters were published and the novel grew by 1231 characters. Total chapters: 780. Total characters: 9446500. https://ncode.syosetu.com/n2267be/"
-                .replace("https://ncode.syosetu.com/n2267be/", "https://ncode.syosetu.com/n2267be/780")
-            ),
-            service.sentMessages
+        assertAlert(
+            service = service,
+            description = "2 new chapters were published and the novel grew by 1231 characters.",
+            totalChapters = 780,
+            totalCharacters = 9_446_500L,
+            chapterLink = "https://ncode.syosetu.com/n2267be/780"
         )
         assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 9_876_000L, 780), pendingAlerts[1L])
         verify(narouNovelAlertSettingsRepository, never()).save(settings)
@@ -269,7 +283,8 @@ class NarouNovelPollingServiceTest {
 
         service.pollNovel()
 
-        assertEquals(emptyList<String>(), service.sentMessages)
+        assertEquals(emptyList<String>(), service.sentMessageContents)
+        assertEquals(emptyList<MessageEmbed>(), service.sentEmbeds)
         verify(jda, never()).getTextChannelById(any<Long>())
         verify(narouNovelPendingAlertRepository).findById(1L)
     }
@@ -304,7 +319,8 @@ class NarouNovelPollingServiceTest {
         service.pollNovel()
         service.pollNovel()
 
-        assertEquals(2, service.sentMessages.size)
+        assertEquals(2, service.sentMessageContents.size)
+        assertEquals(2, service.sentEmbeds.size)
         verify(narouNovelAlertSettingsRepository, never()).save(settings)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
@@ -338,7 +354,8 @@ class NarouNovelPollingServiceTest {
         service.pollNovel()
         service.pollNovel()
 
-        assertEquals(1, service.sentMessages.size)
+        assertEquals(1, service.sentMessageContents.size)
+        assertEquals(1, service.sentEmbeds.size)
         assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 9_876_000L, 780), pendingAlerts[1L])
     }
 
@@ -377,7 +394,8 @@ class NarouNovelPollingServiceTest {
 
         assertEquals("boom", firstFailure.message)
         assertEquals("boom", secondFailure.message)
-        assertEquals(2, service.sentMessages.size)
+        assertEquals(2, service.sentMessageContents.size)
+        assertEquals(2, service.sentEmbeds.size)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
 
@@ -411,7 +429,8 @@ class NarouNovelPollingServiceTest {
         service.pollNovel()
         service.pollNovel()
 
-        assertEquals(1, service.sentMessages.size)
+        assertEquals(1, service.sentMessageContents.size)
+        assertEquals(1, service.sentEmbeds.size)
         assertNull(settings.channelId)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
@@ -436,7 +455,8 @@ class NarouNovelPollingServiceTest {
         service.pollNovel()
         service.pollNovel()
 
-        assertEquals(emptyList<String>(), service.sentMessages)
+        assertEquals(emptyList<String>(), service.sentMessageContents)
+        assertEquals(emptyList<MessageEmbed>(), service.sentEmbeds)
         assertNull(settings.channelId)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
     }
@@ -494,6 +514,27 @@ class NarouNovelPollingServiceTest {
         return NarouAuthorProfileApiResponseEntry(novelLength = novelLength)
     }
 
+    private fun assertAlert(
+        service: TestNarouNovelPollingService,
+        description: String,
+        totalChapters: Int,
+        totalCharacters: Long,
+        chapterLink: String,
+        index: Int = 0
+    ) {
+        assertEquals("@everyone", service.sentMessageContents[index])
+        val embed = service.sentEmbeds[index]
+        assertEquals("Narou update for n2267be", embed.title)
+        assertEquals(description, embed.description)
+        assertEquals(totalChapters.toString(), embed.fieldValue("Total chapters"))
+        assertEquals(totalCharacters.toString(), embed.fieldValue("Total characters"))
+        assertEquals(chapterLink, embed.fieldValue("Chapter link"))
+    }
+
+    private fun MessageEmbed.fieldValue(name: String): String? {
+        return fields.firstOrNull { it.name == name }?.value
+    }
+
     private fun snapshot(length: Long, generalAllNo: Int, authorProfileLength: Long = 9_876_000): NarouNovelSnapshot {
         return NarouNovelSnapshot(
             ncode = NarouNovelPollingService.NOVEL_CODE,
@@ -541,7 +582,8 @@ class NarouNovelPollingServiceTest {
         narouNovelPendingAlertRepository,
         jda
     ) {
-        val sentMessages = mutableListOf<String>()
+        val sentMessageContents = mutableListOf<String>()
+        val sentEmbeds = mutableListOf<MessageEmbed>()
 
         override fun isTerminalChannelFailure(exception: Throwable): Boolean {
             return terminalFailurePredicate(exception)
@@ -549,11 +591,13 @@ class NarouNovelPollingServiceTest {
 
         override fun sendAlertMessage(
             channel: TextChannel,
-            message: String,
+            messageContent: String,
+            embed: MessageEmbed,
             onSuccess: () -> Unit,
             onFailure: (Throwable) -> Unit
         ) {
-            sentMessages += message
+            sentMessageContents += messageContent
+            sentEmbeds += embed
             onSend?.invoke()
             throwOnSend?.let { throw it }
             failWith?.let {

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -222,6 +222,66 @@ class NarouNovelPollingServiceTest {
     }
 
     @Test
+    fun `chapter alert still sends when author profile fetch fails`() {
+        stubPendingAlertRepository()
+        val snapshot = snapshot(length = 9_445_500, generalAllNo = 779, authorProfileLength = 9_876_000)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_500, generalAllNo = 779)))
+        whenever(narouNovelApiClient.fetchAuthorProfile()).thenThrow(IllegalStateException("profile down"))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        service.pollNovel()
+
+        assertAlert(
+            service = service,
+            description = "1 new chapter was published.",
+            totalChapters = 779,
+            totalCharacters = 9_445_500L,
+            chapterLink = "https://ncode.syosetu.com/n2267be/779"
+        )
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(9_445_269L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(9_876_000L, settingsCaptor.lastValue.lastAlertedAuthorProfileLength)
+        assertEquals(779, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+    }
+
+    @Test
+    fun `missing baselines stay unset for zero author profile snapshot when profile fetch fails`() {
+        val snapshot = snapshot(length = 9_445_500, generalAllNo = 779, authorProfileLength = 0)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lastAlertedLength = null,
+            lastAlertedAuthorProfileLength = null,
+            lastAlertedGeneralAllNo = null
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_500, generalAllNo = 779)))
+        whenever(narouNovelApiClient.fetchAuthorProfile()).thenThrow(IllegalStateException("profile down"))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+
+        service.pollNovel()
+
+        verify(jda, never()).getTextChannelById(11L)
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(9_445_500L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(null, settingsCaptor.lastValue.lastAlertedAuthorProfileLength)
+        assertEquals(779, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+    }
+
+    @Test
     fun `poll skips duplicate guild alert while Discord send callback is still pending`() {
         stubPendingAlertRepository(includeDeleteById = false)
         service = TestNarouNovelPollingService(


### PR DESCRIPTION
## Summary
- keep chapter and published-length alerts working when the author profile poll fails
- only evaluate prediction alerts from fresh author profile data
- ignore zero author profile snapshots when initializing alert baselines

## Testing
- .\gradlew.bat test --tests "be.duncanc.discordmodbot.narou.novel.api.NarouNovelPollingServiceTest" --tests "be.duncanc.discordmodbot.narou.novel.api.NarouNovelConfigCommandTest"