### PR TITLE
feat(voting): use public replies for vote messages

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/voting/VoteCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/voting/VoteCommand.kt
@@ -124,7 +124,12 @@ class VoteCommand(
         onSuccess: (Message) -> Unit,
         onFailure: (Throwable) -> Unit
     ) {
-        event.channel.sendMessage(content).queue(onSuccess, onFailure)
+        event.deferReply(false).queue(
+            { hook ->
+                hook.editOriginal(content).queue(onSuccess, onFailure)
+            },
+            onFailure
+        )
     }
 
     internal fun resolveYesNoReactions(guildId: Long, event: SlashCommandInteractionEvent): List<Emoji> {
@@ -148,29 +153,25 @@ class VoteCommand(
     }
 
     private fun createVote(event: SlashCommandInteractionEvent, content: String, reactions: List<Emoji>) {
-        event.deferReply(true).queue { hook ->
-            createVoteMessage(
-                event = event,
-                content = content,
-                onSuccess = { message ->
-                    addReactions(
-                        message = message,
-                        reactions = reactions,
-                        onSuccess = {
-                            hook.sendMessage("Vote created in ${event.channel.asMention}.").setEphemeral(true).queue()
-                        },
-                        onFailure = {
-                            hook.sendMessage("The vote message was posted, but I could not add all reactions.")
-                                .setEphemeral(true)
-                                .queue()
-                        }
-                    )
-                },
-                onFailure = {
-                    hook.sendMessage("I could not post the vote message in this channel.").setEphemeral(true).queue()
-                }
-            )
-        }
+        createVoteMessage(
+            event = event,
+            content = content,
+            onSuccess = { message ->
+                addReactions(
+                    message = message,
+                    reactions = reactions,
+                    onSuccess = {},
+                    onFailure = {
+                        event.hook.sendMessage("The vote message was posted, but I could not add all reactions.")
+                            .setEphemeral(true)
+                            .queue()
+                    }
+                )
+            },
+            onFailure = {
+                event.reply("I could not post the vote message in this channel.").setEphemeral(true).queue()
+            }
+        )
     }
 
     private fun addReactionSequentially(

--- a/src/test/kotlin/be/duncanc/discordmodbot/voting/VoteCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/voting/VoteCommandTest.kt
@@ -1,17 +1,15 @@
 package be.duncanc.discordmodbot.voting
 
 import be.duncanc.discordmodbot.voting.persistence.VotingEmotesRepository
-import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
-import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion
 import net.dv8tion.jda.api.entities.emoji.Emoji
-import net.dv8tion.jda.api.entities.emoji.RichCustomEmoji
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -23,6 +21,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -44,25 +43,16 @@ class VoteCommandTest {
     private lateinit var member: Member
 
     @Mock
-    private lateinit var channel: MessageChannelUnion
-
-    @Mock
     private lateinit var replyAction: ReplyCallbackAction
 
     @Mock
     private lateinit var interactionHook: InteractionHook
 
     @Mock
+    private lateinit var editAction: WebhookMessageEditAction<Message>
+
+    @Mock
     private lateinit var followupAction: WebhookMessageCreateAction<Message>
-
-    @Mock
-    private lateinit var jda: JDA
-
-    @Mock
-    private lateinit var yesEmoji: RichCustomEmoji
-
-    @Mock
-    private lateinit var noEmoji: RichCustomEmoji
 
     private lateinit var command: TestVoteCommand
 
@@ -85,7 +75,6 @@ class VoteCommandTest {
         stubSlashCommandContext("yesno")
         stubGuildId()
         stubVoteMessageContext()
-        stubDeferredReply()
         command.prompt = "Should we do this?"
         whenever(votingEmotesRepository.findById(1L)).thenReturn(Optional.empty())
 
@@ -93,7 +82,6 @@ class VoteCommandTest {
 
         assertEquals("Vote started by <@99>\n\nShould we do this?", command.createdContent)
         assertEquals(listOf("✅", "❎"), command.capturedReactions)
-        verify(interactionHook).sendMessage("Vote created in <#10>.")
     }
 
     @Test
@@ -101,7 +89,6 @@ class VoteCommandTest {
         stubSlashCommandContext("yesno")
         stubGuildId()
         stubVoteMessageContext()
-        stubDeferredReply()
         command.prompt = "Use custom emoji?"
         command.yesNoReactionsOverride = listOf(Emoji.fromFormatted("<:yes:100>"), Emoji.fromFormatted("<:no:101>"))
 
@@ -126,7 +113,6 @@ class VoteCommandTest {
     fun `numeric vote preserves eleven option sequence`() {
         stubSlashCommandContext("numeric")
         stubVoteMessageContext()
-        stubDeferredReply()
         command.prompt = "Pick a number"
         command.count = 11
 
@@ -134,6 +120,72 @@ class VoteCommandTest {
 
         assertTrue(command.createdContent!!.contains("Options: 1-11"))
         assertEquals(listOf("1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣", "7⃣", "8⃣", "9⃣", "🔟", "0⃣"), command.capturedReactions)
+    }
+
+    @Test
+    fun `reaction failure sends ephemeral followup`() {
+        stubSlashCommandContext("yesno")
+        stubGuildId()
+        stubVoteMessageContext()
+        stubFollowupReply()
+        command.prompt = "Should we do this?"
+        command.reactionFailure = IllegalStateException("boom")
+        whenever(slashEvent.hook).thenReturn(interactionHook)
+        whenever(votingEmotesRepository.findById(1L)).thenReturn(Optional.empty())
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(interactionHook).sendMessage("The vote message was posted, but I could not add all reactions.")
+        verify(followupAction).setEphemeral(true)
+    }
+
+    @Test
+    fun `vote message failure falls back to ephemeral reply`() {
+        stubSlashCommandContext("yesno")
+        stubGuildId()
+        stubVoteMessageContext()
+        stubReply()
+        command.prompt = "Should we do this?"
+        command.voteMessageFailure = IllegalStateException("boom")
+        whenever(votingEmotesRepository.findById(1L)).thenReturn(Optional.empty())
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).reply("I could not post the vote message in this channel.")
+        verify(replyAction).setEphemeral(true)
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `create vote message uses public deferred reply`() {
+        val realCommand = VoteCommand(votingEmotesRepository)
+        val message = mock<Message>()
+
+        whenever(slashEvent.deferReply(false)).thenReturn(replyAction)
+        whenever(interactionHook.editOriginal("Vote content")).thenReturn(editAction)
+        doAnswer {
+            val success = it.arguments[0] as Consumer<InteractionHook>
+            success.accept(interactionHook)
+            null
+        }.whenever(replyAction).queue(any<Consumer<InteractionHook>>(), any())
+        doAnswer {
+            val success = it.arguments[0] as Consumer<Message>
+            success.accept(message)
+            null
+        }.whenever(editAction).queue(any<Consumer<Message>>(), any())
+
+        var capturedMessage: Message? = null
+
+        realCommand.createVoteMessage(
+            event = slashEvent,
+            content = "Vote content",
+            onSuccess = { capturedMessage = it },
+            onFailure = { throw AssertionError("Unexpected failure", it) }
+        )
+
+        verify(slashEvent).deferReply(false)
+        verify(interactionHook).editOriginal("Vote content")
+        assertEquals(message, capturedMessage)
     }
 
     @Test
@@ -157,9 +209,7 @@ class VoteCommandTest {
     }
 
     private fun stubVoteMessageContext() {
-        whenever(slashEvent.channel).thenReturn(channel)
         whenever(member.asMention).thenReturn("<@99>")
-        whenever(channel.asMention).thenReturn("<#10>")
     }
 
     private fun stubReply() {
@@ -167,16 +217,9 @@ class VoteCommandTest {
         whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun stubDeferredReply() {
-        whenever(slashEvent.deferReply(true)).thenReturn(replyAction)
+    private fun stubFollowupReply() {
         whenever(interactionHook.sendMessage(any<String>())).thenReturn(followupAction)
         whenever(followupAction.setEphemeral(true)).thenReturn(followupAction)
-        doAnswer {
-            val consumer = it.arguments[0] as Consumer<InteractionHook>
-            consumer.accept(interactionHook)
-            null
-        }.whenever(replyAction).queue(any<Consumer<InteractionHook>>())
     }
 
     private class TestVoteCommand(
@@ -187,6 +230,8 @@ class VoteCommandTest {
         var createdContent: String? = null
         var capturedReactions: List<String> = emptyList()
         var yesNoReactionsOverride: List<Emoji>? = null
+        var voteMessageFailure: Throwable? = null
+        var reactionFailure: Throwable? = null
 
         override fun getPrompt(event: SlashCommandInteractionEvent): String? {
             return prompt
@@ -207,7 +252,7 @@ class VoteCommandTest {
             onFailure: (Throwable) -> Unit
         ) {
             createdContent = content
-            onSuccess(org.mockito.kotlin.mock())
+            voteMessageFailure?.let(onFailure) ?: onSuccess(mock())
         }
 
         override fun addReactions(
@@ -217,7 +262,7 @@ class VoteCommandTest {
             onFailure: (Throwable) -> Unit
         ) {
             capturedReactions = reactions.map { it.formatted }
-            onSuccess()
+            reactionFailure?.let(onFailure) ?: onSuccess()
         }
     }
 }


### PR DESCRIPTION
## Summary
- use the interaction reply itself as the public vote message
- add reactions to that reply instead of creating a separate channel message
- update vote command tests for the new reply and failure flows

## Testing
- gradlew.bat test --tests be.duncanc.discordmodbot.voting.VoteCommandTest