### PR TITLE
fix(narouNovelApi): alert on revision updates

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommand.kt
@@ -172,6 +172,9 @@ class NarouNovelConfigCommand(
         if (settings.lastAlertedGeneralAllNo == null) {
             settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
         }
+        if (settings.lastAlertedNovelUpdatedAt == null) {
+            settings.lastAlertedNovelUpdatedAt = snapshot.novelUpdatedAt
+        }
     }
 
     private fun clearAlertConfiguration(guildId: Long) {

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingService.kt
@@ -61,7 +61,7 @@ class NarouNovelPollingService(
                     updatedAt = payload.updatedAt
                 )
             )
-            initializeMissingBaselines(payload.length, payload.generalAllNo)
+            initializeMissingBaselines(payload.length, payload.generalAllNo, payload.novelUpdatedAt)
             return
         }
 
@@ -105,30 +105,38 @@ class NarouNovelPollingService(
 
             val lastAlertedLength = settings.lastAlertedLength ?: return@forEach
             val lastAlertedGeneralAllNo = settings.lastAlertedGeneralAllNo ?: return@forEach
+            val lastAlertedNovelUpdatedAt = settings.lastAlertedNovelUpdatedAt ?: return@forEach
             val lengthDelta = snapshot.length - lastAlertedLength
             val chapterDelta = snapshot.generalAllNo - lastAlertedGeneralAllNo
             val lengthTriggered = lengthDelta >= settings.lengthThreshold
             val chapterTriggered = chapterDelta > 0
-            if (!lengthTriggered && !chapterTriggered) {
+            val novelUpdatedTriggered = snapshot.novelUpdatedAt != lastAlertedNovelUpdatedAt
+            if (!lengthTriggered && !chapterTriggered && !novelUpdatedTriggered) {
                 return@forEach
             }
 
             val pendingAlert = narouNovelPendingAlertRepository.findById(settings.guildId).orElse(null)
             if (pendingAlert != null) {
-                if (pendingAlert.snapshotGeneralAllNo == snapshot.generalAllNo && pendingAlert.snapshotLength == snapshot.length) {
+                if (
+                    pendingAlert.snapshotGeneralAllNo == snapshot.generalAllNo &&
+                    pendingAlert.snapshotLength == snapshot.length &&
+                    pendingAlert.snapshotNovelUpdatedAt == snapshot.novelUpdatedAt
+                ) {
                     LOG.debug(
-                        "Skipping Narou novel alert for guild {} because snapshot {}:{} was already sent or is still being finalized",
+                        "Skipping Narou novel alert for guild {} because snapshot {}:{}:{} was already sent or is still being finalized",
                         settings.guildId,
                         pendingAlert.snapshotGeneralAllNo,
-                        pendingAlert.snapshotLength
+                        pendingAlert.snapshotLength,
+                        pendingAlert.snapshotNovelUpdatedAt
                     )
                     return@forEach
                 }
                 LOG.debug(
-                    "Skipping Narou novel alert for guild {} because a pending alert lock exists for snapshot {}:{}",
+                    "Skipping Narou novel alert for guild {} because a pending alert lock exists for snapshot {}:{}:{}",
                     settings.guildId,
                     pendingAlert.snapshotGeneralAllNo,
-                    pendingAlert.snapshotLength
+                    pendingAlert.snapshotLength,
+                    pendingAlert.snapshotNovelUpdatedAt
                 )
                 return@forEach
             }
@@ -149,6 +157,7 @@ class NarouNovelPollingService(
                 lengthDelta,
                 chapterTriggered,
                 chapterDelta,
+                novelUpdatedTriggered,
                 snapshot
             )
             val messageContent = resolveAlertMention(settings)
@@ -156,7 +165,8 @@ class NarouNovelPollingService(
                 NarouNovelPendingAlert(
                     guildId = settings.guildId,
                     snapshotLength = snapshot.length,
-                    snapshotGeneralAllNo = snapshot.generalAllNo
+                    snapshotGeneralAllNo = snapshot.generalAllNo,
+                    snapshotNovelUpdatedAt = snapshot.novelUpdatedAt
                 )
             )
             try {
@@ -171,6 +181,9 @@ class NarouNovelPollingService(
                             }
                             if (chapterTriggered) {
                                 settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
+                            }
+                            if (novelUpdatedTriggered) {
+                                settings.lastAlertedNovelUpdatedAt = snapshot.novelUpdatedAt
                             }
                             narouNovelAlertSettingsRepository.save(settings)
                             narouNovelPendingAlertRepository.deleteById(settings.guildId)
@@ -275,7 +288,8 @@ class NarouNovelPollingService(
 
     private fun initializeMissingBaselines(
         length: Long,
-        generalAllNo: Int
+        generalAllNo: Int,
+        novelUpdatedAt: String
     ) {
         narouNovelAlertSettingsRepository.findAll().forEach { settings ->
             var changed = false
@@ -285,6 +299,10 @@ class NarouNovelPollingService(
             }
             if (settings.lastAlertedGeneralAllNo == null) {
                 settings.lastAlertedGeneralAllNo = generalAllNo
+                changed = true
+            }
+            if (settings.lastAlertedNovelUpdatedAt == null) {
+                settings.lastAlertedNovelUpdatedAt = novelUpdatedAt
                 changed = true
             }
             if (changed) {
@@ -304,6 +322,13 @@ class NarouNovelPollingService(
         }
         if (settings.lastAlertedGeneralAllNo == null || settings.lastAlertedGeneralAllNo!! > snapshot.generalAllNo) {
             settings.lastAlertedGeneralAllNo = snapshot.generalAllNo
+            changed = true
+        }
+        if (
+            settings.lastAlertedNovelUpdatedAt == null ||
+            settings.lastAlertedNovelUpdatedAt!! > snapshot.novelUpdatedAt
+        ) {
+            settings.lastAlertedNovelUpdatedAt = snapshot.novelUpdatedAt
             changed = true
         }
         if (changed) {
@@ -344,6 +369,7 @@ class NarouNovelPollingService(
         lengthDelta: Long,
         chapterTriggered: Boolean,
         chapterDelta: Int,
+        novelUpdatedTriggered: Boolean,
         snapshot: NarouNovelSnapshot
     ): MessageEmbed {
         val updates = mutableListOf<String>()
@@ -358,14 +384,20 @@ class NarouNovelPollingService(
             updates += "the novel grew by $lengthDelta characters"
         }
 
-        val summary = truncate(updates.joinToString(" and ") + ".", MessageEmbed.DESCRIPTION_MAX_LENGTH)
+        val summary = if (updates.isNotEmpty()) {
+            updates.joinToString(" and ") + "."
+        } else if (novelUpdatedTriggered) {
+            "This might indicate a new chapter has been scheduled or is in the works."
+        } else {
+            throw IllegalStateException("Narou novel alert requires at least one trigger")
+        }
         val chapterLink = truncate(NOVEL_URL + snapshot.generalAllNo, MessageEmbed.VALUE_MAX_LENGTH)
         val nextChapterLink = truncate(NOVEL_URL + (snapshot.generalAllNo + 1), MessageEmbed.VALUE_MAX_LENGTH)
 
         val embedBuilder = EmbedBuilder()
             .setColor(Color.ORANGE)
             .setTitle(truncate(EMBED_TITLE, MessageEmbed.TITLE_MAX_LENGTH))
-            .setDescription(summary)
+            .setDescription(truncate(summary, MessageEmbed.DESCRIPTION_MAX_LENGTH))
             .addField("Total chapters", snapshot.generalAllNo.toString(), true)
             .addField("Total characters", snapshot.length.toString(), true)
             .addField("Chapter link", chapterLink, false)

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettings.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelAlertSettings.kt
@@ -20,7 +20,9 @@ data class NarouNovelAlertSettings(
     @Column(nullable = true)
     var lastAlertedLength: Long? = null,
     @Column(nullable = true)
-    var lastAlertedGeneralAllNo: Int? = null
+    var lastAlertedGeneralAllNo: Int? = null,
+    @Column(nullable = true)
+    var lastAlertedNovelUpdatedAt: String? = null
 ) {
     companion object {
         const val DEFAULT_LENGTH_THRESHOLD = 1000L

--- a/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelPendingAlert.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/narou/novel/api/persistence/NarouNovelPendingAlert.kt
@@ -8,5 +8,6 @@ data class NarouNovelPendingAlert(
     @Id
     val guildId: Long,
     val snapshotLength: Long,
-    val snapshotGeneralAllNo: Int
+    val snapshotGeneralAllNo: Int,
+    val snapshotNovelUpdatedAt: String
 )

--- a/src/main/resources/db/migration/V15__track_narou_novel_revision_alerts.sql
+++ b/src/main/resources/db/migration/V15__track_narou_novel_revision_alerts.sql
@@ -1,0 +1,2 @@
+alter table narou_novel_alert_settings
+    add column last_alerted_novel_updated_at varchar(32) null;

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelConfigCommandTest.kt
@@ -146,6 +146,7 @@ class NarouNovelConfigCommandTest {
         assertEquals(11L, settingsCaptor.firstValue.channelId)
         assertEquals(9_445_269L, settingsCaptor.firstValue.lastAlertedLength)
         assertEquals(778, settingsCaptor.firstValue.lastAlertedGeneralAllNo)
+        assertEquals("2026-05-15 07:00:36", settingsCaptor.firstValue.lastAlertedNovelUpdatedAt)
         verify(slashEvent).reply("Narou novel alerts will be sent to <#11>.")
     }
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/narou/novel/api/NarouNovelPollingServiceTest.kt
@@ -93,7 +93,8 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_500, generalAllNo = 779)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -126,7 +127,8 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 778)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -160,7 +162,8 @@ class NarouNovelPollingServiceTest {
             pingRoleId = 15L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 778)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -192,7 +195,8 @@ class NarouNovelPollingServiceTest {
             pingRoleId = 15L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 778)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -225,7 +229,8 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -266,7 +271,8 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -284,7 +290,7 @@ class NarouNovelPollingServiceTest {
             chapterLink = "https://ncode.syosetu.com/n2267be/780",
             nextChapterLink = "https://ncode.syosetu.com/n2267be/781"
         )
-        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 780), pendingAlerts[1L])
+        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 780, "2026-05-15 07:00:36"), pendingAlerts[1L])
         verify(narouNovelAlertSettingsRepository, never()).save(settings)
         assertEquals(9_445_269L, settings.lastAlertedLength)
         assertEquals(778, settings.lastAlertedGeneralAllNo)
@@ -298,9 +304,12 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
-        whenever(narouNovelPendingAlertRepository.findById(1L)).thenReturn(Optional.of(NarouNovelPendingAlert(1L, 9_446_500L, 780)))
+        whenever(narouNovelPendingAlertRepository.findById(1L)).thenReturn(
+            Optional.of(NarouNovelPendingAlert(1L, 9_446_500L, 780, "2026-05-15 07:00:36"))
+        )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
         whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
@@ -331,7 +340,8 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -363,7 +373,8 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -376,7 +387,7 @@ class NarouNovelPollingServiceTest {
 
         assertEquals(1, service.sentMessageContents.size)
         assertEquals(1, service.sentEmbeds.size)
-        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 780), pendingAlerts[1L])
+        assertEquals(NarouNovelPendingAlert(1L, 9_446_500L, 780, "2026-05-15 07:00:36"), pendingAlerts[1L])
     }
 
     @Test
@@ -396,7 +407,8 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -435,7 +447,8 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -459,7 +472,8 @@ class NarouNovelPollingServiceTest {
             channelId = 11L,
             lengthThreshold = 1_000L,
             lastAlertedLength = 9_445_269L,
-            lastAlertedGeneralAllNo = 778
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_446_500, generalAllNo = 780)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -482,7 +496,8 @@ class NarouNovelPollingServiceTest {
             guildId = 1L,
             channelId = 11L,
             lastAlertedLength = null,
-            lastAlertedGeneralAllNo = null
+            lastAlertedGeneralAllNo = null,
+            lastAlertedNovelUpdatedAt = null
         )
         whenever(narouNovelApiClient.fetchNovel()).thenReturn(listOf(payload(length = 9_445_500, generalAllNo = 779)))
         whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
@@ -495,15 +510,57 @@ class NarouNovelPollingServiceTest {
         verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
         assertEquals(9_445_500L, settingsCaptor.lastValue.lastAlertedLength)
         assertEquals(779, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+        assertEquals("2026-05-15 07:00:36", settingsCaptor.lastValue.lastAlertedNovelUpdatedAt)
     }
 
-    private fun payload(length: Long, generalAllNo: Int): NarouNovelApiResponseEntry {
+    @Test
+    fun `novel updated alert triggers when only novelupdated at changes`() {
+        stubPendingAlertRepository()
+        val snapshot = snapshot(length = 9_445_269, generalAllNo = 778)
+        val settings = NarouNovelAlertSettings(
+            guildId = 1L,
+            channelId = 11L,
+            lengthThreshold = 1_000L,
+            lastAlertedLength = 9_445_269L,
+            lastAlertedGeneralAllNo = 778,
+            lastAlertedNovelUpdatedAt = "2026-05-15 07:00:36"
+        )
+        whenever(
+            narouNovelApiClient.fetchNovel()
+        ).thenReturn(listOf(payload(length = 9_445_269, generalAllNo = 778, novelUpdatedAt = "2026-05-15 07:05:36")))
+        whenever(narouNovelSnapshotRepository.findById(NarouNovelPollingService.NOVEL_CODE)).thenReturn(Optional.of(snapshot))
+        whenever(narouNovelAlertSettingsRepository.findAll()).thenReturn(listOf(settings))
+        whenever(jda.getTextChannelById(11L)).thenReturn(textChannel)
+
+        service.pollNovel()
+
+        assertAlert(
+            service = service,
+            description = "This might indicate a new chapter has been scheduled or is in the works.",
+            totalChapters = 778,
+            totalCharacters = 9_445_269L,
+            chapterLink = "https://ncode.syosetu.com/n2267be/778",
+            nextChapterLink = "https://ncode.syosetu.com/n2267be/779"
+        )
+        val settingsCaptor = argumentCaptor<NarouNovelAlertSettings>()
+        verify(narouNovelAlertSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(9_445_269L, settingsCaptor.lastValue.lastAlertedLength)
+        assertEquals(778, settingsCaptor.lastValue.lastAlertedGeneralAllNo)
+        assertEquals("2026-05-15 07:05:36", settingsCaptor.lastValue.lastAlertedNovelUpdatedAt)
+        assertEquals(emptyMap<Long, NarouNovelPendingAlert>(), pendingAlerts)
+    }
+
+    private fun payload(
+        length: Long,
+        generalAllNo: Int,
+        novelUpdatedAt: String = "2026-05-15 07:00:36"
+    ): NarouNovelApiResponseEntry {
         return NarouNovelApiResponseEntry(
             generalLastup = "2026-05-15 07:00:00",
             generalAllNo = generalAllNo,
             length = length,
             time = 18_891,
-            novelUpdatedAt = "2026-05-15 07:00:36",
+            novelUpdatedAt = novelUpdatedAt,
             updatedAt = "2026-05-15 20:14:23"
         )
     }


### PR DESCRIPTION
## Summary
- trigger Narou alerts when only novelupdated_at changes
- persist and initialize a per-guild revision baseline for Narou alerts
- dedupe pending revision-only alerts and cover the behavior with tests

## Testing
- .\gradlew.bat cleanTest test