### PR TITLE
feat(moderation): unify warn reason modal flow

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
@@ -46,7 +46,6 @@ class AddWarnPointsByIdCommand(
         private const val OPTION_POINTS = "points"
         private const val OPTION_DAYS = "days"
         private const val OPTION_ACTION = "action"
-        private const val OPTION_REASON = "reason"
         private const val MODAL_ID = "addwarnpointsbyid_reason"
 
         val LOG: Logger = LoggerFactory.getLogger(AddWarnPointsByIdCommand::class.java)
@@ -101,17 +100,7 @@ class AddWarnPointsByIdCommand(
             return
         }
 
-        val reason = event.getOption(OPTION_REASON)?.asString
-        if (reason == null) {
-            event.replyModal(createReasonModal(targetUserId, points, days, action)).queue()
-            return
-        }
-        if (reason.length > 1024) {
-            event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
-            return
-        }
-
-        processSlashCommand(event, moderator, targetUserId, targetMember, points, days, action, reason)
+        event.replyModal(createReasonModal(targetUserId, points, days, action)).queue()
     }
 
     override fun onModalInteraction(event: ModalInteractionEvent) {
@@ -167,43 +156,6 @@ class AddWarnPointsByIdCommand(
         processModalCommand(event, moderator, targetUserId, targetMember, points, days, action, reason)
     }
 
-    private fun processSlashCommand(
-        event: SlashCommandInteractionEvent,
-        moderator: Member,
-        targetUserId: Long,
-        targetMember: Member?,
-        points: Int,
-        days: Int,
-        action: Int,
-        reason: String
-    ) {
-        val guild = event.guild!!
-        val guildPointsSettings = getGuildWarnPointsSettings(event, points)
-        if (guildPointsSettings == null) {
-            return
-        }
-
-        event.deferReply(true).queue { hook ->
-            try {
-                processWarnPoints(
-                    guild,
-                    moderator,
-                    targetUserId,
-                    targetMember,
-                    points,
-                    days,
-                    action,
-                    reason,
-                    guildPointsSettings,
-                    hook
-                )
-            } catch (t: Throwable) {
-                LOG.error("Error processing warn points", t)
-                hook.editOriginal("Error: ${t.message}").queue()
-            }
-        }
-    }
-
     private fun processModalCommand(
         event: ModalInteractionEvent,
         moderator: Member,
@@ -239,29 +191,6 @@ class AddWarnPointsByIdCommand(
                 hook.editOriginal("Error: ${t.message}").queue()
             }
         }
-    }
-
-    private fun getGuildWarnPointsSettings(
-        event: SlashCommandInteractionEvent,
-        requestedPoints: Int
-    ): GuildWarnPointsSettings? {
-        val guildId = event.guild!!.idLong
-        val guildPointsSettings = guildWarnPointsSettingsRepository.findById(guildId)
-            .orElse(null) ?: GuildWarnPointsSettings(guildId, announceChannelId = -1)
-
-        if (requestedPoints > guildPointsSettings.maxPointsPerReason) {
-            event.reply("The maximum points per reason is ${guildPointsSettings.maxPointsPerReason}.")
-                .setEphemeral(true).queue()
-            return null
-        }
-
-        if (guildPointsSettings.announceChannelId.let { event.jda.getTextChannelById(it) == null }) {
-            event.reply("The announcement channel is not configured. Please contact an administrator.")
-                .setEphemeral(true).queue()
-            return null
-        }
-
-        return guildPointsSettings
     }
 
     private fun getGuildWarnPointsSettings(
@@ -464,7 +393,6 @@ The user was not warned by DM, please do so manually when they rejoin."""
                         .addChoice("Mute", 1L)
                         .setMinValue(0L)
                         .setMaxValue(1L),
-                    OptionData(OptionType.STRING, OPTION_REASON, "Reason for the warning", false)
                 )
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
         )

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -236,33 +236,60 @@ class AddWarnPointsCommand(
                 val muteRole = try {
                     muteRoleCommandAndEventsListener.getMuteRole(guild)
                 } catch (_: IllegalStateException) {
-                    hook.sendMessage("Warn points added, but mute role is not configured.").setEphemeral(true).queue()
-
-                    null
-                }
-                muteRole?.let { role ->
-                    guild.addRoleToMember(targetMember, role).reason(reason).queue(
-                        {
-                            val unmutePlanMessage =
-                                scheduleUnmuteIfRequested(guild, targetMember, moderator, unmuteDays)
-                            finishWarnPointsProcessing(
-                                jda,
-                                moderator,
-                                targetMember,
-                                reason,
-                                points,
-                                guildWarnPoint.id,
-                                expireDate,
-                                action.toByte(),
-                                unmuteDays,
-                                totalPoints,
-                                hook,
-                                unmutePlanMessage
-                            )
-                        },
-                        { hook.sendMessage("Unable to add mute role to user.").setEphemeral(true).queue() }
+                    finishWarnPointsProcessing(
+                        jda,
+                        moderator,
+                        targetMember,
+                        reason,
+                        points,
+                        guildWarnPoint.id,
+                        expireDate,
+                        0,
+                        null,
+                        totalPoints,
+                        hook,
+                        moderatorNote = "Mute role is not configured."
                     )
+
+                    return
                 }
+
+                guild.addRoleToMember(targetMember, muteRole).reason(reason).queue(
+                    {
+                        val unmutePlanMessage =
+                            scheduleUnmuteIfRequested(guild, targetMember, moderator, unmuteDays)
+                        finishWarnPointsProcessing(
+                            jda,
+                            moderator,
+                            targetMember,
+                            reason,
+                            points,
+                            guildWarnPoint.id,
+                            expireDate,
+                            action.toByte(),
+                            unmuteDays,
+                            totalPoints,
+                            hook,
+                            unmutePlanMessage
+                        )
+                    },
+                    {
+                        finishWarnPointsProcessing(
+                            jda,
+                            moderator,
+                            targetMember,
+                            reason,
+                            points,
+                            guildWarnPoint.id,
+                            expireDate,
+                            0,
+                            null,
+                            totalPoints,
+                            hook,
+                            moderatorNote = "Unable to add mute role to user."
+                        )
+                    }
+                )
                 return
             }
 
@@ -298,7 +325,8 @@ class AddWarnPointsCommand(
         unmuteDays: Int?,
         totalPoints: Int,
         hook: InteractionHook,
-        unmutePlanMessage: String? = null
+        unmutePlanMessage: String? = null,
+        moderatorNote: String? = null
     ) {
         logAddPoints(
             jda,
@@ -321,7 +349,8 @@ class AddWarnPointsCommand(
             hook,
             action,
             unmuteDays,
-            unmutePlanMessage
+            unmutePlanMessage,
+            moderatorNote
         )
     }
 
@@ -420,7 +449,8 @@ class AddWarnPointsCommand(
         hook: InteractionHook,
         action: Byte,
         unmuteDays: Int?,
-        unmutePlanMessage: String?
+        unmutePlanMessage: String?,
+        moderatorNote: String?
     ) {
         val noteMessage = if (amountOfWarnings <= 1) {
             "Please watch your behavior in our server."
@@ -450,23 +480,25 @@ class AddWarnPointsCommand(
         toInform.user.openPrivateChannel().queue(
             { privateChannelUserToWarn ->
                 privateChannelUserToWarn.sendMessageEmbeds(userWarning).queue(
-                    { onSuccessfulInformUser(hook, toInform, userWarning, unmutePlanMessage) }
-                ) { throwable -> onFailToInformUser(hook, toInform, throwable, unmutePlanMessage) }
+                    { onSuccessfulInformUser(hook, toInform, userWarning, unmutePlanMessage, moderatorNote) }
+                ) { throwable -> onFailToInformUser(hook, toInform, throwable, unmutePlanMessage, moderatorNote) }
             }
-        ) { throwable -> onFailToInformUser(hook, toInform, throwable, unmutePlanMessage) }
+        ) { throwable -> onFailToInformUser(hook, toInform, throwable, unmutePlanMessage, moderatorNote) }
     }
 
     private fun onSuccessfulInformUser(
         hook: InteractionHook,
         toInform: Member,
         informationMessage: MessageEmbed,
-        unmutePlanMessage: String?
+        unmutePlanMessage: String?,
+        moderatorNote: String?
     ) {
         hook.sendMessage(
             buildModeratorResultMessage(
                 "Added warn points to $toInform.",
                 "The following message was sent to the user:",
-                unmutePlanMessage
+                unmutePlanMessage,
+                moderatorNote
             )
         )
             .setEphemeral(true)
@@ -477,13 +509,15 @@ class AddWarnPointsCommand(
         hook: InteractionHook,
         toInform: Member,
         throwable: Throwable,
-        unmutePlanMessage: String?
+        unmutePlanMessage: String?,
+        moderatorNote: String?
     ) {
         hook.sendMessage(
             buildModeratorResultMessage(
                 "Added warn points to $toInform.",
                 "Was unable to send a DM to the user please inform the user manually.\nError: ${throwable.message}",
-                unmutePlanMessage
+                unmutePlanMessage,
+                moderatorNote
             )
         )
             .setEphemeral(true)
@@ -522,12 +556,21 @@ class AddWarnPointsCommand(
         }
     }
 
-    private fun buildModeratorResultMessage(summary: String, detail: String, unmutePlanMessage: String?): String {
+    private fun buildModeratorResultMessage(
+        summary: String,
+        detail: String,
+        unmutePlanMessage: String?,
+        moderatorNote: String?
+    ): String {
         return buildString {
             append(summary)
             if (unmutePlanMessage != null) {
                 append('\n')
                 append(unmutePlanMessage)
+            }
+            if (moderatorNote != null) {
+                append('\n')
+                append(moderatorNote)
             }
             append("\n\n")
             append(detail)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -7,8 +7,6 @@ import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettings
 import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettingsRepository
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
-import net.dv8tion.jda.api.components.actionrow.ActionRow
-import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.components.label.Label
 import net.dv8tion.jda.api.components.textinput.TextInput
 import net.dv8tion.jda.api.components.textinput.TextInputStyle
@@ -17,7 +15,6 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
-import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
@@ -47,12 +44,9 @@ class AddWarnPointsCommand(
         private const val OPTION_POINTS = "points"
         private const val OPTION_DAYS = "days"
         private const val OPTION_ACTION = "action"
-        private const val OPTION_REASON = "reason"
         private const val MODAL_ID = "addwarnpoints_reason"
-        private const val UNMUTE_BUTTON_PREFIX = "addwarnpoints_unmute:"
-        private const val SKIP_UNMUTE_BUTTON_PREFIX = "addwarnpoints_skip_unmute:"
-        private const val UNMUTE_MODAL_ID = "addwarnpoints_plan_unmute"
         private const val UNMUTE_DAYS_INPUT_ID = "unmute_days"
+        private const val REASON_INPUT_ID = "reason"
 
         val LOG: Logger = LoggerFactory.getLogger(AddWarnPointsCommand::class.java)
     }
@@ -105,69 +99,12 @@ class AddWarnPointsCommand(
             return
         }
 
-        val reason = event.getOption(OPTION_REASON)?.asString
-        if (reason == null) {
-            val modal = createReasonModal(targetMember, points, days, action)
-            event.replyModal(modal).queue()
-            return
-        }
-        if (reason.length > 1024) {
-            event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
-            return
-        }
-
-        val guildId = event.guild!!.idLong
-        val guildPointsSettings =
-            guildWarnPointsSettingsRepository.findById(guildId)
-                .orElse(null) ?: GuildWarnPointsSettings(
-                guildId,
-                announceChannelId = -1
-            )
-
-        if (points > guildPointsSettings.maxPointsPerReason) {
-            event.reply("The maximum points per reason is ${guildPointsSettings.maxPointsPerReason}.")
-                .setEphemeral(true).queue()
-            return
-        }
-
-        if (guildPointsSettings.announceChannelId.let { event.jda.getTextChannelById(it) == null }) {
-            event.reply("The announcement channel is not configured. Please contact an administrator.")
-                .setEphemeral(true).queue()
-            return
-        }
-
-        event.deferReply(true).queue { hook ->
-            try {
-                processWarnPoints(
-                    event.guild!!,
-                    event.jda,
-                    moderator,
-                    targetMember,
-                    points,
-                    days,
-                    action,
-                    reason,
-                    guildPointsSettings,
-                    hook
-                )
-            } catch (t: Throwable) {
-                LOG.error("Error processing warn points", t)
-                hook.editOriginal("Error: ${t.message}").queue()
-            }
-        }
+        event.replyModal(createReasonModal(targetMember, points, days, action)).queue()
     }
 
     override fun onModalInteraction(event: ModalInteractionEvent) {
         when {
             event.modalId.startsWith(MODAL_ID) -> handleReasonModal(event)
-            event.modalId.startsWith(UNMUTE_MODAL_ID) -> handlePlanUnmuteModal(event)
-        }
-    }
-
-    override fun onButtonInteraction(event: ButtonInteractionEvent) {
-        when {
-            event.componentId.startsWith(UNMUTE_BUTTON_PREFIX) -> handlePlanUnmuteButton(event)
-            event.componentId.startsWith(SKIP_UNMUTE_BUTTON_PREFIX) -> handleSkipUnmuteButton(event)
         }
     }
 
@@ -209,7 +146,19 @@ class AddWarnPointsCommand(
             return
         }
 
-        val reason = event.getValue("reason")?.asString ?: ""
+        val reason = event.getValue(REASON_INPUT_ID)?.asString ?: ""
+        val unmuteDays = if (action == 1) {
+            val rawUnmuteDays = event.getValue(UNMUTE_DAYS_INPUT_ID)?.asString?.trim().orEmpty()
+            when {
+                rawUnmuteDays.isBlank() -> null
+                else -> rawUnmuteDays.toIntOrNull()?.takeIf { it > 0 } ?: run {
+                    event.reply("Please provide a valid number of days.").setEphemeral(true).queue()
+                    return
+                }
+            }
+        } else {
+            null
+        }
 
         if (reason.length > 1024) {
             event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
@@ -242,6 +191,7 @@ class AddWarnPointsCommand(
                     points,
                     days,
                     action,
+                    unmuteDays,
                     reason,
                     guildPointsSettings,
                     hook
@@ -253,90 +203,6 @@ class AddWarnPointsCommand(
         }
     }
 
-    private fun handlePlanUnmuteButton(event: ButtonInteractionEvent) {
-        val buttonAction = parseModeratorTargetComponent(event.componentId, UNMUTE_BUTTON_PREFIX)
-        if (buttonAction == null) {
-            event.reply("This unmute action is no longer available.").setEphemeral(true).queue()
-            return
-        }
-
-        if (event.member?.hasPermission(Permission.MANAGE_ROLES) != true) {
-            event.reply("You need manage roles permission to schedule an unmute.").setEphemeral(true).queue()
-            return
-        }
-
-        if (buttonAction.moderatorId != event.user.idLong) {
-            event.reply("You cannot plan an unmute initiated by another moderator.").setEphemeral(true).queue()
-            return
-        }
-
-        event.replyModal(createPlanUnmuteModal(buttonAction)).queue()
-    }
-
-    private fun handleSkipUnmuteButton(event: ButtonInteractionEvent) {
-        val buttonAction = parseModeratorTargetComponent(event.componentId, SKIP_UNMUTE_BUTTON_PREFIX)
-        if (buttonAction == null) {
-            event.reply("This unmute action is no longer available.").setEphemeral(true).queue()
-            return
-        }
-
-        if (buttonAction.moderatorId != event.user.idLong) {
-            event.reply("You cannot skip an unmute prompt initiated by another moderator.").setEphemeral(true).queue()
-            return
-        }
-
-        event.editMessage("Skipped planning an unmute for <@${buttonAction.targetUserId}>.")
-            .setComponents(emptyList())
-            .queue()
-    }
-
-    private fun handlePlanUnmuteModal(event: ModalInteractionEvent) {
-        val modalAction = parseModeratorTargetComponent(event.modalId, "$UNMUTE_MODAL_ID:")
-        if (modalAction == null) {
-            event.reply("This unmute action is no longer available.").setEphemeral(true).queue()
-            return
-        }
-
-        if (event.member?.hasPermission(Permission.MANAGE_ROLES) != true) {
-            event.reply("You need manage roles permission to schedule an unmute.").setEphemeral(true).queue()
-            return
-        }
-
-        if (modalAction.moderatorId != event.user.idLong) {
-            event.reply("You cannot plan an unmute initiated by another moderator.").setEphemeral(true).queue()
-            return
-        }
-
-        val days = event.getValue(UNMUTE_DAYS_INPUT_ID)?.asString?.trim()?.toIntOrNull()
-        if (days == null || days <= 0) {
-            event.reply("Please provide a valid number of days.").setEphemeral(true).queue()
-            return
-        }
-
-        val guild = event.guild
-        val moderator = event.member
-        if (guild == null || moderator == null) {
-            event.reply("This command only works in a guild.").setEphemeral(true).queue()
-            return
-        }
-
-        try {
-            val unmuteDateTime = unmutePlanningService.planUnmute(guild, modalAction.targetUserId, moderator, days)
-            val targetMention =
-                guild.getMemberById(modalAction.targetUserId)?.asMention ?: "<@${modalAction.targetUserId}>"
-
-            event.reply(
-                "Unmute has been planned for $targetMention on ${
-                    TimeFormat.DATE_SHORT_TIME_SHORT.atInstant(unmuteDateTime.toInstant())
-                }."
-            ).setEphemeral(true).queue()
-        } catch (e: IllegalArgumentException) {
-            event.reply(e.message ?: "Please provide a valid number of days.").setEphemeral(true).queue()
-        } catch (e: IllegalStateException) {
-            event.reply(e.message ?: "Unable to plan an unmute.").setEphemeral(true).queue()
-        }
-    }
-
     private fun processWarnPoints(
         guild: net.dv8tion.jda.api.entities.Guild,
         jda: net.dv8tion.jda.api.JDA,
@@ -345,6 +211,7 @@ class AddWarnPointsCommand(
         points: Int,
         days: Int,
         action: Int,
+        unmuteDays: Int?,
         reason: String,
         guildPointsSettings: GuildWarnPointsSettings,
         hook: InteractionHook
@@ -364,18 +231,6 @@ class AddWarnPointsCommand(
 
         performChecks(guildPointsSettings, targetMember.user, guild)
 
-        logAddPoints(
-            jda,
-            moderator,
-            targetMember.user,
-            reason,
-            points,
-            guildWarnPoint.id,
-            expireDate,
-            action.toByte(),
-            guild
-        )
-
         when (action) {
             1 -> {
                 val muteRole = try {
@@ -387,10 +242,28 @@ class AddWarnPointsCommand(
                 }
                 muteRole?.let { role ->
                     guild.addRoleToMember(targetMember, role).reason(reason).queue(
-                        { sendPlanUnmutePrompt(hook, moderator, targetMember) },
+                        {
+                            val unmutePlanMessage =
+                                scheduleUnmuteIfRequested(guild, targetMember, moderator, unmuteDays)
+                            finishWarnPointsProcessing(
+                                jda,
+                                moderator,
+                                targetMember,
+                                reason,
+                                points,
+                                guildWarnPoint.id,
+                                expireDate,
+                                action.toByte(),
+                                unmuteDays,
+                                totalPoints,
+                                hook,
+                                unmutePlanMessage
+                            )
+                        },
                         { hook.sendMessage("Unable to add mute role to user.").setEphemeral(true).queue() }
                     )
                 }
+                return
             }
 
             2 -> {
@@ -398,7 +271,78 @@ class AddWarnPointsCommand(
             }
         }
 
-        informUserAndModerator(moderator, targetMember, reason, totalPoints, hook, action.toByte())
+        finishWarnPointsProcessing(
+            jda,
+            moderator,
+            targetMember,
+            reason,
+            points,
+            guildWarnPoint.id,
+            expireDate,
+            action.toByte(),
+            unmuteDays,
+            totalPoints,
+            hook
+        )
+    }
+
+    private fun finishWarnPointsProcessing(
+        jda: net.dv8tion.jda.api.JDA,
+        moderator: Member,
+        targetMember: Member,
+        reason: String,
+        points: Int,
+        warnPointId: java.util.UUID,
+        expireDate: OffsetDateTime,
+        action: Byte,
+        unmuteDays: Int?,
+        totalPoints: Int,
+        hook: InteractionHook,
+        unmutePlanMessage: String? = null
+    ) {
+        logAddPoints(
+            jda,
+            moderator,
+            targetMember.user,
+            reason,
+            points,
+            warnPointId,
+            expireDate,
+            action,
+            unmuteDays,
+            targetMember.guild
+        )
+
+        informUserAndModerator(
+            moderator,
+            targetMember,
+            reason,
+            totalPoints,
+            hook,
+            action,
+            unmuteDays,
+            unmutePlanMessage
+        )
+    }
+
+    private fun scheduleUnmuteIfRequested(
+        guild: net.dv8tion.jda.api.entities.Guild,
+        targetMember: Member,
+        moderator: Member,
+        unmuteDays: Int?
+    ): String? {
+        if (unmuteDays == null) {
+            return null
+        }
+
+        return try {
+            val unmuteDateTime = unmutePlanningService.planUnmute(guild, targetMember.idLong, moderator, unmuteDays)
+            "Unmute planned for ${TimeFormat.DATE_SHORT_TIME_SHORT.atInstant(unmuteDateTime.toInstant())}."
+        } catch (e: IllegalArgumentException) {
+            e.message ?: "Unable to plan an unmute."
+        } catch (e: IllegalStateException) {
+            e.message ?: "Unable to plan an unmute."
+        }
     }
 
     private fun performChecks(
@@ -445,6 +389,7 @@ class AddWarnPointsCommand(
         id: java.util.UUID,
         dateTime: OffsetDateTime,
         action: Byte,
+        unmuteDays: Int?,
         guild: net.dv8tion.jda.api.entities.Guild
     ) {
         val guildLogger = jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
@@ -459,7 +404,7 @@ class AddWarnPointsCommand(
                 .addField("Reason", reason, false)
                 .addField("Expires", TimeFormat.DATE_SHORT_TIME_SHORT.atInstant(dateTime.toInstant()).toString(), false)
             when (action) {
-                1.toByte() -> logEmbed.addField("Punishment", "Mute", false)
+                1.toByte() -> logEmbed.addField("Punishment", buildPunishmentText(unmuteDays), false)
                 2.toByte() -> logEmbed.addField("Punishment", "Kick", false)
             }
 
@@ -473,7 +418,9 @@ class AddWarnPointsCommand(
         reason: String,
         amountOfWarnings: Int,
         hook: InteractionHook,
-        action: Byte
+        action: Byte,
+        unmuteDays: Int?,
+        unmutePlanMessage: String?
     ) {
         val noteMessage = if (amountOfWarnings <= 1) {
             "Please watch your behavior in our server."
@@ -481,9 +428,9 @@ class AddWarnPointsCommand(
             "You have received $amountOfWarnings warnings in recent history. Please watch your behaviour in our server."
         }
 
-        val actionText = when (action) {
-            1.toByte() -> "\nPunishment: Mute"
-            2.toByte() -> "\nPunishment: Kick"
+        val punishmentText = when (action) {
+            1.toByte() -> buildPunishmentText(unmuteDays)
+            2.toByte() -> "Kick"
             else -> ""
         }
 
@@ -494,8 +441,8 @@ class AddWarnPointsCommand(
             .addField("Reason", reason, false)
             .addField("Note", noteMessage, false)
             .apply {
-                if (actionText.isNotEmpty()) {
-                    addField("Action", actionText.trim(), false)
+                if (punishmentText.isNotEmpty()) {
+                    addField("Punishment", punishmentText, false)
                 }
             }
             .build()
@@ -503,19 +450,24 @@ class AddWarnPointsCommand(
         toInform.user.openPrivateChannel().queue(
             { privateChannelUserToWarn ->
                 privateChannelUserToWarn.sendMessageEmbeds(userWarning).queue(
-                    { onSuccessfulInformUser(hook, toInform, userWarning) }
-                ) { throwable -> onFailToInformUser(hook, toInform, throwable) }
+                    { onSuccessfulInformUser(hook, toInform, userWarning, unmutePlanMessage) }
+                ) { throwable -> onFailToInformUser(hook, toInform, throwable, unmutePlanMessage) }
             }
-        ) { throwable -> onFailToInformUser(hook, toInform, throwable) }
+        ) { throwable -> onFailToInformUser(hook, toInform, throwable, unmutePlanMessage) }
     }
 
     private fun onSuccessfulInformUser(
         hook: InteractionHook,
         toInform: Member,
-        informationMessage: MessageEmbed
+        informationMessage: MessageEmbed,
+        unmutePlanMessage: String?
     ) {
         hook.sendMessage(
-            "Added warn points to $toInform.\n\nThe following message was sent to the user:"
+            buildModeratorResultMessage(
+                "Added warn points to $toInform.",
+                "The following message was sent to the user:",
+                unmutePlanMessage
+            )
         )
             .setEphemeral(true)
             .setEmbeds(informationMessage).queue()
@@ -524,77 +476,62 @@ class AddWarnPointsCommand(
     private fun onFailToInformUser(
         hook: InteractionHook,
         toInform: Member,
-        throwable: Throwable
+        throwable: Throwable,
+        unmutePlanMessage: String?
     ) {
         hook.sendMessage(
-            "Added warn points to $toInform.\n\nWas unable to send a DM to the user please inform the user manually.\nError: ${throwable.message}"
+            buildModeratorResultMessage(
+                "Added warn points to $toInform.",
+                "Was unable to send a DM to the user please inform the user manually.\nError: ${throwable.message}",
+                unmutePlanMessage
+            )
         )
             .setEphemeral(true)
             .queue()
     }
 
-    private fun sendPlanUnmutePrompt(hook: InteractionHook, moderator: Member, targetMember: Member) {
-        if (!moderator.hasPermission(Permission.MANAGE_ROLES)) {
-            return
-        }
-
-        val planButtonId = "$UNMUTE_BUTTON_PREFIX${moderator.idLong}:${targetMember.idLong}"
-        val skipButtonId = "$SKIP_UNMUTE_BUTTON_PREFIX${moderator.idLong}:${targetMember.idLong}"
-
-        hook.sendMessage("Do you want to plan an unmute for ${targetMember.asMention}?")
-            .setEphemeral(true)
-            .addComponents(
-                ActionRow.of(
-                    Button.primary(planButtonId, "Plan unmute"),
-                    Button.secondary(skipButtonId, "Skip")
-                )
-            )
-            .queue()
-    }
-
-    private fun createPlanUnmuteModal(action: ModeratorTargetAction): Modal {
-        val daysInput = TextInput.create(UNMUTE_DAYS_INPUT_ID, TextInputStyle.SHORT)
-            .setPlaceholder("Enter the number of days...")
-            .setMinLength(1)
-            .setMaxLength(4)
-            .build()
-
-        return Modal.create("$UNMUTE_MODAL_ID:${action.moderatorId}:${action.targetUserId}", "Plan Unmute")
-            .addComponents(Label.of("Days until unmute", daysInput))
-            .build()
-    }
-
-    private fun parseModeratorTargetComponent(componentId: String, prefix: String): ModeratorTargetAction? {
-        if (!componentId.startsWith(prefix)) {
-            return null
-        }
-
-        val segments = componentId.removePrefix(prefix).split(":", limit = 2)
-        if (segments.size != 2) {
-            return null
-        }
-
-        val moderatorId = segments[0].toLongOrNull() ?: return null
-        val targetUserId = segments[1].toLongOrNull() ?: return null
-        return ModeratorTargetAction(moderatorId, targetUserId)
-    }
-
-    private data class ModeratorTargetAction(
-        val moderatorId: Long,
-        val targetUserId: Long
-    )
-
     private fun createReasonModal(targetMember: Member, points: Int, days: Int, action: Int): Modal {
         val modalId = "$MODAL_ID:${targetMember.idLong}:$points:$days:$action"
-        val textInput = TextInput.create("reason", TextInputStyle.PARAGRAPH)
+        val textInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
             .setPlaceholder("Enter the reason for this warning...")
             .setMinLength(1)
             .setMaxLength(1024)
             .build()
 
-        return Modal.create(modalId, "Enter Reason")
+        val modalBuilder = Modal.create(modalId, "Enter Reason")
             .addComponents(Label.of("Reason", textInput))
-            .build()
+
+        if (action == 1) {
+            val unmuteDaysInput = TextInput.create(UNMUTE_DAYS_INPUT_ID, TextInputStyle.SHORT)
+                .setPlaceholder("Optional: days until unmute")
+                .setRequired(false)
+                .setMaxLength(4)
+                .build()
+
+            modalBuilder.addComponents(Label.of("Days until unmute", unmuteDaysInput))
+        }
+
+        return modalBuilder.build()
+    }
+
+    private fun buildPunishmentText(unmuteDays: Int?): String {
+        return when (unmuteDays) {
+            null -> "Mute"
+            1 -> "1 day mute"
+            else -> "$unmuteDays days mute"
+        }
+    }
+
+    private fun buildModeratorResultMessage(summary: String, detail: String, unmutePlanMessage: String?): String {
+        return buildString {
+            append(summary)
+            if (unmutePlanMessage != null) {
+                append('\n')
+                append(unmutePlanMessage)
+            }
+            append("\n\n")
+            append(detail)
+        }
     }
 
     override fun getCommandsData(): List<SlashCommandData> {
@@ -615,7 +552,6 @@ class AddWarnPointsCommand(
                         .addChoice("Kick", 2L)
                         .setMinValue(0L)
                         .setMaxValue(2L),
-                    OptionData(OptionType.STRING, OPTION_REASON, "Reason for the warning", false)
                 )
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
         )

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -37,6 +37,12 @@ class AddWarnPointsCommand(
     private val muteRoleCommandAndEventsListener: MuteRoleCommandAndEventsListener,
     private val unmutePlanningService: UnmutePlanningService
 ) : ListenerAdapter(), SlashCommand {
+    private data class UnmuteSchedulingResult(
+        val effectiveUnmuteDays: Int?,
+        val unmutePlanMessage: String? = null,
+        val moderatorNote: String? = null
+    )
+
     companion object {
         private const val COMMAND = "addwarnpoints"
         private const val DESCRIPTION = "Add warn points to a user, optionally muting or kicking them."
@@ -256,7 +262,7 @@ class AddWarnPointsCommand(
 
                 guild.addRoleToMember(targetMember, muteRole).reason(reason).queue(
                     {
-                        val unmutePlanMessage =
+                        val unmuteSchedulingResult =
                             scheduleUnmuteIfRequested(guild, targetMember, moderator, unmuteDays)
                         finishWarnPointsProcessing(
                             jda,
@@ -267,10 +273,11 @@ class AddWarnPointsCommand(
                             guildWarnPoint.id,
                             expireDate,
                             action.toByte(),
-                            unmuteDays,
+                            unmuteSchedulingResult.effectiveUnmuteDays,
                             totalPoints,
                             hook,
-                            unmutePlanMessage
+                            unmuteSchedulingResult.unmutePlanMessage,
+                            unmuteSchedulingResult.moderatorNote
                         )
                     },
                     {
@@ -359,18 +366,27 @@ class AddWarnPointsCommand(
         targetMember: Member,
         moderator: Member,
         unmuteDays: Int?
-    ): String? {
+    ): UnmuteSchedulingResult {
         if (unmuteDays == null) {
-            return null
+            return UnmuteSchedulingResult(effectiveUnmuteDays = null)
         }
 
         return try {
             val unmuteDateTime = unmutePlanningService.planUnmute(guild, targetMember.idLong, moderator, unmuteDays)
-            "Unmute planned for ${TimeFormat.DATE_SHORT_TIME_SHORT.atInstant(unmuteDateTime.toInstant())}."
+            UnmuteSchedulingResult(
+                effectiveUnmuteDays = unmuteDays,
+                unmutePlanMessage = "Unmute planned for ${TimeFormat.DATE_SHORT_TIME_SHORT.atInstant(unmuteDateTime.toInstant())}."
+            )
         } catch (e: IllegalArgumentException) {
-            e.message ?: "Unable to plan an unmute."
+            UnmuteSchedulingResult(
+                effectiveUnmuteDays = null,
+                moderatorNote = e.message ?: "Unable to plan an unmute."
+            )
         } catch (e: IllegalStateException) {
-            e.message ?: "Unable to plan an unmute."
+            UnmuteSchedulingResult(
+                effectiveUnmuteDays = null,
+                moderatorNote = e.message ?: "Unable to plan an unmute."
+            )
         }
     }
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
@@ -101,9 +101,6 @@ class AddWarnPointsByIdCommandTest {
     private lateinit var actionOption: OptionMapping
 
     @Mock
-    private lateinit var reasonOption: OptionMapping
-
-    @Mock
     private lateinit var reasonValue: ModalMapping
 
     @Mock
@@ -126,121 +123,13 @@ class AddWarnPointsByIdCommandTest {
     }
 
     @Test
-    fun `opens a reason modal when reason is omitted`() {
-        stubSlashContext(reason = null, targetMember = null, configureSettings = false)
+    fun `opens a reason modal`() {
+        stubSlashContext(targetMember = null)
         whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
 
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent).replyModal(argThat { id == "addwarnpointsbyid_reason:99:2:3:0" })
-    }
-
-    @Test
-    fun `stores warn points for a user who left the server`() {
-        val warnPoint = warnPoint()
-        val settings = settings()
-
-        stubSlashContext(reason = "Spamming", targetMember = null, settings = settings)
-        whenever(
-            guildWarnPointsService.addWarnPoint(
-                eq(99L),
-                eq(1L),
-                eq(2),
-                eq(12L),
-                eq("Spamming"),
-                any<OffsetDateTime>()
-            )
-        ).thenReturn(warnPoint)
-        whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
-        whenever(slashEvent.deferReply(true)).thenReturn(replyAction)
-        whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
-        doQueue(replyAction)
-
-        command.onSlashCommandInteraction(slashEvent)
-
-        verify(guildWarnPointsService).addWarnPoint(
-            eq(99L),
-            eq(1L),
-            eq(2),
-            eq(12L),
-            eq("Spamming"),
-            any<OffsetDateTime>()
-        )
-        verify(interactionHook).editOriginal(
-            """Added warn points to <@99>.
-The user was not warned by DM, please do so manually when they rejoin."""
-        )
-        verify(muteService, never()).muteUserById(1L, 99L)
-    }
-
-    @Test
-    fun `mutes a present user by id`() {
-        val warnPoint = warnPoint()
-        val settings = settings()
-
-        stubSlashContext(reason = "Spamming", targetMember = targetMember, settings = settings, action = 1)
-        whenever(member.canInteract(targetMember)).thenReturn(true)
-        whenever(targetMember.asMention).thenReturn("<@99>")
-        whenever(targetMember.user).thenReturn(targetUser)
-        whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
-        whenever(guild.addRoleToMember(targetMember, muteRole)).thenReturn(addRoleAction)
-        whenever(addRoleAction.reason("Spamming")).thenReturn(addRoleAction)
-        whenever(
-            guildWarnPointsService.addWarnPoint(
-                eq(99L),
-                eq(1L),
-                eq(2),
-                eq(12L),
-                eq("Spamming"),
-                any<OffsetDateTime>()
-            )
-        ).thenReturn(warnPoint)
-        whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
-        whenever(slashEvent.deferReply(true)).thenReturn(replyAction)
-        whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
-        doQueue(replyAction)
-
-        command.onSlashCommandInteraction(slashEvent)
-
-        verify(muteService).muteUserById(1L, 99L)
-        verify(addRoleAction).queue()
-        verify(interactionHook).editOriginal(
-            """Added warn points to <@99> and tried to apply the mute role.
-The user was present but not warned by DM, please do so manually."""
-        )
-    }
-
-    @Test
-    fun `mutes a departed user by id without trying to add the role immediately`() {
-        val warnPoint = warnPoint()
-        val settings = settings()
-
-        stubSlashContext(reason = "Spamming", targetMember = null, settings = settings, action = 1)
-        whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
-        whenever(
-            guildWarnPointsService.addWarnPoint(
-                eq(99L),
-                eq(1L),
-                eq(2),
-                eq(12L),
-                eq("Spamming"),
-                any<OffsetDateTime>()
-            )
-        ).thenReturn(warnPoint)
-        whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
-        whenever(slashEvent.deferReply(true)).thenReturn(replyAction)
-        whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
-        doQueue(replyAction)
-
-        command.onSlashCommandInteraction(slashEvent)
-
-        verify(muteService).muteUserById(1L, 99L)
-        verify(guild, never()).addRoleToMember(targetMember, muteRole)
-        verify(interactionHook).editOriginal(
-            """Added warn points to <@99>.
-The mute will be applied when they rejoin.
-The user was not warned by DM, please do so manually when they rejoin."""
-        )
     }
 
     @Test
@@ -318,11 +207,8 @@ The user was not warned by DM, please do so manually when they rejoin."""
     }
 
     private fun stubSlashContext(
-        reason: String?,
         targetMember: Member?,
-        settings: GuildWarnPointsSettings = settings(),
-        action: Int = 0,
-        configureSettings: Boolean = true
+        action: Int = 0
     ) {
         whenever(slashEvent.name).thenReturn("addwarnpointsbyid")
         whenever(slashEvent.member).thenReturn(member)
@@ -331,28 +217,11 @@ The user was not warned by DM, please do so manually when they rejoin."""
         whenever(slashEvent.getOption("points")).thenReturn(pointsOption)
         whenever(slashEvent.getOption("days")).thenReturn(daysOption)
         whenever(slashEvent.getOption("action")).thenReturn(actionOption)
-        whenever(slashEvent.getOption("reason")).thenReturn(reasonOption)
         whenever(userOption.asLong).thenReturn(99L)
         whenever(userOption.asMember).thenReturn(targetMember)
         whenever(pointsOption.asInt).thenReturn(2)
         whenever(daysOption.asInt).thenReturn(3)
         whenever(actionOption.asInt).thenReturn(action)
-        whenever(reasonOption.asString).thenReturn(reason)
-        if (reason != null) {
-            whenever(slashEvent.guild).thenReturn(guild)
-            whenever(member.guild).thenReturn(guild)
-            whenever(member.idLong).thenReturn(12L)
-            whenever(guild.idLong).thenReturn(1L)
-        }
-        if (configureSettings) {
-            whenever(slashEvent.jda).thenReturn(jda)
-            whenever(guildWarnPointsSettingsRepository.findById(1L)).thenReturn(Optional.of(settings))
-            whenever(jda.getTextChannelById(1L)).thenReturn(textChannel)
-        }
-        if (reason != null) {
-            whenever(moderatorUser.name).thenReturn("ModeratorUser")
-            whenever(member.user).thenReturn(moderatorUser)
-        }
     }
 
     private fun settings(): GuildWarnPointsSettings {

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
@@ -318,6 +318,43 @@ class AddWarnPointsCommandTest {
         kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Unable to add mute role to user."))
     }
 
+    @Test
+    fun `mute modal with failed unmute scheduling falls back to plain mute`() {
+        val dmCaptor = argumentCaptor<MessageEmbed>()
+        val logCaptor = argumentCaptor<EmbedBuilder>()
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 366)
+        whenever(unmutePlanningService.planUnmute(guild, 99L, member, 366))
+            .thenThrow(IllegalArgumentException("Unmute cannot be scheduled beyond 365 days."))
+
+        command.onModalInteraction(modalEvent)
+
+        verify(unmutePlanningService).planUnmute(guild, 99L, member, 366)
+        verify(guildLogger).log(
+            logCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
+        verify(privateChannel).sendMessageEmbeds(dmCaptor.capture())
+        verify(hook).sendMessage(resultCaptor.capture())
+        kotlin.test.assertEquals(
+            "Mute",
+            dmCaptor.firstValue.fields.single { it.name == "Punishment" }.value
+        )
+        kotlin.test.assertEquals(
+            "Mute",
+            logCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
+        )
+        kotlin.test.assertEquals(
+            true,
+            resultCaptor.firstValue.contains("Unmute cannot be scheduled beyond 365 days.")
+        )
+    }
+
     private fun stubSlashCommand(action: Int) {
         whenever(slashEvent.name).thenReturn("addwarnpoints")
         whenever(slashEvent.member).thenReturn(member)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
@@ -1,16 +1,26 @@
 package be.duncanc.discordmodbot.moderation
 
+import be.duncanc.discordmodbot.logging.GuildLogger
+import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPoint
+import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettings
 import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettingsRepository
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
-import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
-import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.modals.ModalMapping
-import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
+import net.dv8tion.jda.api.requests.restaction.CacheRestAction
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.BeforeEach
@@ -18,10 +28,23 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.*
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
 import java.time.OffsetDateTime
+import java.util.Optional
+import java.util.function.Consumer
 
 @ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AddWarnPointsCommandTest {
     @Mock
     private lateinit var guildWarnPointsService: GuildWarnPointsService
@@ -36,13 +59,10 @@ class AddWarnPointsCommandTest {
     private lateinit var unmutePlanningService: UnmutePlanningService
 
     @Mock
-    private lateinit var buttonEvent: ButtonInteractionEvent
+    private lateinit var slashEvent: SlashCommandInteractionEvent
 
     @Mock
     private lateinit var modalEvent: ModalInteractionEvent
-
-    @Mock
-    private lateinit var slashEvent: SlashCommandInteractionEvent
 
     @Mock
     private lateinit var member: Member
@@ -63,10 +83,16 @@ class AddWarnPointsCommandTest {
     private lateinit var targetMember: Member
 
     @Mock
-    private lateinit var daysValue: ModalMapping
+    private lateinit var targetUser: User
 
     @Mock
-    private lateinit var messageEditAction: MessageEditCallbackAction
+    private lateinit var jda: JDA
+
+    @Mock
+    private lateinit var hook: InteractionHook
+
+    @Mock
+    private lateinit var followupAction: WebhookMessageCreateAction<Message>
 
     @Mock
     private lateinit var userOption: OptionMapping
@@ -80,6 +106,30 @@ class AddWarnPointsCommandTest {
     @Mock
     private lateinit var actionOption: OptionMapping
 
+    @Mock
+    private lateinit var reasonValue: ModalMapping
+
+    @Mock
+    private lateinit var unmuteDaysValue: ModalMapping
+
+    @Mock
+    private lateinit var guildLogger: GuildLogger
+
+    @Mock
+    private lateinit var openPrivateChannelAction: CacheRestAction<PrivateChannel>
+
+    @Mock
+    private lateinit var privateChannel: PrivateChannel
+
+    @Mock
+    private lateinit var messageCreateAction: MessageCreateAction
+
+    @Mock
+    private lateinit var muteRole: net.dv8tion.jda.api.entities.Role
+
+    @Mock
+    private lateinit var addRoleAction: AuditableRestAction<Void>
+
     private lateinit var command: AddWarnPointsCommand
 
     @BeforeEach
@@ -90,22 +140,6 @@ class AddWarnPointsCommandTest {
             muteRoleCommandAndEventsListener,
             unmutePlanningService
         )
-    }
-
-    @Test
-    fun `plan unmute button only works for the moderator who triggered it`() {
-        whenever(buttonEvent.componentId).thenReturn("addwarnpoints_unmute:12:99")
-        whenever(buttonEvent.member).thenReturn(member)
-        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
-        whenever(buttonEvent.user).thenReturn(moderatorUser)
-        whenever(moderatorUser.idLong).thenReturn(42L)
-        whenever(buttonEvent.reply(any<String>())).thenReturn(replyAction)
-        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
-
-        command.onButtonInteraction(buttonEvent)
-
-        verify(buttonEvent).reply("You cannot plan an unmute initiated by another moderator.")
-        verify(buttonEvent, never()).replyModal(any())
     }
 
     @Test
@@ -133,86 +167,191 @@ class AddWarnPointsCommandTest {
     }
 
     @Test
-    fun `reason modal requires kick members when kick punishment is selected`() {
-        whenever(modalEvent.modalId).thenReturn("addwarnpoints_reason:99:2:3:2")
-        whenever(modalEvent.guild).thenReturn(guild)
-        whenever(guild.getMemberById("99")).thenReturn(targetMember)
-        whenever(modalEvent.member).thenReturn(member)
-        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
-        whenever(member.hasPermission(Permission.KICK_MEMBERS)).thenReturn(false)
-        whenever(member.canInteract(targetMember)).thenReturn(true)
+    fun `mute slash command opens a combined modal`() {
+        stubSlashCommand(action = 1)
+        whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).replyModal(argThat {
+            id == "addwarnpoints_reason:99:2:3:1" && components.size == 2
+        })
+    }
+
+    @Test
+    fun `kick slash command opens a reason only modal`() {
+        stubSlashCommand(action = 2)
+        whenever(member.hasPermission(Permission.KICK_MEMBERS)).thenReturn(true)
+        whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).replyModal(argThat {
+            id == "addwarnpoints_reason:99:2:3:2" && components.size == 1
+        })
+    }
+
+    @Test
+    fun `mute modal rejects invalid unmute days`() {
+        stubModalContext(modalId = "addwarnpoints_reason:99:2:3:1")
+        whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
+        whenever(reasonValue.asString).thenReturn("Spamming")
+        whenever(modalEvent.getValue("unmute_days")).thenReturn(unmuteDaysValue)
+        whenever(unmuteDaysValue.asString).thenReturn("abc")
         whenever(modalEvent.reply(any<String>())).thenReturn(replyAction)
         whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
 
         command.onModalInteraction(modalEvent)
 
-        verify(modalEvent).reply("You need kick members permission to apply the kick punishment.")
+        verify(modalEvent).reply("Please provide a valid number of days.")
         verify(modalEvent, never()).deferReply(true)
     }
 
     @Test
-    fun `plan unmute button opens a modal for the moderator who triggered it`() {
-        whenever(buttonEvent.componentId).thenReturn("addwarnpoints_unmute:12:99")
-        whenever(buttonEvent.member).thenReturn(member)
-        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
-        whenever(buttonEvent.user).thenReturn(moderatorUser)
-        whenever(moderatorUser.idLong).thenReturn(12L)
-        whenever(buttonEvent.replyModal(any())).thenReturn(modalAction)
+    fun `mute modal without unmute days keeps punishment as mute`() {
+        val embedCaptor = argumentCaptor<MessageEmbed>()
 
-        command.onButtonInteraction(buttonEvent)
+        stubSuccessfulMuteModalFlow(unmuteDays = null)
 
-        verify(buttonEvent).replyModal(argThat { id == "addwarnpoints_plan_unmute:12:99" })
+        command.onModalInteraction(modalEvent)
+
+        verify(unmutePlanningService, never()).planUnmute(any(), any(), any(), any())
+        verify(privateChannel).sendMessageEmbeds(embedCaptor.capture())
+        kotlin.test.assertEquals(
+            "Mute",
+            embedCaptor.firstValue.fields.single { it.name == "Punishment" }.value
+        )
     }
 
     @Test
-    fun `plan unmute modal schedules the unmute`() {
-        val unmuteDateTime = OffsetDateTime.now().plusDays(3)
+    fun `mute modal with unmute days schedules unmute and uses duration punishment`() {
+        val embedCaptor = argumentCaptor<MessageEmbed>()
+        val logCaptor = argumentCaptor<EmbedBuilder>()
+        val plannedUnmute = OffsetDateTime.now().plusDays(3)
 
-        whenever(modalEvent.modalId).thenReturn("addwarnpoints_plan_unmute:12:99")
-        whenever(modalEvent.member).thenReturn(member)
-        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
-        whenever(modalEvent.user).thenReturn(moderatorUser)
-        whenever(moderatorUser.idLong).thenReturn(12L)
-        whenever(modalEvent.getValue("unmute_days")).thenReturn(daysValue)
-        whenever(daysValue.asString).thenReturn("3")
-        whenever(modalEvent.guild).thenReturn(guild)
-        whenever(unmutePlanningService.planUnmute(guild, 99L, member, 3)).thenReturn(unmuteDateTime)
-        whenever(guild.getMemberById(99L)).thenReturn(targetMember)
-        whenever(targetMember.asMention).thenReturn("<@99>")
-        whenever(modalEvent.reply(any<String>())).thenReturn(replyAction)
-        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        stubSuccessfulMuteModalFlow(unmuteDays = 3)
+        whenever(unmutePlanningService.planUnmute(guild, 99L, member, 3)).thenReturn(plannedUnmute)
 
         command.onModalInteraction(modalEvent)
 
         verify(unmutePlanningService).planUnmute(guild, 99L, member, 3)
-        verify(modalEvent).reply(argThat<String> { contains("Unmute has been planned for <@99>") })
+        verify(privateChannel).sendMessageEmbeds(embedCaptor.capture())
+        verify(guildLogger).log(
+            logCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
+        kotlin.test.assertEquals(
+            "3 days mute",
+            embedCaptor.firstValue.fields.single { it.name == "Punishment" }.value
+        )
+        kotlin.test.assertEquals(
+            "3 days mute",
+            logCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
+        )
     }
 
-    @Test
-    fun `skip unmute button only works for the moderator who triggered it`() {
-        whenever(buttonEvent.componentId).thenReturn("addwarnpoints_skip_unmute:12:99")
-        whenever(buttonEvent.user).thenReturn(moderatorUser)
-        whenever(moderatorUser.idLong).thenReturn(77L)
-        whenever(buttonEvent.reply(any<String>())).thenReturn(replyAction)
-        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
-
-        command.onButtonInteraction(buttonEvent)
-
-        verify(buttonEvent).reply("You cannot skip an unmute prompt initiated by another moderator.")
-        verify(buttonEvent, never()).editMessage(any<String>())
+    private fun stubSlashCommand(action: Int) {
+        whenever(slashEvent.name).thenReturn("addwarnpoints")
+        whenever(slashEvent.member).thenReturn(member)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(slashEvent.getOption("user")).thenReturn(userOption)
+        whenever(userOption.asMember).thenReturn(targetMember)
+        whenever(targetMember.idLong).thenReturn(99L)
+        whenever(member.canInteract(targetMember)).thenReturn(true)
+        whenever(slashEvent.getOption("points")).thenReturn(pointsOption)
+        whenever(pointsOption.asInt).thenReturn(2)
+        whenever(slashEvent.getOption("days")).thenReturn(daysOption)
+        whenever(daysOption.asInt).thenReturn(3)
+        whenever(slashEvent.getOption("action")).thenReturn(actionOption)
+        whenever(actionOption.asInt).thenReturn(action)
     }
 
-    @Test
-    fun `skip unmute button edits message when moderator matches`() {
-        whenever(buttonEvent.componentId).thenReturn("addwarnpoints_skip_unmute:12:99")
-        whenever(buttonEvent.user).thenReturn(moderatorUser)
-        whenever(moderatorUser.idLong).thenReturn(12L)
-        whenever(buttonEvent.editMessage(any<String>())).thenReturn(messageEditAction)
-        whenever(messageEditAction.setComponents(any<List<ActionRow>>())).thenReturn(messageEditAction)
+    private fun stubModalContext(modalId: String) {
+        whenever(modalEvent.modalId).thenReturn(modalId)
+        whenever(modalEvent.guild).thenReturn(guild)
+        whenever(modalEvent.member).thenReturn(member)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(guild.getMemberById("99")).thenReturn(targetMember)
+        whenever(member.canInteract(targetMember)).thenReturn(true)
+    }
 
-        command.onButtonInteraction(buttonEvent)
+    @Suppress("UNCHECKED_CAST")
+    private fun stubSuccessfulMuteModalFlow(unmuteDays: Int?) {
+        val settings = GuildWarnPointsSettings(
+            guildId = 1L,
+            maxPointsPerReason = 10,
+            announcePointsSummaryLimit = 99,
+            announceChannelId = 1L,
+            overrideWarnCommand = false
+        )
+        val warnPoint = GuildWarnPoint(
+            userId = 99L,
+            guildId = 1L,
+            points = 2,
+            creatorId = 12L,
+            reason = "Spamming",
+            expireDate = OffsetDateTime.now().plusDays(3)
+        )
 
-        verify(buttonEvent).editMessage("Skipped planning an unmute for <@99>.")
-        verify(buttonEvent, never()).reply(any<String>())
+        stubModalContext(modalId = "addwarnpoints_reason:99:2:3:1")
+        whenever(modalEvent.jda).thenReturn(jda)
+        whenever(member.guild).thenReturn(guild)
+        whenever(member.idLong).thenReturn(12L)
+        whenever(member.user).thenReturn(moderatorUser)
+        whenever(moderatorUser.name).thenReturn("ModeratorUser")
+        whenever(moderatorUser.effectiveAvatarUrl).thenReturn("https://example.com/mod.png")
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guild.name).thenReturn("Guild")
+        whenever(targetMember.idLong).thenReturn(99L)
+        whenever(targetMember.guild).thenReturn(guild)
+        whenever(targetMember.user).thenReturn(targetUser)
+        whenever(targetMember.nickname).thenReturn(null)
+        whenever(targetUser.name).thenReturn("TargetUser")
+        whenever(jda.registeredListeners).thenReturn(listOf(guildLogger))
+        whenever(jda.getTextChannelById(1L)).thenReturn(mockTextChannel())
+        whenever(guildWarnPointsSettingsRepository.findById(1L)).thenReturn(Optional.of(settings))
+        whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
+        whenever(reasonValue.asString).thenReturn("Spamming")
+        whenever(modalEvent.getValue("unmute_days")).thenReturn(unmuteDaysValue)
+        whenever(unmuteDaysValue.asString).thenReturn(unmuteDays?.toString().orEmpty())
+        whenever(modalEvent.deferReply(true)).thenReturn(replyAction)
+        whenever(guildWarnPointsService.addWarnPoint(eq(99L), eq(1L), eq(2), eq(12L), eq("Spamming"), any()))
+            .thenReturn(warnPoint)
+        whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
+        whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
+        whenever(guild.addRoleToMember(targetMember, muteRole)).thenReturn(addRoleAction)
+        whenever(addRoleAction.reason("Spamming")).thenReturn(addRoleAction)
+        doAnswer {
+            val consumer = it.arguments[0] as Consumer<InteractionHook>
+            consumer.accept(hook)
+            null
+        }.whenever(replyAction).queue(any<Consumer<InteractionHook>>())
+        doAnswer {
+            val success = it.arguments[0] as Consumer<Void?>
+            success.accept(null)
+            null
+        }.whenever(addRoleAction).queue(any<Consumer<Void?>>(), any<Consumer<Throwable>>())
+        whenever(targetUser.openPrivateChannel()).thenReturn(openPrivateChannelAction)
+        doAnswer {
+            val success = it.arguments[0] as Consumer<PrivateChannel>
+            success.accept(privateChannel)
+            null
+        }.whenever(openPrivateChannelAction).queue(any<Consumer<PrivateChannel>>(), any<Consumer<Throwable>>())
+        whenever(privateChannel.sendMessageEmbeds(any<MessageEmbed>())).thenReturn(messageCreateAction)
+        doAnswer {
+            val failure = it.arguments[1] as Consumer<Throwable>
+            failure.accept(IllegalStateException("DMs disabled"))
+            null
+        }.whenever(messageCreateAction).queue(any<Consumer<Message>>(), any<Consumer<Throwable>>())
+        whenever(hook.sendMessage(any<String>())).thenReturn(followupAction)
+        whenever(followupAction.setEphemeral(true)).thenReturn(followupAction)
+    }
+
+    private fun mockTextChannel(): net.dv8tion.jda.api.entities.channel.concrete.TextChannel {
+        return org.mockito.kotlin.mock()
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
@@ -254,6 +254,70 @@ class AddWarnPointsCommandTest {
         )
     }
 
+    @Test
+    fun `mute modal without configured mute role still logs and attempts DM`() {
+        val dmCaptor = argumentCaptor<MessageEmbed>()
+        val logCaptor = argumentCaptor<EmbedBuilder>()
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3, muteRoleConfigured = false)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(unmutePlanningService, never()).planUnmute(any(), any(), any(), any())
+        verify(guildLogger).log(
+            logCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
+        verify(privateChannel).sendMessageEmbeds(dmCaptor.capture())
+        verify(hook).sendMessage(resultCaptor.capture())
+        kotlin.test.assertEquals(
+            null,
+            dmCaptor.firstValue.fields.singleOrNull { it.name == "Punishment" }
+        )
+        kotlin.test.assertEquals(
+            null,
+            logCaptor.firstValue.build().fields.singleOrNull { it.name == "Punishment" }
+        )
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Mute role is not configured."))
+    }
+
+    @Test
+    fun `mute modal when role assignment fails still logs and attempts DM`() {
+        val dmCaptor = argumentCaptor<MessageEmbed>()
+        val logCaptor = argumentCaptor<EmbedBuilder>()
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3, muteRoleAssignmentSucceeds = false)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(unmutePlanningService, never()).planUnmute(any(), any(), any(), any())
+        verify(guildLogger).log(
+            logCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
+        verify(privateChannel).sendMessageEmbeds(dmCaptor.capture())
+        verify(hook).sendMessage(resultCaptor.capture())
+        kotlin.test.assertEquals(
+            null,
+            dmCaptor.firstValue.fields.singleOrNull { it.name == "Punishment" }
+        )
+        kotlin.test.assertEquals(
+            null,
+            logCaptor.firstValue.build().fields.singleOrNull { it.name == "Punishment" }
+        )
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Unable to add mute role to user."))
+    }
+
     private fun stubSlashCommand(action: Int) {
         whenever(slashEvent.name).thenReturn("addwarnpoints")
         whenever(slashEvent.member).thenReturn(member)
@@ -280,7 +344,11 @@ class AddWarnPointsCommandTest {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun stubSuccessfulMuteModalFlow(unmuteDays: Int?) {
+    private fun stubSuccessfulMuteModalFlow(
+        unmuteDays: Int?,
+        muteRoleConfigured: Boolean = true,
+        muteRoleAssignmentSucceeds: Boolean = true
+    ) {
         val settings = GuildWarnPointsSettings(
             guildId = 1L,
             maxPointsPerReason = 10,
@@ -322,7 +390,12 @@ class AddWarnPointsCommandTest {
         whenever(guildWarnPointsService.addWarnPoint(eq(99L), eq(1L), eq(2), eq(12L), eq("Spamming"), any()))
             .thenReturn(warnPoint)
         whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
-        whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
+        if (muteRoleConfigured) {
+            whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
+        } else {
+            whenever(muteRoleCommandAndEventsListener.getMuteRole(guild))
+                .thenThrow(IllegalStateException("Mute role not configured"))
+        }
         whenever(guild.addRoleToMember(targetMember, muteRole)).thenReturn(addRoleAction)
         whenever(addRoleAction.reason("Spamming")).thenReturn(addRoleAction)
         doAnswer {
@@ -330,11 +403,19 @@ class AddWarnPointsCommandTest {
             consumer.accept(hook)
             null
         }.whenever(replyAction).queue(any<Consumer<InteractionHook>>())
-        doAnswer {
-            val success = it.arguments[0] as Consumer<Void?>
-            success.accept(null)
-            null
-        }.whenever(addRoleAction).queue(any<Consumer<Void?>>(), any<Consumer<Throwable>>())
+        if (muteRoleAssignmentSucceeds) {
+            doAnswer {
+                val success = it.arguments[0] as Consumer<Void?>
+                success.accept(null)
+                null
+            }.whenever(addRoleAction).queue(any<Consumer<Void?>>(), any<Consumer<Throwable>>())
+        } else {
+            doAnswer {
+                val failure = it.arguments[1] as Consumer<Throwable>
+                failure.accept(IllegalStateException("Missing permissions"))
+                null
+            }.whenever(addRoleAction).queue(any<Consumer<Void?>>(), any<Consumer<Throwable>>())
+        }
         whenever(targetUser.openPrivateChannel()).thenReturn(openPrivateChannelAction)
         doAnswer {
             val success = it.arguments[0] as Consumer<PrivateChannel>


### PR DESCRIPTION
## Summary
- remove the optional slash-command reason path for add warn points commands and always collect the reason through a modal
- merge warn mute and plan-unmute into a single modal with optional unmute scheduling for `/addwarnpoints`
- rename the DM embed punishment field and include x days mute when an unmute is scheduled

## Testing
- gradlew.bat test --tests 'be.duncanc.discordmodbot.moderation.AddWarnPointsCommandTest'
- gradlew.bat test --tests 'be.duncanc.discordmodbot.moderation.AddWarnPointsCommandTest' --tests 'be.duncanc.discordmodbot.moderation.AddWarnPointsByIdCommandTest'