### PR TITLE
fix(moderation): add unmute planning to warn-by-id modal

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
@@ -328,7 +328,21 @@ class AddWarnPointsByIdCommand(
                             ).queue()
                         } catch (t: Throwable) {
                             LOG.error("Error processing warn points", t)
-                            hook.sendMessage("Error: ${t.message}").queue()
+                            logAddPoints(
+                                moderator,
+                                targetUserId,
+                                targetMember,
+                                reason,
+                                points,
+                                guildWarnPoint.id,
+                                expireDate,
+                                action.toByte(),
+                                null,
+                                guild
+                            )
+                            hook.sendMessage(
+                                buildManualUnmutePlanningMessage(targetUserId, targetMember, t.message)
+                            ).queue()
                         }
                     },
                     {
@@ -502,6 +516,23 @@ class AddWarnPointsByIdCommand(
                     "\nThe user was present but not warned by DM, please do so manually."
                 }
             )
+        }
+    }
+
+    private fun buildManualUnmutePlanningMessage(
+        targetUserId: Long,
+        targetMember: Member,
+        errorMessage: String?
+    ): String {
+        val target = formatTarget(targetUserId, targetMember)
+        val message = errorMessage ?: "Unable to persist mute state."
+
+        return buildString {
+            append("Added warn points to $target and applied the mute role.")
+            append("\nError: $message")
+            append(" The mute role was added, but the unmute was not planned automatically.")
+            append(" Please plan the unmute manually.")
+            append("\nThe user was present but not warned by DM, please do so manually.")
         }
     }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
@@ -269,33 +269,87 @@ class AddWarnPointsByIdCommand(
         if (action == 1) {
             try {
                 val muteRole = muteRoleCommandAndEventsListener.getMuteRole(guild)
-                muteService.muteUserById(guild.idLong, targetUserId)
-                targetMember?.let {
-                    guild.addRoleToMember(it, muteRole).reason(reason).queue()
+
+                if (targetMember == null) {
+                    muteService.muteUserById(guild.idLong, targetUserId)
+
+                    val unmuteSchedulingResult = scheduleUnmuteIfRequested(guild, targetUserId, moderator, unmuteDays)
+                    logAddPoints(
+                        moderator,
+                        targetUserId,
+                        null,
+                        reason,
+                        points,
+                        guildWarnPoint.id,
+                        expireDate,
+                        action.toByte(),
+                        unmuteSchedulingResult.effectiveUnmuteDays,
+                        guild
+                    )
+                    hook.editOriginal(
+                        buildCompletionMessage(
+                            targetUserId,
+                            null,
+                            true,
+                            unmuteSchedulingResult.unmutePlanMessage,
+                            unmuteSchedulingResult.moderatorNote
+                        )
+                    ).queue()
+                    return
                 }
 
-                val unmuteSchedulingResult = scheduleUnmuteIfRequested(guild, targetUserId, moderator, unmuteDays)
-                logAddPoints(
-                    moderator,
-                    targetUserId,
-                    targetMember,
-                    reason,
-                    points,
-                    guildWarnPoint.id,
-                    expireDate,
-                    action.toByte(),
-                    unmuteSchedulingResult.effectiveUnmuteDays,
-                    guild
+                guild.addRoleToMember(targetMember, muteRole).reason(reason).queue(
+                    {
+                        muteService.muteUserById(guild.idLong, targetUserId)
+
+                        val unmuteSchedulingResult =
+                            scheduleUnmuteIfRequested(guild, targetUserId, moderator, unmuteDays)
+                        logAddPoints(
+                            moderator,
+                            targetUserId,
+                            targetMember,
+                            reason,
+                            points,
+                            guildWarnPoint.id,
+                            expireDate,
+                            action.toByte(),
+                            unmuteSchedulingResult.effectiveUnmuteDays,
+                            guild
+                        )
+                        hook.editOriginal(
+                            buildCompletionMessage(
+                                targetUserId,
+                                targetMember,
+                                true,
+                                unmuteSchedulingResult.unmutePlanMessage,
+                                unmuteSchedulingResult.moderatorNote
+                            )
+                        ).queue()
+                    },
+                    {
+                        logAddPoints(
+                            moderator,
+                            targetUserId,
+                            targetMember,
+                            reason,
+                            points,
+                            guildWarnPoint.id,
+                            expireDate,
+                            0,
+                            null,
+                            guild
+                        )
+                        hook.editOriginal(
+                            buildCompletionMessage(
+                                targetUserId,
+                                targetMember,
+                                false,
+                                null,
+                                "Unable to add mute role to user."
+                            )
+                        ).queue()
+                    }
                 )
-                hook.editOriginal(
-                    buildCompletionMessage(
-                        targetUserId,
-                        targetMember,
-                        true,
-                        unmuteSchedulingResult.unmutePlanMessage,
-                        unmuteSchedulingResult.moderatorNote
-                    )
-                ).queue()
                 return
             } catch (_: IllegalStateException) {
                 logAddPoints(

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
@@ -300,31 +300,36 @@ class AddWarnPointsByIdCommand(
 
                 guild.addRoleToMember(targetMember, muteRole).reason(reason).queue(
                     {
-                        muteService.muteUserById(guild.idLong, targetUserId)
+                        try {
+                            muteService.muteUserById(guild.idLong, targetUserId)
 
-                        val unmuteSchedulingResult =
-                            scheduleUnmuteIfRequested(guild, targetUserId, moderator, unmuteDays)
-                        logAddPoints(
-                            moderator,
-                            targetUserId,
-                            targetMember,
-                            reason,
-                            points,
-                            guildWarnPoint.id,
-                            expireDate,
-                            action.toByte(),
-                            unmuteSchedulingResult.effectiveUnmuteDays,
-                            guild
-                        )
-                        hook.editOriginal(
-                            buildCompletionMessage(
+                            val unmuteSchedulingResult =
+                                scheduleUnmuteIfRequested(guild, targetUserId, moderator, unmuteDays)
+                            logAddPoints(
+                                moderator,
                                 targetUserId,
                                 targetMember,
-                                true,
-                                unmuteSchedulingResult.unmutePlanMessage,
-                                unmuteSchedulingResult.moderatorNote
+                                reason,
+                                points,
+                                guildWarnPoint.id,
+                                expireDate,
+                                action.toByte(),
+                                unmuteSchedulingResult.effectiveUnmuteDays,
+                                guild
                             )
-                        ).queue()
+                            hook.editOriginal(
+                                buildCompletionMessage(
+                                    targetUserId,
+                                    targetMember,
+                                    true,
+                                    unmuteSchedulingResult.unmutePlanMessage,
+                                    unmuteSchedulingResult.moderatorNote
+                                )
+                            ).queue()
+                        } catch (t: Throwable) {
+                            LOG.error("Error processing warn points", t)
+                            hook.editOriginal("Error: ${t.message}").queue()
+                        }
                     },
                     {
                         logAddPoints(

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
@@ -212,7 +212,7 @@ class AddWarnPointsByIdCommand(
                 )
             } catch (t: Throwable) {
                 LOG.error("Error processing warn points", t)
-                hook.editOriginal("Error: ${t.message}").queue()
+                hook.sendMessage("Error: ${t.message}").queue()
             }
         }
     }
@@ -286,7 +286,7 @@ class AddWarnPointsByIdCommand(
                         unmuteSchedulingResult.effectiveUnmuteDays,
                         guild
                     )
-                    hook.editOriginal(
+                    hook.sendMessage(
                         buildCompletionMessage(
                             targetUserId,
                             null,
@@ -317,7 +317,7 @@ class AddWarnPointsByIdCommand(
                                 unmuteSchedulingResult.effectiveUnmuteDays,
                                 guild
                             )
-                            hook.editOriginal(
+                            hook.sendMessage(
                                 buildCompletionMessage(
                                     targetUserId,
                                     targetMember,
@@ -328,7 +328,7 @@ class AddWarnPointsByIdCommand(
                             ).queue()
                         } catch (t: Throwable) {
                             LOG.error("Error processing warn points", t)
-                            hook.editOriginal("Error: ${t.message}").queue()
+                            hook.sendMessage("Error: ${t.message}").queue()
                         }
                     },
                     {
@@ -344,7 +344,7 @@ class AddWarnPointsByIdCommand(
                             null,
                             guild
                         )
-                        hook.editOriginal(
+                        hook.sendMessage(
                             buildCompletionMessage(
                                 targetUserId,
                                 targetMember,
@@ -369,7 +369,7 @@ class AddWarnPointsByIdCommand(
                     null,
                     guild
                 )
-                hook.editOriginal(
+                hook.sendMessage(
                     "Added warn points to ${
                         formatTarget(
                             targetUserId,
@@ -394,7 +394,7 @@ class AddWarnPointsByIdCommand(
             null,
             guild
         )
-        hook.editOriginal(buildCompletionMessage(targetUserId, targetMember, false, null, null)).queue()
+        hook.sendMessage(buildCompletionMessage(targetUserId, targetMember, false, null, null)).queue()
     }
 
     private fun performChecks(

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
@@ -37,8 +37,15 @@ class AddWarnPointsByIdCommand(
     private val guildWarnPointsSettingsRepository: GuildWarnPointsSettingsRepository,
     private val muteRoleCommandAndEventsListener: MuteRoleCommandAndEventsListener,
     private val muteService: MuteService,
+    private val unmutePlanningService: UnmutePlanningService,
     private val guildLogger: GuildLogger
 ) : ListenerAdapter(), SlashCommand {
+    private data class UnmuteSchedulingResult(
+        val effectiveUnmuteDays: Int?,
+        val unmutePlanMessage: String? = null,
+        val moderatorNote: String? = null
+    )
+
     companion object {
         private const val COMMAND = "addwarnpointsbyid"
         private const val DESCRIPTION = "Add warn points to a user by ID, optionally muting them when they rejoin."
@@ -47,6 +54,8 @@ class AddWarnPointsByIdCommand(
         private const val OPTION_DAYS = "days"
         private const val OPTION_ACTION = "action"
         private const val MODAL_ID = "addwarnpointsbyid_reason"
+        private const val REASON_INPUT_ID = "reason"
+        private const val UNMUTE_DAYS_INPUT_ID = "unmute_days"
 
         val LOG: Logger = LoggerFactory.getLogger(AddWarnPointsByIdCommand::class.java)
     }
@@ -118,7 +127,7 @@ class AddWarnPointsByIdCommand(
         val points = parts[1].toIntOrNull()
         val days = parts[2].toIntOrNull()
         val action = parts[3].toIntOrNull()
-        val reason = event.getValue("reason")?.asString ?: ""
+        val reason = event.getValue(REASON_INPUT_ID)?.asString ?: ""
 
         if (targetUserId == null || points == null || days == null || action == null) {
             event.reply("This form is no longer valid.").setEphemeral(true).queue()
@@ -140,6 +149,19 @@ class AddWarnPointsByIdCommand(
             return
         }
 
+        val unmuteDays = if (action == 1) {
+            val rawUnmuteDays = event.getValue(UNMUTE_DAYS_INPUT_ID)?.asString?.trim().orEmpty()
+            when {
+                rawUnmuteDays.isBlank() -> null
+                else -> rawUnmuteDays.toIntOrNull()?.takeIf { it > 0 } ?: run {
+                    event.reply("Please provide a valid number of days.").setEphemeral(true).queue()
+                    return
+                }
+            }
+        } else {
+            null
+        }
+
         val guild = event.guild
         val moderator = event.member
         if (guild == null || moderator == null) {
@@ -153,7 +175,7 @@ class AddWarnPointsByIdCommand(
             return
         }
 
-        processModalCommand(event, moderator, targetUserId, targetMember, points, days, action, reason)
+        processModalCommand(event, moderator, targetUserId, targetMember, points, days, action, unmuteDays, reason)
     }
 
     private fun processModalCommand(
@@ -164,6 +186,7 @@ class AddWarnPointsByIdCommand(
         points: Int,
         days: Int,
         action: Int,
+        unmuteDays: Int?,
         reason: String
     ) {
         val guild = event.guild!!
@@ -182,6 +205,7 @@ class AddWarnPointsByIdCommand(
                     points,
                     days,
                     action,
+                    unmuteDays,
                     reason,
                     guildPointsSettings,
                     hook
@@ -224,6 +248,7 @@ class AddWarnPointsByIdCommand(
         points: Int,
         days: Int,
         action: Int,
+        unmuteDays: Int?,
         reason: String,
         guildPointsSettings: GuildWarnPointsSettings,
         hook: InteractionHook
@@ -241,18 +266,6 @@ class AddWarnPointsByIdCommand(
 
         performChecks(guildPointsSettings, targetUserId, guild)
 
-        logAddPoints(
-            moderator,
-            targetUserId,
-            targetMember,
-            reason,
-            points,
-            guildWarnPoint.id,
-            expireDate,
-            action.toByte(),
-            guild
-        )
-
         if (action == 1) {
             try {
                 val muteRole = muteRoleCommandAndEventsListener.getMuteRole(guild)
@@ -260,7 +273,43 @@ class AddWarnPointsByIdCommand(
                 targetMember?.let {
                     guild.addRoleToMember(it, muteRole).reason(reason).queue()
                 }
+
+                val unmuteSchedulingResult = scheduleUnmuteIfRequested(guild, targetUserId, moderator, unmuteDays)
+                logAddPoints(
+                    moderator,
+                    targetUserId,
+                    targetMember,
+                    reason,
+                    points,
+                    guildWarnPoint.id,
+                    expireDate,
+                    action.toByte(),
+                    unmuteSchedulingResult.effectiveUnmuteDays,
+                    guild
+                )
+                hook.editOriginal(
+                    buildCompletionMessage(
+                        targetUserId,
+                        targetMember,
+                        true,
+                        unmuteSchedulingResult.unmutePlanMessage,
+                        unmuteSchedulingResult.moderatorNote
+                    )
+                ).queue()
+                return
             } catch (_: IllegalStateException) {
+                logAddPoints(
+                    moderator,
+                    targetUserId,
+                    targetMember,
+                    reason,
+                    points,
+                    guildWarnPoint.id,
+                    expireDate,
+                    0,
+                    null,
+                    guild
+                )
                 hook.editOriginal(
                     "Added warn points to ${
                         formatTarget(
@@ -274,7 +323,19 @@ class AddWarnPointsByIdCommand(
             }
         }
 
-        hook.editOriginal(buildCompletionMessage(targetUserId, targetMember, action)).queue()
+        logAddPoints(
+            moderator,
+            targetUserId,
+            targetMember,
+            reason,
+            points,
+            guildWarnPoint.id,
+            expireDate,
+            action.toByte(),
+            null,
+            guild
+        )
+        hook.editOriginal(buildCompletionMessage(targetUserId, targetMember, false, null, null)).queue()
     }
 
     private fun performChecks(
@@ -324,6 +385,7 @@ class AddWarnPointsByIdCommand(
         id: UUID,
         dateTime: OffsetDateTime,
         action: Byte,
+        unmuteDays: Int?,
         guild: Guild
     ) {
         val logEmbed = EmbedBuilder()
@@ -337,26 +399,50 @@ class AddWarnPointsByIdCommand(
             .addField("Expires", TimeFormat.DATE_SHORT_TIME_SHORT.atInstant(dateTime.toInstant()).toString(), false)
 
         when (action) {
-            1.toByte() -> logEmbed.addField("Punishment", "Mute", false)
+            1.toByte() -> logEmbed.addField("Punishment", buildPunishmentText(unmuteDays), false)
         }
 
         guildLogger.log(logEmbed, targetMember?.user, guild, null, GuildLogger.LogTypeAction.MODERATOR)
     }
 
-    private fun buildCompletionMessage(targetUserId: Long, targetMember: Member?, action: Int): String {
+    private fun buildCompletionMessage(
+        targetUserId: Long,
+        targetMember: Member?,
+        muted: Boolean,
+        unmutePlanMessage: String?,
+        moderatorNote: String?
+    ): String {
         val target = formatTarget(targetUserId, targetMember)
-        return when (action) {
-            1 -> if (targetMember == null) {
-                """Added warn points to $target.
-The mute will be applied when they rejoin.
-The user was not warned by DM, please do so manually when they rejoin."""
-            } else {
-                """Added warn points to $target and tried to apply the mute role.
-The user was present but not warned by DM, please do so manually."""
+        return buildString {
+            append(
+                if (!muted || targetMember == null) {
+                    "Added warn points to $target."
+                } else {
+                    "Added warn points to $target and tried to apply the mute role."
+                }
+            )
+
+            if (targetMember == null && muted) {
+                append("\nThe mute will be applied when they rejoin.")
             }
 
-            else -> """Added warn points to $target.
-The user was not warned by DM, please do so manually when they rejoin."""
+            if (unmutePlanMessage != null) {
+                append('\n')
+                append(unmutePlanMessage)
+            }
+
+            if (moderatorNote != null) {
+                append('\n')
+                append(moderatorNote)
+            }
+
+            append(
+                if (targetMember == null) {
+                    "\nThe user was not warned by DM, please do so manually when they rejoin."
+                } else {
+                    "\nThe user was present but not warned by DM, please do so manually."
+                }
+            )
         }
     }
 
@@ -364,16 +450,64 @@ The user was not warned by DM, please do so manually when they rejoin."""
         return targetMember?.asMention ?: "<@$targetUserId>"
     }
 
+    private fun scheduleUnmuteIfRequested(
+        guild: Guild,
+        targetUserId: Long,
+        moderator: Member,
+        unmuteDays: Int?
+    ): UnmuteSchedulingResult {
+        if (unmuteDays == null) {
+            return UnmuteSchedulingResult(effectiveUnmuteDays = null)
+        }
+
+        return try {
+            val unmuteDateTime = unmutePlanningService.planUnmute(guild, targetUserId, moderator, unmuteDays)
+            UnmuteSchedulingResult(
+                effectiveUnmuteDays = unmuteDays,
+                unmutePlanMessage = "Unmute planned for ${TimeFormat.DATE_SHORT_TIME_SHORT.atInstant(unmuteDateTime.toInstant())}."
+            )
+        } catch (e: IllegalArgumentException) {
+            UnmuteSchedulingResult(
+                effectiveUnmuteDays = null,
+                moderatorNote = e.message ?: "Unable to plan an unmute."
+            )
+        } catch (e: IllegalStateException) {
+            UnmuteSchedulingResult(
+                effectiveUnmuteDays = null,
+                moderatorNote = e.message ?: "Unable to plan an unmute."
+            )
+        }
+    }
+
     private fun createReasonModal(targetUserId: Long, points: Int, days: Int, action: Int): Modal {
-        val textInput = TextInput.create("reason", TextInputStyle.PARAGRAPH)
+        val textInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
             .setPlaceholder("Enter the reason for this warning...")
             .setMinLength(1)
             .setMaxLength(1024)
             .build()
 
-        return Modal.create("$MODAL_ID:$targetUserId:$points:$days:$action", "Enter Reason")
+        val modalBuilder = Modal.create("$MODAL_ID:$targetUserId:$points:$days:$action", "Enter Reason")
             .addComponents(Label.of("Reason", textInput))
-            .build()
+
+        if (action == 1) {
+            val unmuteDaysInput = TextInput.create(UNMUTE_DAYS_INPUT_ID, TextInputStyle.SHORT)
+                .setPlaceholder("Optional: days until unmute")
+                .setRequired(false)
+                .setMaxLength(4)
+                .build()
+
+            modalBuilder.addComponents(Label.of("Days until unmute", unmuteDaysInput))
+        }
+
+        return modalBuilder.build()
+    }
+
+    private fun buildPunishmentText(unmuteDays: Int?): String {
+        return when (unmuteDays) {
+            null -> "Mute"
+            1 -> "1 day mute"
+            else -> "$unmuteDays days mute"
+        }
     }
 
     override fun getCommandsData(): List<SlashCommandData> {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -262,39 +262,49 @@ class AddWarnPointsCommand(
 
                 guild.addRoleToMember(targetMember, muteRole).reason(reason).queue(
                     {
-                        val unmuteSchedulingResult =
-                            scheduleUnmuteIfRequested(guild, targetMember, moderator, unmuteDays)
-                        finishWarnPointsProcessing(
-                            jda,
-                            moderator,
-                            targetMember,
-                            reason,
-                            points,
-                            guildWarnPoint.id,
-                            expireDate,
-                            action.toByte(),
-                            unmuteSchedulingResult.effectiveUnmuteDays,
-                            totalPoints,
-                            hook,
-                            unmuteSchedulingResult.unmutePlanMessage,
-                            unmuteSchedulingResult.moderatorNote
-                        )
+                        try {
+                            val unmuteSchedulingResult =
+                                scheduleUnmuteIfRequested(guild, targetMember, moderator, unmuteDays)
+                            finishWarnPointsProcessing(
+                                jda,
+                                moderator,
+                                targetMember,
+                                reason,
+                                points,
+                                guildWarnPoint.id,
+                                expireDate,
+                                action.toByte(),
+                                unmuteSchedulingResult.effectiveUnmuteDays,
+                                totalPoints,
+                                hook,
+                                unmuteSchedulingResult.unmutePlanMessage,
+                                unmuteSchedulingResult.moderatorNote
+                            )
+                        } catch (t: Throwable) {
+                            LOG.error("Error processing warn points", t)
+                            hook.editOriginal("Error: ${t.message}").queue()
+                        }
                     },
                     {
-                        finishWarnPointsProcessing(
-                            jda,
-                            moderator,
-                            targetMember,
-                            reason,
-                            points,
-                            guildWarnPoint.id,
-                            expireDate,
-                            0,
-                            null,
-                            totalPoints,
-                            hook,
-                            moderatorNote = "Unable to add mute role to user."
-                        )
+                        try {
+                            finishWarnPointsProcessing(
+                                jda,
+                                moderator,
+                                targetMember,
+                                reason,
+                                points,
+                                guildWarnPoint.id,
+                                expireDate,
+                                0,
+                                null,
+                                totalPoints,
+                                hook,
+                                moderatorNote = "Unable to add mute role to user."
+                            )
+                        } catch (t: Throwable) {
+                            LOG.error("Error processing warn points", t)
+                            hook.editOriginal("Error: ${t.message}").queue()
+                        }
                     }
                 )
                 return

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -282,7 +282,14 @@ class AddWarnPointsCommand(
                             )
                         } catch (t: Throwable) {
                             LOG.error("Error processing warn points", t)
-                            hook.sendMessage("Error: ${t.message}").queue()
+                            hook.sendMessage(
+                                buildModeratorResultMessage(
+                                    "Added warn points to $targetMember and applied the mute role.",
+                                    "A follow-up step failed, so logging or notification may need manual checking.",
+                                    null,
+                                    null
+                                )
+                            ).setEphemeral(true).queue()
                         }
                     },
                     {
@@ -303,7 +310,14 @@ class AddWarnPointsCommand(
                             )
                         } catch (t: Throwable) {
                             LOG.error("Error processing warn points", t)
-                            hook.sendMessage("Error: ${t.message}").queue()
+                            hook.sendMessage(
+                                buildModeratorResultMessage(
+                                    "Added warn points to $targetMember.",
+                                    "A follow-up step failed, so logging or notification may need manual checking.",
+                                    null,
+                                    "Unable to add mute role to user."
+                                )
+                            ).setEphemeral(true).queue()
                         }
                     }
                 )

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -204,7 +204,7 @@ class AddWarnPointsCommand(
                 )
             } catch (t: Throwable) {
                 LOG.error("Error processing warn points", t)
-                hook.editOriginal("Error: ${t.message}").queue()
+                hook.sendMessage("Error: ${t.message}").queue()
             }
         }
     }
@@ -282,7 +282,7 @@ class AddWarnPointsCommand(
                             )
                         } catch (t: Throwable) {
                             LOG.error("Error processing warn points", t)
-                            hook.editOriginal("Error: ${t.message}").queue()
+                            hook.sendMessage("Error: ${t.message}").queue()
                         }
                     },
                     {
@@ -303,7 +303,7 @@ class AddWarnPointsCommand(
                             )
                         } catch (t: Throwable) {
                             LOG.error("Error processing warn points", t)
-                            hook.editOriginal("Error: ${t.message}").queue()
+                            hook.sendMessage("Error: ${t.message}").queue()
                         }
                     }
                 )

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
@@ -390,6 +390,39 @@ The user was not warned by DM, please do so manually when they rejoin.""",
         kotlin.test.assertEquals(false, resultCaptor.firstValue.contains("Unmute planned for"))
     }
 
+    @Test
+    fun `mute modal for present member completes deferred reply when mute persistence fails after role assignment`() {
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3, targetMemberPresent = true)
+        whenever(muteService.muteUserById(1L, 99L)).thenThrow(IllegalStateException("Failed to persist mute state"))
+
+        command.onModalInteraction(modalEvent)
+
+        verify(muteService).muteUserById(1L, 99L)
+        verify(unmutePlanningService, never()).planUnmute(any(), any(), any(), any())
+        verify(interactionHook).editOriginal(resultCaptor.capture())
+        verify(guildLogger, never()).log(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull())
+        kotlin.test.assertEquals("Error: Failed to persist mute state", resultCaptor.firstValue)
+    }
+
+    @Test
+    fun `mute modal for present member completes deferred reply when unexpected unmute planning fails`() {
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3, targetMemberPresent = true)
+        whenever(unmutePlanningService.planUnmute(guild, 99L, member, 3))
+            .thenThrow(RuntimeException("Scheduler unavailable"))
+
+        command.onModalInteraction(modalEvent)
+
+        verify(muteService).muteUserById(1L, 99L)
+        verify(unmutePlanningService).planUnmute(guild, 99L, member, 3)
+        verify(interactionHook).editOriginal(resultCaptor.capture())
+        verify(guildLogger, never()).log(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull())
+        kotlin.test.assertEquals("Error: Scheduler unavailable", resultCaptor.firstValue)
+    }
+
     private fun stubSlashContext(
         targetMember: Member?,
         action: Int = 0

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
@@ -16,6 +16,7 @@ import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.modals.ModalMapping
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
@@ -90,6 +91,9 @@ class AddWarnPointsByIdCommandTest {
 
     @Mock
     private lateinit var editAction: WebhookMessageEditAction<net.dv8tion.jda.api.entities.Message>
+
+    @Mock
+    private lateinit var followupAction: WebhookMessageCreateAction<net.dv8tion.jda.api.entities.Message>
 
     @Mock
     private lateinit var userOption: OptionMapping
@@ -182,7 +186,7 @@ class AddWarnPointsByIdCommandTest {
         ).thenReturn(warnPoint)
         whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
         whenever(modalEvent.deferReply(true)).thenReturn(replyAction)
-        whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
+        whenever(interactionHook.sendMessage(any<String>())).thenReturn(followupAction)
         doQueue(replyAction)
 
         command.onModalInteraction(modalEvent)
@@ -195,7 +199,7 @@ class AddWarnPointsByIdCommandTest {
             eq("Spamming"),
             any<OffsetDateTime>()
         )
-        verify(interactionHook).editOriginal(
+        verify(interactionHook).sendMessage(
             """Added warn points to <@99>.
 The user was not warned by DM, please do so manually when they rejoin."""
         )
@@ -264,7 +268,7 @@ The user was not warned by DM, please do so manually when they rejoin."""
             eq(GuildLogger.LogTypeAction.MODERATOR),
             isNull()
         )
-        verify(interactionHook).editOriginal(resultCaptor.capture())
+        verify(interactionHook).sendMessage(resultCaptor.capture())
         kotlin.test.assertEquals(
             "Mute",
             embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
@@ -297,7 +301,7 @@ The user was not warned by DM, please do so manually when they rejoin.""",
             eq(GuildLogger.LogTypeAction.MODERATOR),
             isNull()
         )
-        verify(interactionHook).editOriginal(resultCaptor.capture())
+        verify(interactionHook).sendMessage(resultCaptor.capture())
         kotlin.test.assertEquals(
             "3 days mute",
             embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
@@ -325,7 +329,7 @@ The user was not warned by DM, please do so manually when they rejoin.""",
             eq(GuildLogger.LogTypeAction.MODERATOR),
             isNull()
         )
-        verify(interactionHook).editOriginal(resultCaptor.capture())
+        verify(interactionHook).sendMessage(resultCaptor.capture())
         kotlin.test.assertEquals(
             "Mute",
             embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
@@ -354,7 +358,7 @@ The user was not warned by DM, please do so manually when they rejoin.""",
             eq(GuildLogger.LogTypeAction.MODERATOR),
             isNull()
         )
-        verify(interactionHook).editOriginal(resultCaptor.capture())
+        verify(interactionHook).sendMessage(resultCaptor.capture())
         kotlin.test.assertEquals(
             "3 days mute",
             embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
@@ -381,7 +385,7 @@ The user was not warned by DM, please do so manually when they rejoin.""",
             eq(GuildLogger.LogTypeAction.MODERATOR),
             isNull()
         )
-        verify(interactionHook).editOriginal(resultCaptor.capture())
+        verify(interactionHook).sendMessage(resultCaptor.capture())
         kotlin.test.assertEquals(
             null,
             embedCaptor.firstValue.build().fields.singleOrNull { it.name == "Punishment" }
@@ -401,7 +405,7 @@ The user was not warned by DM, please do so manually when they rejoin.""",
 
         verify(muteService).muteUserById(1L, 99L)
         verify(unmutePlanningService, never()).planUnmute(any(), any(), any(), any())
-        verify(interactionHook).editOriginal(resultCaptor.capture())
+        verify(interactionHook).sendMessage(resultCaptor.capture())
         verify(guildLogger, never()).log(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull())
         kotlin.test.assertEquals("Error: Failed to persist mute state", resultCaptor.firstValue)
     }
@@ -418,7 +422,7 @@ The user was not warned by DM, please do so manually when they rejoin.""",
 
         verify(muteService).muteUserById(1L, 99L)
         verify(unmutePlanningService).planUnmute(guild, 99L, member, 3)
-        verify(interactionHook).editOriginal(resultCaptor.capture())
+        verify(interactionHook).sendMessage(resultCaptor.capture())
         verify(guildLogger, never()).log(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull())
         kotlin.test.assertEquals("Error: Scheduler unavailable", resultCaptor.firstValue)
     }
@@ -501,7 +505,7 @@ The user was not warned by DM, please do so manually when they rejoin.""",
         ).thenReturn(warnPoint)
         whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
         whenever(modalEvent.deferReply(true)).thenReturn(replyAction)
-        whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
+        whenever(interactionHook.sendMessage(any<String>())).thenReturn(followupAction)
         whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
         whenever(targetMember.asMention).thenReturn("<@99>")
         whenever(targetMember.user).thenReturn(targetUser)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
@@ -396,6 +396,7 @@ The user was not warned by DM, please do so manually when they rejoin.""",
 
     @Test
     fun `mute modal for present member completes deferred reply when mute persistence fails after role assignment`() {
+        val embedCaptor = argumentCaptor<net.dv8tion.jda.api.EmbedBuilder>()
         val resultCaptor = argumentCaptor<String>()
 
         stubSuccessfulMuteModalFlow(unmuteDays = 3, targetMemberPresent = true)
@@ -405,13 +406,27 @@ The user was not warned by DM, please do so manually when they rejoin.""",
 
         verify(muteService).muteUserById(1L, 99L)
         verify(unmutePlanningService, never()).planUnmute(any(), any(), any(), any())
+        verify(guildLogger).log(
+            embedCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
         verify(interactionHook).sendMessage(resultCaptor.capture())
-        verify(guildLogger, never()).log(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull())
-        kotlin.test.assertEquals("Error: Failed to persist mute state", resultCaptor.firstValue)
+        kotlin.test.assertEquals(
+            "Mute",
+            embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
+        )
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Error: Failed to persist mute state"))
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Please plan the unmute manually."))
+        kotlin.test.assertEquals(false, resultCaptor.firstValue.contains("Unmute planned for"))
     }
 
     @Test
     fun `mute modal for present member completes deferred reply when unexpected unmute planning fails`() {
+        val embedCaptor = argumentCaptor<net.dv8tion.jda.api.EmbedBuilder>()
         val resultCaptor = argumentCaptor<String>()
 
         stubSuccessfulMuteModalFlow(unmuteDays = 3, targetMemberPresent = true)
@@ -422,9 +437,22 @@ The user was not warned by DM, please do so manually when they rejoin.""",
 
         verify(muteService).muteUserById(1L, 99L)
         verify(unmutePlanningService).planUnmute(guild, 99L, member, 3)
+        verify(guildLogger).log(
+            embedCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
         verify(interactionHook).sendMessage(resultCaptor.capture())
-        verify(guildLogger, never()).log(any(), anyOrNull(), any(), anyOrNull(), any(), anyOrNull())
-        kotlin.test.assertEquals("Error: Scheduler unavailable", resultCaptor.firstValue)
+        kotlin.test.assertEquals(
+            "Mute",
+            embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
+        )
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Error: Scheduler unavailable"))
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Please plan the unmute manually."))
+        kotlin.test.assertEquals(false, resultCaptor.firstValue.contains("Unmute planned for"))
     }
 
     private fun stubSlashContext(

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
@@ -47,6 +47,9 @@ class AddWarnPointsByIdCommandTest {
     private lateinit var muteService: MuteService
 
     @Mock
+    private lateinit var unmutePlanningService: UnmutePlanningService
+
+    @Mock
     private lateinit var guildLogger: GuildLogger
 
     @Mock
@@ -104,6 +107,9 @@ class AddWarnPointsByIdCommandTest {
     private lateinit var reasonValue: ModalMapping
 
     @Mock
+    private lateinit var unmuteDaysValue: ModalMapping
+
+    @Mock
     private lateinit var muteRole: Role
 
     @Mock
@@ -118,6 +124,7 @@ class AddWarnPointsByIdCommandTest {
             guildWarnPointsSettingsRepository,
             muteRoleCommandAndEventsListener,
             muteService,
+            unmutePlanningService,
             guildLogger
         )
     }
@@ -130,6 +137,18 @@ class AddWarnPointsByIdCommandTest {
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent).replyModal(argThat { id == "addwarnpointsbyid_reason:99:2:3:0" })
+    }
+
+    @Test
+    fun `mute slash command opens a combined modal`() {
+        stubSlashContext(targetMember = null, action = 1)
+        whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).replyModal(argThat {
+            id == "addwarnpointsbyid_reason:99:2:3:1" && components.size == 2
+        })
     }
 
     @Test
@@ -206,6 +225,114 @@ The user was not warned by DM, please do so manually when they rejoin."""
         verify(guildWarnPointsService, never()).addWarnPoint(any(), any(), any(), any(), any(), any())
     }
 
+    @Test
+    fun `mute modal rejects invalid unmute days`() {
+        whenever(modalEvent.modalId).thenReturn("addwarnpointsbyid_reason:99:2:3:1")
+        whenever(modalEvent.member).thenReturn(member)
+        whenever(modalEvent.guild).thenReturn(guild)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(guild.getMemberById(99L)).thenReturn(null)
+        whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
+        whenever(reasonValue.asString).thenReturn("Spamming")
+        whenever(modalEvent.getValue("unmute_days")).thenReturn(unmuteDaysValue)
+        whenever(unmuteDaysValue.asString).thenReturn("abc")
+        whenever(modalEvent.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(modalEvent).reply("Please provide a valid number of days.")
+        verify(modalEvent, never()).deferReply(true)
+    }
+
+    @Test
+    fun `mute modal without unmute days keeps punishment as mute`() {
+        val embedCaptor = argumentCaptor<net.dv8tion.jda.api.EmbedBuilder>()
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = null)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(unmutePlanningService, never()).planUnmute(any(), any(), any(), any())
+        verify(muteService).muteUserById(1L, 99L)
+        verify(guildLogger).log(
+            embedCaptor.capture(),
+            isNull(),
+            eq(guild),
+            isNull(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
+        verify(interactionHook).editOriginal(resultCaptor.capture())
+        kotlin.test.assertEquals(
+            "Mute",
+            embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
+        )
+        kotlin.test.assertEquals(
+            """Added warn points to <@99>.
+The mute will be applied when they rejoin.
+The user was not warned by DM, please do so manually when they rejoin.""",
+            resultCaptor.firstValue
+        )
+    }
+
+    @Test
+    fun `mute modal with unmute days schedules unmute and uses duration punishment`() {
+        val embedCaptor = argumentCaptor<net.dv8tion.jda.api.EmbedBuilder>()
+        val resultCaptor = argumentCaptor<String>()
+        val plannedUnmute = OffsetDateTime.now().plusDays(3)
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3)
+        whenever(unmutePlanningService.planUnmute(guild, 99L, member, 3)).thenReturn(plannedUnmute)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(unmutePlanningService).planUnmute(guild, 99L, member, 3)
+        verify(guildLogger).log(
+            embedCaptor.capture(),
+            isNull(),
+            eq(guild),
+            isNull(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
+        verify(interactionHook).editOriginal(resultCaptor.capture())
+        kotlin.test.assertEquals(
+            "3 days mute",
+            embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
+        )
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Unmute planned for"))
+    }
+
+    @Test
+    fun `mute modal with failed unmute scheduling falls back to plain mute`() {
+        val embedCaptor = argumentCaptor<net.dv8tion.jda.api.EmbedBuilder>()
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 366)
+        whenever(unmutePlanningService.planUnmute(guild, 99L, member, 366))
+            .thenThrow(IllegalArgumentException("A mute can't take longer than 1 year"))
+
+        command.onModalInteraction(modalEvent)
+
+        verify(unmutePlanningService).planUnmute(guild, 99L, member, 366)
+        verify(guildLogger).log(
+            embedCaptor.capture(),
+            isNull(),
+            eq(guild),
+            isNull(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
+        verify(interactionHook).editOriginal(resultCaptor.capture())
+        kotlin.test.assertEquals(
+            "Mute",
+            embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
+        )
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("A mute can't take longer than 1 year"))
+    }
+
     private fun stubSlashContext(
         targetMember: Member?,
         action: Int = 0
@@ -243,6 +370,44 @@ The user was not warned by DM, please do so manually when they rejoin."""
             reason = "Spamming",
             expireDate = OffsetDateTime.now().plusDays(2)
         )
+    }
+
+    private fun stubSuccessfulMuteModalFlow(unmuteDays: Int?) {
+        val warnPoint = warnPoint()
+        val settings = settings()
+
+        whenever(modalEvent.modalId).thenReturn("addwarnpointsbyid_reason:99:2:3:1")
+        whenever(modalEvent.member).thenReturn(member)
+        whenever(modalEvent.guild).thenReturn(guild)
+        whenever(modalEvent.jda).thenReturn(jda)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(member.idLong).thenReturn(12L)
+        whenever(member.nickname).thenReturn(null)
+        whenever(member.user).thenReturn(moderatorUser)
+        whenever(moderatorUser.name).thenReturn("ModeratorUser")
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guild.getMemberById(99L)).thenReturn(null)
+        whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
+        whenever(reasonValue.asString).thenReturn("Spamming")
+        whenever(modalEvent.getValue("unmute_days")).thenReturn(unmuteDaysValue)
+        whenever(unmuteDaysValue.asString).thenReturn(unmuteDays?.toString().orEmpty())
+        whenever(guildWarnPointsSettingsRepository.findById(1L)).thenReturn(Optional.of(settings))
+        whenever(jda.getTextChannelById(1L)).thenReturn(textChannel)
+        whenever(
+            guildWarnPointsService.addWarnPoint(
+                eq(99L),
+                eq(1L),
+                eq(2),
+                eq(12L),
+                eq("Spamming"),
+                any<OffsetDateTime>()
+            )
+        ).thenReturn(warnPoint)
+        whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
+        whenever(modalEvent.deferReply(true)).thenReturn(replyAction)
+        whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
+        whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
+        doQueue(replyAction)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
@@ -333,6 +333,63 @@ The user was not warned by DM, please do so manually when they rejoin.""",
         kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("A mute can't take longer than 1 year"))
     }
 
+    @Test
+    fun `mute modal for present member schedules unmute only after role assignment succeeds`() {
+        val embedCaptor = argumentCaptor<net.dv8tion.jda.api.EmbedBuilder>()
+        val resultCaptor = argumentCaptor<String>()
+        val plannedUnmute = OffsetDateTime.now().plusDays(3)
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3, targetMemberPresent = true)
+        whenever(unmutePlanningService.planUnmute(guild, 99L, member, 3)).thenReturn(plannedUnmute)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(muteService).muteUserById(1L, 99L)
+        verify(unmutePlanningService).planUnmute(guild, 99L, member, 3)
+        verify(guildLogger).log(
+            embedCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
+        verify(interactionHook).editOriginal(resultCaptor.capture())
+        kotlin.test.assertEquals(
+            "3 days mute",
+            embedCaptor.firstValue.build().fields.single { it.name == "Punishment" }.value
+        )
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Unmute planned for"))
+    }
+
+    @Test
+    fun `mute modal for present member does not persist mute or schedule unmute when role assignment fails`() {
+        val embedCaptor = argumentCaptor<net.dv8tion.jda.api.EmbedBuilder>()
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3, targetMemberPresent = true, muteRoleAssignmentSucceeds = false)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(muteService, never()).muteUserById(any(), any())
+        verify(unmutePlanningService, never()).planUnmute(any(), any(), any(), any())
+        verify(guildLogger).log(
+            embedCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull()
+        )
+        verify(interactionHook).editOriginal(resultCaptor.capture())
+        kotlin.test.assertEquals(
+            null,
+            embedCaptor.firstValue.build().fields.singleOrNull { it.name == "Punishment" }
+        )
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Unable to add mute role to user."))
+        kotlin.test.assertEquals(false, resultCaptor.firstValue.contains("Unmute planned for"))
+    }
+
     private fun stubSlashContext(
         targetMember: Member?,
         action: Int = 0
@@ -372,7 +429,12 @@ The user was not warned by DM, please do so manually when they rejoin.""",
         )
     }
 
-    private fun stubSuccessfulMuteModalFlow(unmuteDays: Int?) {
+    @Suppress("UNCHECKED_CAST")
+    private fun stubSuccessfulMuteModalFlow(
+        unmuteDays: Int?,
+        targetMemberPresent: Boolean = false,
+        muteRoleAssignmentSucceeds: Boolean = true
+    ) {
         val warnPoint = warnPoint()
         val settings = settings()
 
@@ -386,7 +448,8 @@ The user was not warned by DM, please do so manually when they rejoin.""",
         whenever(member.user).thenReturn(moderatorUser)
         whenever(moderatorUser.name).thenReturn("ModeratorUser")
         whenever(guild.idLong).thenReturn(1L)
-        whenever(guild.getMemberById(99L)).thenReturn(null)
+        whenever(guild.getMemberById(99L)).thenReturn(if (targetMemberPresent) targetMember else null)
+        whenever(member.canInteract(targetMember)).thenReturn(true)
         whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
         whenever(reasonValue.asString).thenReturn("Spamming")
         whenever(modalEvent.getValue("unmute_days")).thenReturn(unmuteDaysValue)
@@ -407,6 +470,23 @@ The user was not warned by DM, please do so manually when they rejoin.""",
         whenever(modalEvent.deferReply(true)).thenReturn(replyAction)
         whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
         whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
+        whenever(targetMember.asMention).thenReturn("<@99>")
+        whenever(targetMember.user).thenReturn(targetUser)
+        whenever(guild.addRoleToMember(targetMember, muteRole)).thenReturn(addRoleAction)
+        whenever(addRoleAction.reason("Spamming")).thenReturn(addRoleAction)
+        if (muteRoleAssignmentSucceeds) {
+            doAnswer {
+                val success = it.arguments[0] as Consumer<Void?>
+                success.accept(null)
+                null
+            }.whenever(addRoleAction).queue(any<Consumer<Void?>>(), any<Consumer<Throwable>>())
+        } else {
+            doAnswer {
+                val failure = it.arguments[1] as Consumer<Throwable>
+                failure.accept(IllegalStateException("Missing permissions"))
+                null
+            }.whenever(addRoleAction).queue(any<Consumer<Void?>>(), any<Consumer<Throwable>>())
+        }
         doQueue(replyAction)
     }
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
@@ -372,7 +372,14 @@ class AddWarnPointsCommandTest {
 
         verify(unmutePlanningService).planUnmute(guild, 99L, member, 3)
         verify(hook).sendMessage(resultCaptor.capture())
-        kotlin.test.assertEquals("Error: Scheduler unavailable", resultCaptor.firstValue)
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Added warn points to $targetMember and applied the mute role."))
+        kotlin.test.assertEquals(
+            true,
+            resultCaptor.firstValue.contains(
+                "A follow-up step failed, so logging or notification may need manual checking."
+            )
+        )
+        kotlin.test.assertEquals(false, resultCaptor.firstValue.contains("Scheduler unavailable"))
     }
 
     @Test
@@ -386,7 +393,15 @@ class AddWarnPointsCommandTest {
         command.onModalInteraction(modalEvent)
 
         verify(hook).sendMessage(resultCaptor.capture())
-        kotlin.test.assertEquals("Error: Logger unavailable", resultCaptor.firstValue)
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Added warn points to $targetMember."))
+        kotlin.test.assertEquals(true, resultCaptor.firstValue.contains("Unable to add mute role to user."))
+        kotlin.test.assertEquals(
+            true,
+            resultCaptor.firstValue.contains(
+                "A follow-up step failed, so logging or notification may need manual checking."
+            )
+        )
+        kotlin.test.assertEquals(false, resultCaptor.firstValue.contains("Logger unavailable"))
     }
 
     private fun stubSlashCommand(action: Int) {

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
@@ -364,15 +364,14 @@ class AddWarnPointsCommandTest {
         val resultCaptor = argumentCaptor<String>()
 
         stubSuccessfulMuteModalFlow(unmuteDays = 3)
-        whenever(hook.editOriginal(any<String>())).thenReturn(editAction)
+        whenever(hook.sendMessage(any<String>())).thenReturn(followupAction)
         whenever(unmutePlanningService.planUnmute(guild, 99L, member, 3))
             .thenThrow(RuntimeException("Scheduler unavailable"))
 
         command.onModalInteraction(modalEvent)
 
         verify(unmutePlanningService).planUnmute(guild, 99L, member, 3)
-        verify(hook).editOriginal(resultCaptor.capture())
-        verify(hook, never()).sendMessage(any<String>())
+        verify(hook).sendMessage(resultCaptor.capture())
         kotlin.test.assertEquals("Error: Scheduler unavailable", resultCaptor.firstValue)
     }
 
@@ -381,13 +380,12 @@ class AddWarnPointsCommandTest {
         val resultCaptor = argumentCaptor<String>()
 
         stubSuccessfulMuteModalFlow(unmuteDays = 3, muteRoleAssignmentSucceeds = false)
-        whenever(hook.editOriginal(any<String>())).thenReturn(editAction)
+        whenever(hook.sendMessage(any<String>())).thenReturn(followupAction)
         whenever(jda.registeredListeners).thenThrow(RuntimeException("Logger unavailable"))
 
         command.onModalInteraction(modalEvent)
 
-        verify(hook).editOriginal(resultCaptor.capture())
-        verify(hook, never()).sendMessage(any<String>())
+        verify(hook).sendMessage(resultCaptor.capture())
         kotlin.test.assertEquals("Error: Logger unavailable", resultCaptor.firstValue)
     }
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
 import net.dv8tion.jda.api.requests.restaction.CacheRestAction
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.BeforeEach
@@ -93,6 +94,9 @@ class AddWarnPointsCommandTest {
 
     @Mock
     private lateinit var followupAction: WebhookMessageCreateAction<Message>
+
+    @Mock
+    private lateinit var editAction: WebhookMessageEditAction<Message>
 
     @Mock
     private lateinit var userOption: OptionMapping
@@ -353,6 +357,38 @@ class AddWarnPointsCommandTest {
             true,
             resultCaptor.firstValue.contains("Unmute cannot be scheduled beyond 365 days.")
         )
+    }
+
+    @Test
+    fun `mute modal completes deferred reply when unexpected unmute planning fails`() {
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3)
+        whenever(hook.editOriginal(any<String>())).thenReturn(editAction)
+        whenever(unmutePlanningService.planUnmute(guild, 99L, member, 3))
+            .thenThrow(RuntimeException("Scheduler unavailable"))
+
+        command.onModalInteraction(modalEvent)
+
+        verify(unmutePlanningService).planUnmute(guild, 99L, member, 3)
+        verify(hook).editOriginal(resultCaptor.capture())
+        verify(hook, never()).sendMessage(any<String>())
+        kotlin.test.assertEquals("Error: Scheduler unavailable", resultCaptor.firstValue)
+    }
+
+    @Test
+    fun `mute modal completes deferred reply when role assignment failure handling throws`() {
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3, muteRoleAssignmentSucceeds = false)
+        whenever(hook.editOriginal(any<String>())).thenReturn(editAction)
+        whenever(jda.registeredListeners).thenThrow(RuntimeException("Logger unavailable"))
+
+        command.onModalInteraction(modalEvent)
+
+        verify(hook).editOriginal(resultCaptor.capture())
+        verify(hook, never()).sendMessage(any<String>())
+        kotlin.test.assertEquals("Error: Logger unavailable", resultCaptor.firstValue)
     }
 
     private fun stubSlashCommand(action: Int) {


### PR DESCRIPTION
## Summary
- add optional unmute scheduling to the warn-by-id mute modal
- mirror the standard warn flow's unmute validation and fallback behavior
- extend tests for the by-id modal, scheduling, and fallback cases

## Testing
- `.\gradlew.bat test --tests "be.duncanc.discordmodbot.moderation.AddWarnPointsByIdCommandTest"`
