### PR TITLE
feat(narouNovelApi): add configurable alert ping role

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
@@ -7,6 +7,7 @@ import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelPendingAle
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.channel.ChannelType
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
@@ -31,9 +32,11 @@ class NarouNovelConfigCommand(
         private const val COMMAND = "narounovelapi"
         private const val DESCRIPTION = "Configure Narou novel update alerts for this server."
         private const val OPTION_CHANNEL = "channel"
+        private const val OPTION_ROLE = "role"
         private const val OPTION_THRESHOLD = "threshold"
         private const val SUBCOMMAND_SHOW = "show"
         private const val SUBCOMMAND_SET_CHANNEL = "set-channel"
+        private const val SUBCOMMAND_SET_PING_ROLE = "set-ping-role"
         private const val SUBCOMMAND_SET_THRESHOLD = "set-threshold"
         private const val SUBCOMMAND_SET_PREDICTION_THRESHOLD = "set-prediction-threshold"
         private const val SUBCOMMAND_DISABLE = "disable"
@@ -72,6 +75,22 @@ class NarouNovelConfigCommand(
                 initializeBaselines(settings)
                 narouNovelAlertSettingsRepository.save(settings)
                 event.reply("Narou novel alerts will be sent to ${channel.asMention}.").setEphemeral(true).queue()
+            }
+
+            SUBCOMMAND_SET_PING_ROLE -> {
+                val role = getOptionalRole(event)
+                val settings = narouNovelAlertSettingsRepository.findById(guild.idLong).orElseGet {
+                    NarouNovelAlertSettings(guildId = guild.idLong)
+                }
+                settings.pingRoleId = role?.idLong
+                initializeBaselines(settings)
+                narouNovelAlertSettingsRepository.save(settings)
+                val reply = if (role == null) {
+                    "Narou novel alerts will now ping @everyone."
+                } else {
+                    "Narou novel alerts will now ping ${role.asMention}."
+                }
+                event.reply(reply).setEphemeral(true).queue()
             }
 
             SUBCOMMAND_SET_THRESHOLD -> {
@@ -126,6 +145,8 @@ class NarouNovelConfigCommand(
                     SubcommandData(SUBCOMMAND_SHOW, "Show the current Narou novel alert settings"),
                     SubcommandData(SUBCOMMAND_SET_CHANNEL, "Set the channel that receives Narou novel alerts")
                         .addOptions(textChannelOption("The channel used for Narou novel alerts")),
+                    SubcommandData(SUBCOMMAND_SET_PING_ROLE, "Set which role Narou novel alerts ping")
+                        .addOptions(roleOption("Role to ping for Narou novel alerts (omit to use @everyone)", false)),
                     SubcommandData(SUBCOMMAND_SET_THRESHOLD, "Set the character growth threshold for alerts")
                         .addOptions(thresholdOption("Minimum published novel growth required before an alert is sent")),
                     SubcommandData(
@@ -148,6 +169,10 @@ class NarouNovelConfigCommand(
         }
 
         return channel
+    }
+
+    internal fun getOptionalRole(event: SlashCommandInteractionEvent): Role? {
+        return event.getOption(OPTION_ROLE)?.asRole
     }
 
     internal fun getRequiredThreshold(event: SlashCommandInteractionEvent): Long? {
@@ -188,6 +213,7 @@ class NarouNovelConfigCommand(
             appendLine("Narou novel alert settings for ${guild.name}")
             appendLine()
             appendLine("- Alert channel: ${formatChannel(guild, settings?.channelId)}")
+            appendLine("- Ping target: ${formatPingTarget(guild, settings?.pingRoleId)}")
             appendLine("- Published novel growth threshold: ${settings?.lengthThreshold ?: NarouNovelAlertSettings.DEFAULT_LENGTH_THRESHOLD}")
             appendLine(
                 "- Author profile prediction threshold: " +
@@ -206,9 +232,21 @@ class NarouNovelConfigCommand(
         return guild.getTextChannelById(channelId)?.asMention ?: "Channel not found (ID: $channelId)"
     }
 
+    private fun formatPingTarget(guild: Guild, pingRoleId: Long?): String {
+        if (pingRoleId == null) {
+            return "@everyone"
+        }
+
+        return guild.getRoleById(pingRoleId)?.asMention ?: "Missing role (ID: $pingRoleId)"
+    }
+
     private fun textChannelOption(description: String): OptionData {
         return OptionData(OptionType.CHANNEL, OPTION_CHANNEL, description, true)
             .setChannelTypes(ChannelType.TEXT)
+    }
+
+    private fun roleOption(description: String, required: Boolean): OptionData {
+        return OptionData(OptionType.ROLE, OPTION_ROLE, description, required)
     }
 
     private fun thresholdOption(description: String): OptionData {

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -4,6 +4,7 @@ import be.duncanc.discordmodbot.narou.novel.api.persistence.*
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.exceptions.ErrorResponseException
 import net.dv8tion.jda.api.requests.ErrorResponse
@@ -35,7 +36,7 @@ class NarouNovelPollingService(
     companion object {
         internal const val NOVEL_CODE = "n2267be"
         private const val NOVEL_URL = "https://ncode.syosetu.com/n2267be/"
-        private const val ALERT_MENTION = "@everyone"
+        private const val DEFAULT_ALERT_MENTION = "@everyone"
         private const val EMBED_TITLE = "Narou update for $NOVEL_CODE"
         private const val PREDICTION_ALERT_MESSAGE =
             "Detected an increase in the author's profile character count. This may indicate that a new chapter is coming soon"
@@ -187,6 +188,7 @@ class NarouNovelPollingService(
                 chapterDelta,
                 snapshot
             )
+            val messageContent = resolveAlertMention(settings)
             narouNovelPendingAlertRepository.save(
                 NarouNovelPendingAlert(
                     guildId = settings.guildId,
@@ -198,7 +200,7 @@ class NarouNovelPollingService(
             try {
                 sendAlertMessage(
                     channel = channel,
-                    messageContent = ALERT_MENTION,
+                    messageContent = messageContent,
                     embed = embed,
                     onSuccess = {
                         try {
@@ -245,6 +247,36 @@ class NarouNovelPollingService(
                 narouNovelPendingAlertRepository.deleteById(settings.guildId)
                 throw exception
             }
+        }
+    }
+
+    private fun resolveAlertMention(settings: NarouNovelAlertSettings): String {
+        val pingRoleId = settings.pingRoleId ?: return DEFAULT_ALERT_MENTION
+        val role = jda.getRoleById(pingRoleId)
+        if (role != null) {
+            return role.asMention
+        }
+
+        clearMissingPingRole(settings, pingRoleId)
+        return ""
+    }
+
+    private fun clearMissingPingRole(settings: NarouNovelAlertSettings, pingRoleId: Long) {
+        try {
+            settings.pingRoleId = null
+            narouNovelAlertSettingsRepository.save(settings)
+            LOG.warn(
+                "Cleared missing Narou novel ping role {} for guild {}",
+                pingRoleId,
+                settings.guildId
+            )
+        } catch (exception: Exception) {
+            LOG.warn(
+                "Failed to clear missing Narou novel ping role {} for guild {}",
+                pingRoleId,
+                settings.guildId,
+                exception
+            )
         }
     }
 
@@ -345,7 +377,12 @@ class NarouNovelPollingService(
         onSuccess: () -> Unit,
         onFailure: (Throwable) -> Unit
     ) {
-        channel.sendMessage(messageContent).addEmbeds(embed).queue({ onSuccess() }, onFailure)
+        val action = if (messageContent.isBlank()) {
+            channel.sendMessageEmbeds(embed)
+        } else {
+            channel.sendMessage(messageContent).addEmbeds(embed)
+        }
+        action.queue({ onSuccess() }, onFailure)
     }
 
     internal fun isTerminalChannelFailure(exception: Throwable): Boolean {

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettings.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettings.kt
@@ -13,6 +13,8 @@ data class NarouNovelAlertSettings(
     val guildId: Long,
     @Column(nullable = true)
     var channelId: Long? = null,
+    @Column(nullable = true)
+    var pingRoleId: Long? = null,
     @Column(nullable = false)
     var lengthThreshold: Long = DEFAULT_LENGTH_THRESHOLD,
     @Column(nullable = false)

--- a/src/main/resources/db/migration/V13__add_narou_ping_role.sql
+++ b/src/main/resources/db/migration/V13__add_narou_ping_role.sql
@@ -1,0 +1,2 @@
+alter table narou_novel_alert_settings
+    add column ping_role_id bigint null;

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
@@ -8,6 +8,7 @@ import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRe
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
@@ -50,6 +51,9 @@ class NarouNovelConfigCommandTest {
     private lateinit var textChannel: TextChannel
 
     @Mock
+    private lateinit var role: Role
+
+    @Mock
     private lateinit var replyAction: ReplyCallbackAction
 
     @Mock
@@ -87,8 +91,42 @@ class NarouNovelConfigCommandTest {
         val replyCaptor = argumentCaptor<String>()
         verify(slashEvent).reply(replyCaptor.capture())
         assertEquals(true, replyCaptor.firstValue.contains("- Alert channel: Disabled"))
+        assertEquals(true, replyCaptor.firstValue.contains("- Ping target: @everyone"))
         assertEquals(true, replyCaptor.firstValue.contains("- Published novel growth threshold: 1000"))
         assertEquals(true, replyCaptor.firstValue.contains("- Author profile prediction threshold: 1000"))
+    }
+
+    @Test
+    fun `show displays configured ping role`() {
+        stubAuthorizedSlashCommand("show")
+        whenever(guild.name).thenReturn("Test Guild")
+        whenever(guild.getRoleById(15L)).thenReturn(role)
+        whenever(role.asMention).thenReturn("<@&15>")
+        whenever(narouNovelAlertSettingsRepository.findById(1L)).thenReturn(
+            Optional.of(NarouNovelAlertSettings(guildId = 1L, pingRoleId = 15L))
+        )
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val replyCaptor = argumentCaptor<String>()
+        verify(slashEvent).reply(replyCaptor.capture())
+        assertEquals(true, replyCaptor.firstValue.contains("- Ping target: <@&15>"))
+    }
+
+    @Test
+    fun `show displays missing ping role`() {
+        stubAuthorizedSlashCommand("show")
+        whenever(guild.name).thenReturn("Test Guild")
+        whenever(guild.getRoleById(15L)).thenReturn(null)
+        whenever(narouNovelAlertSettingsRepository.findById(1L)).thenReturn(
+            Optional.of(NarouNovelAlertSettings(guildId = 1L, pingRoleId = 15L))
+        )
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val replyCaptor = argumentCaptor<String>()
+        verify(slashEvent).reply(replyCaptor.capture())
+        assertEquals(true, replyCaptor.firstValue.contains("- Ping target: Missing role (ID: 15)"))
     }
 
     @Test
@@ -170,6 +208,40 @@ class NarouNovelConfigCommandTest {
     }
 
     @Test
+    fun `set ping role stores selected role`() {
+        stubAuthorizedSlashCommand("set-ping-role")
+        whenever(role.idLong).thenReturn(15L)
+        whenever(role.asMention).thenReturn("<@&15>")
+        whenever(narouNovelAlertSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.empty())
+        command.selectedRole = role
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(15L, settingsCaptor.firstValue.pingRoleId)
+        verify(slashEvent).reply("Narou novel alerts will now ping <@&15>.")
+    }
+
+    @Test
+    fun `set ping role clears configured role when omitted`() {
+        stubAuthorizedSlashCommand("set-ping-role")
+        whenever(narouNovelAlertSettingsRepository.findById(1L)).thenReturn(
+            Optional.of(NarouNovelAlertSettings(guildId = 1L, pingRoleId = 15L))
+        )
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.empty())
+        command.selectedRole = null
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(null, settingsCaptor.firstValue.pingRoleId)
+        verify(slashEvent).reply("Narou novel alerts will now ping @everyone.")
+    }
+
+    @Test
     fun `set threshold stores configured value`() {
         stubAuthorizedSlashCommand("set-threshold")
         command.threshold = 500L
@@ -228,7 +300,7 @@ class NarouNovelConfigCommandTest {
         assertEquals("narounovelapi", commandData.name)
         assertEquals(setOf(InteractionContextType.GUILD), commandData.contexts)
         assertEquals(
-            listOf("show", "set-channel", "set-threshold", "set-prediction-threshold", "disable"),
+            listOf("show", "set-channel", "set-ping-role", "set-threshold", "set-prediction-threshold", "disable"),
             commandData.subcommands.map(SubcommandData::getName)
         )
     }
@@ -258,10 +330,15 @@ class NarouNovelConfigCommandTest {
         narouNovelSnapshotRepository
     ) {
         var selectedChannel: TextChannel? = null
+        var selectedRole: Role? = null
         var threshold: Long? = null
 
         override fun getRequiredTextChannel(event: SlashCommandInteractionEvent): TextChannel? {
             return selectedChannel ?: super.getRequiredTextChannel(event)
+        }
+
+        override fun getOptionalRole(event: SlashCommandInteractionEvent): Role? {
+            return selectedRole ?: super.getOptionalRole(event)
         }
 
         override fun getRequiredThreshold(event: SlashCommandInteractionEvent): Long? {

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -8,6 +8,7 @@ import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshot
 import be.duncanc.discordmodbot.narou.novel.api.persistence.NarouNovelSnapshotRepository
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.never
@@ -44,6 +46,9 @@ class NarouNovelPollingServiceTest {
 
     @Mock
     private lateinit var textChannel: TextChannel
+
+    @Mock
+    private lateinit var role: Role
 
     private lateinit var service: TestNarouNovelPollingService
     private val pendingAlerts = mutableMapOf<Long, NarouNovelPendingAlert>()
@@ -149,6 +154,74 @@ class NarouNovelPollingServiceTest {
         assertEquals(9_876_000L, settingsCaptor.lastValue.lastAlertedAuthorProfileLength)
         assertEquals(778, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
         assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
+    }
+
+    @Test
+    fun `configured ping role is used for alert mention`() {
+        stubPendingAlertRepository()
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 778)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            pingRoleId = 15L,
+            lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 778)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+        whenever(jda.getRoleById(15L)).thenReturn(role)
+        whenever(role.asMention).thenReturn("<@&15>")
+
+        service.pollNovel()
+
+        assertAlert(
+            service = service,
+            description = "the novel grew by 1231 characters.",
+            totalChapters = 778,
+            totalCharacters = 9_446_500L,
+            chapterLink = "https://ncode.syosetu.com/n2267be/778",
+            expectedMessageContent = "<@&15>"
+        )
+    }
+
+    @Test
+    fun `missing configured ping role is cleared and alert sends without mention`() {
+        stubPendingAlertRepository()
+        val snapshot = snapshot(length = 9_446_500, generalAllNo = 778)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            pingRoleId = 15L,
+            lengthThreshold = 1_000L,
+            predictionLengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedAuthorProfileLength = 9_876_000L,
+            lastAlertedGeneralAllNo = 778
+        )
+        whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 778)))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+        whenever(jda.getRoleById(15L)).thenReturn(null)
+
+        service.pollNovel()
+
+        assertAlert(
+            service = service,
+            description = "the novel grew by 1231 characters.",
+            totalChapters = 778,
+            totalCharacters = 9_446_500L,
+            chapterLink = "https://ncode.syosetu.com/n2267be/778",
+            expectedMessageContent = ""
+        )
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository, atLeastOnce()).save(settingsCaptor.capture())
+        assertEquals(null, settingsCaptor.firstValue.pingRoleId)
     }
 
     @Test
@@ -580,9 +653,10 @@ class NarouNovelPollingServiceTest {
         totalChapters: Int,
         totalCharacters: Long,
         chapterLink: String,
+        expectedMessageContent: String = "@everyone",
         index: Int = 0
     ) {
-        assertEquals("@everyone", service.sentMessageContents[index])
+        assertEquals(expectedMessageContent, service.sentMessageContents[index])
         val embed = service.sentEmbeds[index]
         assertEquals("Narou update for n2267be", embed.title)
         assertEquals(description, embed.description)


### PR DESCRIPTION
## Summary
- add a persisted per-server Narou alert ping role setting and Flyway migration
- add /narounovelapi set-ping-role and show the current ping target in config output
- send alerts to the configured role, fall back to @everyone when unset, and clear missing roles without widening the ping

## Testing
- gradlew.bat test for NarouNovelConfigCommandTest and NarouNovelPollingServiceTest