### PR TITLE
fix(narouNovelApi): add next chapter and profile length to alerts

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -4,7 +4,6 @@ import be.duncanc.discordmodbot.narou.novel.api.persistence.*
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.MessageEmbed
-import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.exceptions.ErrorResponseException
 import net.dv8tion.jda.api.requests.ErrorResponse
@@ -184,6 +183,7 @@ class NarouNovelPollingService(
                 lengthTriggered,
                 lengthDelta,
                 predictionTriggered,
+                predictionLengthDelta,
                 chapterTriggered,
                 chapterDelta,
                 snapshot
@@ -400,6 +400,7 @@ class NarouNovelPollingService(
         lengthTriggered: Boolean,
         lengthDelta: Long,
         predictionTriggered: Boolean,
+        predictionLengthDelta: Long,
         chapterTriggered: Boolean,
         chapterDelta: Int,
         snapshot: NarouNovelSnapshot
@@ -421,14 +422,26 @@ class NarouNovelPollingService(
 
         val summary = truncate(updates.joinToString(" and ") + ".", MessageEmbed.DESCRIPTION_MAX_LENGTH)
         val chapterLink = truncate(NOVEL_URL + snapshot.generalAllNo, MessageEmbed.VALUE_MAX_LENGTH)
+        val nextChapterLink = truncate(NOVEL_URL + (snapshot.generalAllNo + 1), MessageEmbed.VALUE_MAX_LENGTH)
 
-        return EmbedBuilder()
+        val embedBuilder = EmbedBuilder()
             .setColor(Color.ORANGE)
             .setTitle(truncate(EMBED_TITLE, MessageEmbed.TITLE_MAX_LENGTH))
             .setDescription(summary)
             .addField("Total chapters", snapshot.generalAllNo.toString(), true)
             .addField("Total characters", snapshot.length.toString(), true)
             .addField("Chapter link", chapterLink, false)
+
+        if (predictionLengthDelta > 0) {
+            embedBuilder.addField(
+                "Author profile length",
+                "${snapshot.authorProfileLength} (+$predictionLengthDelta)",
+                false
+            )
+        }
+
+        return embedBuilder
+            .addField("Next chapter link", nextChapterLink, false)
             .build()
     }
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -111,7 +111,8 @@ class NarouNovelPollingServiceTest {
             description = "1 new chapter was published.",
             totalChapters = 779,
             totalCharacters = 9_445_500L,
-            chapterLink = "https://ncode.syosetu.com/n2267be/779"
+            chapterLink = "https://ncode.syosetu.com/n2267be/779",
+            nextChapterLink = "https://ncode.syosetu.com/n2267be/780"
         )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
@@ -146,7 +147,8 @@ class NarouNovelPollingServiceTest {
             description = "the novel grew by 1231 characters.",
             totalChapters = 778,
             totalCharacters = 9_446_500L,
-            chapterLink = "https://ncode.syosetu.com/n2267be/778"
+            chapterLink = "https://ncode.syosetu.com/n2267be/778",
+            nextChapterLink = "https://ncode.syosetu.com/n2267be/779"
         )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
@@ -185,6 +187,7 @@ class NarouNovelPollingServiceTest {
             totalChapters = 778,
             totalCharacters = 9_446_500L,
             chapterLink = "https://ncode.syosetu.com/n2267be/778",
+            nextChapterLink = "https://ncode.syosetu.com/n2267be/779",
             expectedMessageContent = "<@&15>"
         )
     }
@@ -217,6 +220,7 @@ class NarouNovelPollingServiceTest {
             totalChapters = 778,
             totalCharacters = 9_446_500L,
             chapterLink = "https://ncode.syosetu.com/n2267be/778",
+            nextChapterLink = "https://ncode.syosetu.com/n2267be/779",
             expectedMessageContent = ""
         )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
@@ -249,7 +253,8 @@ class NarouNovelPollingServiceTest {
             description = "2 new chapters were published and the novel grew by 1231 characters.",
             totalChapters = 780,
             totalCharacters = 9_446_500L,
-            chapterLink = "https://ncode.syosetu.com/n2267be/780"
+            chapterLink = "https://ncode.syosetu.com/n2267be/780",
+            nextChapterLink = "https://ncode.syosetu.com/n2267be/781"
         )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
@@ -285,7 +290,9 @@ class NarouNovelPollingServiceTest {
             description = "Detected an increase in the author's profile character count. This may indicate that a new chapter is coming soon.",
             totalChapters = 779,
             totalCharacters = 9_445_500L,
-            chapterLink = "https://ncode.syosetu.com/n2267be/779"
+            chapterLink = "https://ncode.syosetu.com/n2267be/779",
+            nextChapterLink = "https://ncode.syosetu.com/n2267be/780",
+            authorProfileLength = "9877250 (+1250)"
         )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
@@ -320,7 +327,8 @@ class NarouNovelPollingServiceTest {
             description = "1 new chapter was published.",
             totalChapters = 779,
             totalCharacters = 9_445_500L,
-            chapterLink = "https://ncode.syosetu.com/n2267be/779"
+            chapterLink = "https://ncode.syosetu.com/n2267be/779",
+            nextChapterLink = "https://ncode.syosetu.com/n2267be/780"
         )
         val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
@@ -388,7 +396,8 @@ class NarouNovelPollingServiceTest {
             description = "2 new chapters were published and the novel grew by 1231 characters.",
             totalChapters = 780,
             totalCharacters = 9_446_500L,
-            chapterLink = "https://ncode.syosetu.com/n2267be/780"
+            chapterLink = "https://ncode.syosetu.com/n2267be/780",
+            nextChapterLink = "https://ncode.syosetu.com/n2267be/781"
         )
         assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 9_876_000L, 780), pendingAlerts[1L])
         verify(narouNovelAlertSettingsRepository, never()).save(settings)
@@ -653,6 +662,8 @@ class NarouNovelPollingServiceTest {
         totalChapters: Int,
         totalCharacters: Long,
         chapterLink: String,
+        nextChapterLink: String,
+        authorProfileLength: String? = null,
         expectedMessageContent: String = "@everyone",
         index: Int = 0
     ) {
@@ -663,6 +674,8 @@ class NarouNovelPollingServiceTest {
         assertEquals(totalChapters.toString(), embed.fieldValue("Total chapters"))
         assertEquals(totalCharacters.toString(), embed.fieldValue("Total characters"))
         assertEquals(chapterLink, embed.fieldValue("Chapter link"))
+        assertEquals(nextChapterLink, embed.fieldValue("Next chapter link"))
+        assertEquals(authorProfileLength, embed.fieldValue("Author profile length"))
     }
 
     private fun MessageEmbed.fieldValue(name: String): String? {

--- a/src/test/kotlin/be/duncanc/discordmodbot/voting/VoteCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/voting/VoteCommandTest.kt
@@ -144,15 +144,16 @@ class VoteCommandTest {
         stubSlashCommandContext("yesno")
         stubGuildId()
         stubVoteMessageContext()
-        stubReply()
+        stubFollowupReply()
         command.prompt = "Should we do this?"
         command.voteMessageFailure = IllegalStateException("boom")
+        whenever(slashEvent.hook).thenReturn(interactionHook)
         whenever(votingEmotesRepository.findById(1L)).thenReturn(Optional.empty())
 
         command.onSlashCommandInteraction(slashEvent)
 
-        verify(slashEvent).reply("I could not post the vote message in this channel.")
-        verify(replyAction).setEphemeral(true)
+        verify(interactionHook).sendMessage("I could not post the vote message in this channel.")
+        verify(followupAction).setEphemeral(true)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- keep the current chapter link and add a next chapter link to Narou alerts
- include author profile novel_length in the embed when it increases, with the delta
- update Narou polling tests to cover the new embed fields

## Testing
- .\gradlew.bat test --tests "be.duncanc.discordmodbot.narou.novel.api.NarouNovelPollingServiceTest"