### PR TITLE
fix(moderation): collect reasons with modals & show target in modals

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
@@ -8,6 +8,7 @@ import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettingsRe
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
 import net.dv8tion.jda.api.components.textinput.TextInput
 import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Guild
@@ -567,6 +568,7 @@ class AddWarnPointsByIdCommand(
     }
 
     private fun createReasonModal(targetUserId: Long, points: Int, days: Int, action: Int): Modal {
+        val targetText = TextDisplay.of("Warning: <@$targetUserId> (ID: $targetUserId)")
         val textInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
             .setPlaceholder("Enter the reason for this warning...")
             .setMinLength(1)
@@ -574,7 +576,7 @@ class AddWarnPointsByIdCommand(
             .build()
 
         val modalBuilder = Modal.create("$MODAL_ID:$targetUserId:$points:$days:$action", "Enter Reason")
-            .addComponents(Label.of("Reason", textInput))
+            .addComponents(targetText, Label.of("Reason", textInput))
 
         if (action == 1) {
             val unmuteDaysInput = TextInput.create(UNMUTE_DAYS_INPUT_ID, TextInputStyle.SHORT)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -8,6 +8,7 @@ import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettingsRe
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
 import net.dv8tion.jda.api.components.textinput.TextInput
 import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Member
@@ -566,6 +567,9 @@ class AddWarnPointsCommand(
 
     private fun createReasonModal(targetMember: Member, points: Int, days: Int, action: Int): Modal {
         val modalId = "$MODAL_ID:${targetMember.idLong}:$points:$days:$action"
+        val targetText = TextDisplay.of(
+            "Warning: ${targetMember.nicknameAndUsername} (<@${targetMember.idLong}>, ID: ${targetMember.idLong})"
+        )
         val textInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
             .setPlaceholder("Enter the reason for this warning...")
             .setMinLength(1)
@@ -573,7 +577,7 @@ class AddWarnPointsCommand(
             .build()
 
         val modalBuilder = Modal.create(modalId, "Enter Reason")
-            .addComponents(Label.of("Reason", textInput))
+            .addComponents(targetText, Label.of("Reason", textInput))
 
         if (action == 1) {
             val unmuteDaysInput = TextInput.create(UNMUTE_DAYS_INPUT_ID, TextInputStyle.SHORT)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -36,6 +36,7 @@ class AddWarnPointsCommand(
     private val guildWarnPointsService: GuildWarnPointsService,
     private val guildWarnPointsSettingsRepository: GuildWarnPointsSettingsRepository,
     private val muteRoleCommandAndEventsListener: MuteRoleCommandAndEventsListener,
+    private val muteService: MuteService,
     private val unmutePlanningService: UnmutePlanningService
 ) : ListenerAdapter(), SlashCommand {
     private data class UnmuteSchedulingResult(
@@ -123,10 +124,11 @@ class AddWarnPointsCommand(
             return
         }
 
-        val targetMember = event.guild?.getMemberById(parts[1]) ?: run {
-            event.reply("User not found.").setEphemeral(true).queue()
+        val targetUserId = parts[1].toLongOrNull() ?: run {
+            event.reply("This form is no longer valid.").setEphemeral(true).queue()
             return
         }
+        val targetMember = event.guild?.getMemberById(targetUserId)
 
         val moderator = event.member
         if (moderator == null) {
@@ -139,7 +141,7 @@ class AddWarnPointsCommand(
             return
         }
 
-        if (moderator.canInteract(targetMember) != true) {
+        if (targetMember != null && moderator.canInteract(targetMember) != true) {
             event.reply("You can't interact with this member.").setEphemeral(true).queue()
             return
         }
@@ -194,6 +196,7 @@ class AddWarnPointsCommand(
                     moderator.guild,
                     event.jda,
                     moderator,
+                    targetUserId,
                     targetMember,
                     points,
                     days,
@@ -214,7 +217,8 @@ class AddWarnPointsCommand(
         guild: net.dv8tion.jda.api.entities.Guild,
         jda: net.dv8tion.jda.api.JDA,
         moderator: Member,
-        targetMember: Member,
+        targetUserId: Long,
+        targetMember: Member?,
         points: Int,
         days: Int,
         action: Int,
@@ -224,9 +228,10 @@ class AddWarnPointsCommand(
         hook: InteractionHook
     ) {
         val expireDate = OffsetDateTime.now().plusDays(days.toLong())
+        val targetUser = targetMember?.user ?: jda.retrieveUserById(targetUserId).complete()
 
         val guildWarnPoint = guildWarnPointsService.addWarnPoint(
-            targetMember.idLong,
+            targetUserId,
             guild.idLong,
             points,
             moderator.idLong,
@@ -234,9 +239,9 @@ class AddWarnPointsCommand(
             expireDate
         )
 
-        val totalPoints = guildWarnPointsService.getActivePointsCount(guild.idLong, targetMember.idLong)
+        val totalPoints = guildWarnPointsService.getActivePointsCount(guild.idLong, targetUserId)
 
-        performChecks(guildPointsSettings, targetMember.user, guild)
+        performChecks(guildPointsSettings, targetUser, guild)
 
         when (action) {
             1 -> {
@@ -246,7 +251,9 @@ class AddWarnPointsCommand(
                     finishWarnPointsProcessing(
                         jda,
                         moderator,
+                        targetUserId,
                         targetMember,
+                        targetUser,
                         reason,
                         points,
                         guildWarnPoint.id,
@@ -261,15 +268,42 @@ class AddWarnPointsCommand(
                     return
                 }
 
+                if (targetMember == null) {
+                    muteService.muteUserById(guild.idLong, targetUserId)
+
+                    val unmuteSchedulingResult = scheduleUnmuteIfRequested(guild, targetUserId, moderator, unmuteDays)
+                    finishWarnPointsProcessing(
+                        jda,
+                        moderator,
+                        targetUserId,
+                        null,
+                        targetUser,
+                        reason,
+                        points,
+                        guildWarnPoint.id,
+                        expireDate,
+                        action.toByte(),
+                        unmuteSchedulingResult.effectiveUnmuteDays,
+                        totalPoints,
+                        hook,
+                        unmuteSchedulingResult.unmutePlanMessage,
+                        "User left before the mute could be applied. The mute will be applied when they rejoin."
+                    )
+                    return
+                }
+
                 guild.addRoleToMember(targetMember, muteRole).reason(reason).queue(
                     {
+                        muteService.muteUserById(guild.idLong, targetUserId)
                         try {
                             val unmuteSchedulingResult =
-                                scheduleUnmuteIfRequested(guild, targetMember, moderator, unmuteDays)
+                                scheduleUnmuteIfRequested(guild, targetUserId, moderator, unmuteDays)
                             finishWarnPointsProcessing(
                                 jda,
                                 moderator,
+                                targetUserId,
                                 targetMember,
+                                targetUser,
                                 reason,
                                 points,
                                 guildWarnPoint.id,
@@ -298,7 +332,9 @@ class AddWarnPointsCommand(
                             finishWarnPointsProcessing(
                                 jda,
                                 moderator,
+                                targetUserId,
                                 targetMember,
+                                targetUser,
                                 reason,
                                 points,
                                 guildWarnPoint.id,
@@ -326,6 +362,25 @@ class AddWarnPointsCommand(
             }
 
             2 -> {
+                if (targetMember == null) {
+                    finishWarnPointsProcessing(
+                        jda,
+                        moderator,
+                        targetUserId,
+                        null,
+                        targetUser,
+                        reason,
+                        points,
+                        guildWarnPoint.id,
+                        expireDate,
+                        0,
+                        null,
+                        totalPoints,
+                        hook,
+                        moderatorNote = "User left before the kick could be applied."
+                    )
+                    return
+                }
                 guild.kick(targetMember).reason(reason).queue()
             }
         }
@@ -333,7 +388,9 @@ class AddWarnPointsCommand(
         finishWarnPointsProcessing(
             jda,
             moderator,
+            targetUserId,
             targetMember,
+            targetUser,
             reason,
             points,
             guildWarnPoint.id,
@@ -348,7 +405,9 @@ class AddWarnPointsCommand(
     private fun finishWarnPointsProcessing(
         jda: net.dv8tion.jda.api.JDA,
         moderator: Member,
-        targetMember: Member,
+        targetUserId: Long,
+        targetMember: Member?,
+        targetUser: User,
         reason: String,
         points: Int,
         warnPointId: java.util.UUID,
@@ -363,19 +422,21 @@ class AddWarnPointsCommand(
         logAddPoints(
             jda,
             moderator,
-            targetMember.user,
+            targetUser,
             reason,
             points,
             warnPointId,
             expireDate,
             action,
             unmuteDays,
-            targetMember.guild
+            moderator.guild
         )
 
         informUserAndModerator(
             moderator,
+            targetUserId,
             targetMember,
+            targetUser,
             reason,
             totalPoints,
             hook,
@@ -388,7 +449,7 @@ class AddWarnPointsCommand(
 
     private fun scheduleUnmuteIfRequested(
         guild: net.dv8tion.jda.api.entities.Guild,
-        targetMember: Member,
+        targetUserId: Long,
         moderator: Member,
         unmuteDays: Int?
     ): UnmuteSchedulingResult {
@@ -397,7 +458,7 @@ class AddWarnPointsCommand(
         }
 
         return try {
-            val unmuteDateTime = unmutePlanningService.planUnmute(guild, targetMember.idLong, moderator, unmuteDays)
+            val unmuteDateTime = unmutePlanningService.planUnmute(guild, targetUserId, moderator, unmuteDays)
             UnmuteSchedulingResult(
                 effectiveUnmuteDays = unmuteDays,
                 unmutePlanMessage = "Unmute planned for ${TimeFormat.DATE_SHORT_TIME_SHORT.atInstant(unmuteDateTime.toInstant())}."
@@ -468,7 +529,7 @@ class AddWarnPointsCommand(
                 .setColor(Color.YELLOW)
                 .setTitle("Warn points added to user")
                 .addField("UUID", id.toString(), false)
-                .addField("User", guild.getMember(toInform)?.nicknameAndUsername ?: toInform.name, true)
+                .addField("User", guild.getMember(toInform)?.nicknameAndUsername ?: "<@${toInform.idLong}>", true)
                 .addField("Moderator", moderator.nicknameAndUsername, true)
                 .addField("Amount", amount.toString(), false)
                 .addField("Reason", reason, false)
@@ -484,7 +545,9 @@ class AddWarnPointsCommand(
 
     private fun informUserAndModerator(
         moderator: Member,
-        toInform: Member,
+        targetUserId: Long,
+        toInform: Member?,
+        targetUser: User,
         reason: String,
         amountOfWarnings: Int,
         hook: InteractionHook,
@@ -518,25 +581,37 @@ class AddWarnPointsCommand(
             }
             .build()
 
-        toInform.user.openPrivateChannel().queue(
+        targetUser.openPrivateChannel().queue(
             { privateChannelUserToWarn ->
                 privateChannelUserToWarn.sendMessageEmbeds(userWarning).queue(
-                    { onSuccessfulInformUser(hook, toInform, userWarning, unmutePlanMessage, moderatorNote) }
-                ) { throwable -> onFailToInformUser(hook, toInform, throwable, unmutePlanMessage, moderatorNote) }
+                    {
+                        onSuccessfulInformUser(
+                            hook,
+                            targetUserId,
+                            toInform,
+                            userWarning,
+                            unmutePlanMessage,
+                            moderatorNote
+                        )
+                    }
+                ) {
+                    throwable -> onFailToInformUser(hook, targetUserId, toInform, throwable, unmutePlanMessage, moderatorNote)
+                }
             }
-        ) { throwable -> onFailToInformUser(hook, toInform, throwable, unmutePlanMessage, moderatorNote) }
+        ) { throwable -> onFailToInformUser(hook, targetUserId, toInform, throwable, unmutePlanMessage, moderatorNote) }
     }
 
     private fun onSuccessfulInformUser(
         hook: InteractionHook,
-        toInform: Member,
+        targetUserId: Long,
+        toInform: Member?,
         informationMessage: MessageEmbed,
         unmutePlanMessage: String?,
         moderatorNote: String?
     ) {
         hook.sendMessage(
             buildModeratorResultMessage(
-                "Added warn points to $toInform.",
+                "Added warn points to ${toInform ?: "<@$targetUserId>"}.",
                 "The following message was sent to the user:",
                 unmutePlanMessage,
                 moderatorNote
@@ -548,14 +623,15 @@ class AddWarnPointsCommand(
 
     private fun onFailToInformUser(
         hook: InteractionHook,
-        toInform: Member,
+        targetUserId: Long,
+        toInform: Member?,
         throwable: Throwable,
         unmutePlanMessage: String?,
         moderatorNote: String?
     ) {
         hook.sendMessage(
             buildModeratorResultMessage(
-                "Added warn points to $toInform.",
+                "Added warn points to ${toInform ?: "<@$targetUserId>"}.",
                 "Was unable to send a DM to the user please inform the user manually.\nError: ${throwable.message}",
                 unmutePlanMessage,
                 moderatorNote

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanCommand.kt
@@ -5,8 +5,13 @@ import be.duncanc.discordmodbot.discord.nicknameAndUsername
 import be.duncanc.discordmodbot.logging.GuildLogger
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
@@ -14,6 +19,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import net.dv8tion.jda.api.modals.Modal
 import net.dv8tion.jda.api.requests.RestAction
 import org.springframework.stereotype.Component
 import java.awt.Color
@@ -26,7 +32,8 @@ class BanCommand : ListenerAdapter(), SlashCommand {
         private const val DESCRIPTION =
             "Will ban the mentioned user, clear all messages from the last 7 days and log it to the log channel."
         private const val OPTION_USER = "user"
-        private const val OPTION_REASON = "reason"
+        private const val MODAL_ID = "ban_reason"
+        private const val REASON_INPUT_ID = "reason"
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
@@ -54,8 +61,55 @@ class BanCommand : ListenerAdapter(), SlashCommand {
             return
         }
 
-        val reason = event.getOption(OPTION_REASON)?.asString ?: "No reason provided"
+        event.replyModal(createReasonModal(targetMember)).queue()
+    }
 
+    override fun onModalInteraction(event: ModalInteractionEvent) {
+        if (!event.modalId.startsWith("$MODAL_ID:")) return
+
+        val targetMemberId = event.modalId.removePrefix("$MODAL_ID:").toLongOrNull()
+        if (targetMemberId == null) {
+            event.reply("This form is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+
+        val member = event.member
+        if (member == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.hasPermission(Permission.BAN_MEMBERS)) {
+            event.reply("You need ban members permission to use this command.").setEphemeral(true).queue()
+            return
+        }
+
+        val targetMember = event.guild?.getMemberById(targetMemberId)
+        if (targetMember == null) {
+            event.reply("User not found.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.canInteract(targetMember)) {
+            event.reply("You can't ban a user that you can't interact with.").setEphemeral(true).queue()
+            return
+        }
+
+        val reason = event.getValue(REASON_INPUT_ID)?.asString?.trim().orEmpty()
+        if (reason.isBlank()) {
+            event.reply("Please provide a reason.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reason.length > 1024) {
+            event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
+            return
+        }
+
+        processBan(event, member, targetMember, reason)
+    }
+
+    private fun processBan(event: ModalInteractionEvent, member: Member, targetMember: Member, reason: String) {
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
             val banRestAction = guild.ban(targetMember, 7, TimeUnit.DAYS)
@@ -90,7 +144,7 @@ class BanCommand : ListenerAdapter(), SlashCommand {
     }
 
     private fun logBan(
-        event: SlashCommandInteractionEvent,
+        event: ModalInteractionEvent,
         reason: String,
         toBan: Member
     ) {
@@ -110,7 +164,7 @@ class BanCommand : ListenerAdapter(), SlashCommand {
     }
 
     private fun onSuccessfulInformUser(
-        event: SlashCommandInteractionEvent,
+        event: ModalInteractionEvent,
         reason: String,
         hook: net.dv8tion.jda.api.interactions.InteractionHook,
         toBan: Member,
@@ -131,7 +185,7 @@ class BanCommand : ListenerAdapter(), SlashCommand {
     }
 
     private fun onFailToInformUser(
-        event: SlashCommandInteractionEvent,
+        event: ModalInteractionEvent,
         reason: String,
         hook: net.dv8tion.jda.api.interactions.InteractionHook,
         toBan: Member,
@@ -160,9 +214,23 @@ Error: ${throwable.message}"""
             Commands.slash(COMMAND, DESCRIPTION)
                 .addOptions(
                     OptionData(OptionType.USER, OPTION_USER, "The user to ban").setRequired(true),
-                    OptionData(OptionType.STRING, OPTION_REASON, "The reason for the ban").setRequired(true)
                 )
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.BAN_MEMBERS))
         )
+    }
+
+    private fun createReasonModal(targetMember: Member): Modal {
+        val targetText = TextDisplay.of(
+            "Banning: ${targetMember.nicknameAndUsername} (<@${targetMember.idLong}>, ID: ${targetMember.idLong})"
+        )
+        val reasonInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
+            .setPlaceholder("Enter the reason for this ban...")
+            .setMinLength(1)
+            .setMaxLength(1024)
+            .build()
+
+        return Modal.create("$MODAL_ID:${targetMember.idLong}", "Enter Reason")
+            .addComponents(targetText, Label.of("Reason", reasonInput))
+            .build()
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanCommand.kt
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.components.textinput.TextInput
 import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
@@ -85,12 +86,7 @@ class BanCommand : ListenerAdapter(), SlashCommand {
         }
 
         val targetMember = event.guild?.getMemberById(targetMemberId)
-        if (targetMember == null) {
-            event.reply("User not found.").setEphemeral(true).queue()
-            return
-        }
-
-        if (!member.canInteract(targetMember)) {
+        if (targetMember != null && !member.canInteract(targetMember)) {
             event.reply("You can't ban a user that you can't interact with.").setEphemeral(true).queue()
             return
         }
@@ -106,7 +102,12 @@ class BanCommand : ListenerAdapter(), SlashCommand {
             return
         }
 
-        processBan(event, member, targetMember, reason)
+        if (targetMember != null) {
+            processBan(event, member, targetMember, reason)
+            return
+        }
+
+        processBanById(event, member, targetMemberId, reason)
     }
 
     private fun processBan(event: ModalInteractionEvent, member: Member, targetMember: Member, reason: String) {
@@ -143,6 +144,58 @@ class BanCommand : ListenerAdapter(), SlashCommand {
         }
     }
 
+    private fun processBanById(event: ModalInteractionEvent, member: Member, targetUserId: Long, reason: String) {
+        event.deferReply(true).queue { hook ->
+            val guild = event.guild!!
+            val banRestAction = guild.ban(User.fromId(targetUserId), 7, TimeUnit.DAYS)
+
+            event.jda.retrieveUserById(targetUserId).queue(
+                { targetUser ->
+                    val userBanNotification = buildBanNotification(guild, member, reason)
+                    targetUser.openPrivateChannel().queue(
+                        { privateChannelUserToBan ->
+                            privateChannelUserToBan.sendMessageEmbeds(userBanNotification).queue(
+                                { message ->
+                                    onSuccessfulInformUser(event, reason, hook, targetUser, message, banRestAction)
+                                }
+                            ) { throwable ->
+                                onFailToInformUser(event, reason, hook, targetUser, throwable, banRestAction)
+                            }
+                        }
+                    ) { throwable -> onFailToInformUser(event, reason, hook, targetUser, throwable, banRestAction) }
+                },
+                {
+                    banRestAction.queue({
+                        logBan(event, reason, targetUserId)
+                        hook.editOriginal("Banned <@$targetUserId>.").queue()
+                    }) { throwable ->
+                        hook.editOriginal("Ban failed on <@$targetUserId>: ${throwable.message}").queue()
+                    }
+                }
+            )
+        }
+    }
+
+    private fun buildBanNotification(guild: net.dv8tion.jda.api.entities.Guild, member: Member, reason: String) =
+        EmbedBuilder()
+            .setColor(Color.red)
+            .setAuthor(member.nicknameAndUsername, null, member.user.effectiveAvatarUrl)
+            .setTitle(guild.name + ": You have been banned by " + member.nicknameAndUsername, null)
+            .setDescription(buildBanDescription(guild, reason))
+            .build()
+
+    private fun buildBanDescription(guild: net.dv8tion.jda.api.entities.Guild, reason: String): String {
+        val description = StringBuilder("Reason: $reason")
+        if (guild.idLong == 175856762677624832L) {
+            description.append("\n\n")
+                .append("If you'd like to appeal the ban, please use this form: https://goo.gl/forms/SpWg49gaQlMt4lSG3")
+        } else if (guild.idLong == 176028172729450497L) {
+            description.append("\n\n")
+                .append("If you'd like to appeal the ban, please use this form: https://forms.gle/ffbDj12KcSyTT7mUA")
+        }
+        return description.toString()
+    }
+
     private fun logBan(
         event: ModalInteractionEvent,
         reason: String,
@@ -163,6 +216,22 @@ class BanCommand : ListenerAdapter(), SlashCommand {
         }
     }
 
+    private fun logBan(event: ModalInteractionEvent, reason: String, targetUserId: Long, user: User? = null) {
+        val guild = event.guild!!
+        val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
+        if (guildLogger != null) {
+            val logEmbed = EmbedBuilder()
+                .setColor(Color.RED)
+                .setTitle("User banned")
+                .addField("UUID", java.util.UUID.randomUUID().toString(), false)
+                .addField("User", user?.name ?: "<@$targetUserId>", true)
+                .addField("Moderator", event.member!!.nicknameAndUsername, true)
+                .addField("Reason", reason, false)
+
+            guildLogger.log(logEmbed, user, guild, null, GuildLogger.LogTypeAction.MODERATOR)
+        }
+    }
+
     private fun onSuccessfulInformUser(
         event: ModalInteractionEvent,
         reason: String,
@@ -180,6 +249,27 @@ class BanCommand : ListenerAdapter(), SlashCommand {
             userBanWarning.delete().queue()
             hook.editOriginal(
                 "Ban failed on $toBan: ${throwable.message}\n\nThe following message was sent to the user but was automatically deleted:"
+            ).setEmbeds(userBanWarning.embeds).queue()
+        }
+    }
+
+    private fun onSuccessfulInformUser(
+        event: ModalInteractionEvent,
+        reason: String,
+        hook: net.dv8tion.jda.api.interactions.InteractionHook,
+        toBan: User,
+        userBanWarning: Message,
+        banRestAction: RestAction<Void>
+    ) {
+        banRestAction.queue({
+            logBan(event, reason, toBan.idLong, toBan)
+            hook.editOriginal(
+                "Banned <@${toBan.idLong}>.\n\nThe following message was sent to the user:"
+            ).setEmbeds(userBanWarning.embeds).queue()
+        }) { throwable ->
+            userBanWarning.delete().queue()
+            hook.editOriginal(
+                "Ban failed on <@${toBan.idLong}>: ${throwable.message}\n\nThe following message was sent to the user but was automatically deleted:"
             ).setEmbeds(userBanWarning.embeds).queue()
         }
     }
@@ -205,6 +295,31 @@ Error: ${throwable.message}"""
         }) { banThrowable ->
             hook.editOriginal(
                 "Ban failed on $toBan: ${banThrowable.message}\n\nWas unable to send a DM to the user.\nError: ${throwable.message}"
+            ).queue()
+        }
+    }
+
+    private fun onFailToInformUser(
+        event: ModalInteractionEvent,
+        reason: String,
+        hook: net.dv8tion.jda.api.interactions.InteractionHook,
+        toBan: User,
+        throwable: Throwable,
+        banRestAction: RestAction<Void>
+    ) {
+        banRestAction.queue({
+            logBan(event, reason, toBan.idLong, toBan)
+
+            val msg =
+                """Banned <@${toBan.idLong}>.
+
+Was unable to send a DM to the user please inform the user manually, if possible.
+Error: ${throwable.message}"""
+
+            hook.editOriginal(msg).queue()
+        }) { banThrowable ->
+            hook.editOriginal(
+                "Ban failed on <@${toBan.idLong}>: ${banThrowable.message}\n\nWas unable to send a DM to the user.\nError: ${throwable.message}"
             ).queue()
         }
     }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanUserByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanUserByIdCommand.kt
@@ -5,16 +5,25 @@ import be.duncanc.discordmodbot.discord.nicknameAndUsername
 import be.duncanc.discordmodbot.logging.GuildLogger
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import net.dv8tion.jda.api.modals.Modal
 import org.springframework.stereotype.Component
 import java.awt.Color
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 @Component
 class BanUserByIdCommand : ListenerAdapter(), SlashCommand {
@@ -23,7 +32,8 @@ class BanUserByIdCommand : ListenerAdapter(), SlashCommand {
         private const val DESCRIPTION =
             "Ban the user with the given ID, clear all messages from the last 24 hours and log to log channel."
         private const val OPTION_USER_ID = "user_id"
-        private const val OPTION_REASON = "reason"
+        private const val MODAL_ID = "banbyid_reason"
+        private const val REASON_INPUT_ID = "reason"
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
@@ -53,8 +63,49 @@ class BanUserByIdCommand : ListenerAdapter(), SlashCommand {
             return
         }
 
-        val reason = event.getOption(OPTION_REASON)?.asString ?: "No reason provided"
+        event.replyModal(createReasonModal(userId)).queue()
+    }
 
+    override fun onModalInteraction(event: ModalInteractionEvent) {
+        if (!event.modalId.startsWith("$MODAL_ID:")) return
+
+        val userId = event.modalId.removePrefix("$MODAL_ID:").toLongOrNull()
+        if (userId == null) {
+            event.reply("This form is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+
+        val member = event.member
+        if (member == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.hasPermission(Permission.BAN_MEMBERS)) {
+            event.reply("You need ban members permission to use this command.").setEphemeral(true).queue()
+            return
+        }
+
+        val reason = event.getValue(REASON_INPUT_ID)?.asString?.trim().orEmpty()
+        if (reason.isBlank()) {
+            event.reply("Please provide a reason.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reason.length > 1024) {
+            event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
+            return
+        }
+
+        processBanById(event, member, userId, reason)
+    }
+
+    private fun processBanById(
+        event: ModalInteractionEvent,
+        member: Member,
+        userId: Long,
+        reason: String
+    ) {
         event.deferReply(true).queue { hook ->
             event.jda.retrieveUserById(userId).queue({ toBan ->
                 val guild = event.guild!!
@@ -65,9 +116,9 @@ class BanUserByIdCommand : ListenerAdapter(), SlashCommand {
                 }
 
                 guild.ban(
-                    net.dv8tion.jda.api.entities.User.fromId(userId),
+                    User.fromId(userId),
                     1,
-                    java.util.concurrent.TimeUnit.DAYS
+                    TimeUnit.DAYS
                 ).queue({
                     val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
                     if (guildLogger != null) {
@@ -97,9 +148,21 @@ class BanUserByIdCommand : ListenerAdapter(), SlashCommand {
             Commands.slash(COMMAND, DESCRIPTION)
                 .addOptions(
                     OptionData(OptionType.STRING, OPTION_USER_ID, "The user ID to ban").setRequired(true),
-                    OptionData(OptionType.STRING, OPTION_REASON, "The reason for the ban").setRequired(true)
                 )
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.BAN_MEMBERS))
         )
+    }
+
+    private fun createReasonModal(userId: Long): Modal {
+        val targetText = TextDisplay.of("Banning: <@$userId> (ID: $userId)")
+        val reasonInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
+            .setPlaceholder("Enter the reason for this ban...")
+            .setMinLength(1)
+            .setMaxLength(1024)
+            .build()
+
+        return Modal.create("$MODAL_ID:$userId", "Enter Reason")
+            .addComponents(targetText, Label.of("Reason", reasonInput))
+            .build()
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/KickCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/KickCommand.kt
@@ -86,7 +86,7 @@ class KickCommand : ListenerAdapter(), SlashCommand {
 
         val targetMember = event.guild?.getMemberById(targetMemberId)
         if (targetMember == null) {
-            event.reply("User not found.").setEphemeral(true).queue()
+            event.reply("User left before the kick could be applied.").setEphemeral(true).queue()
             return
         }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/KickCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/KickCommand.kt
@@ -5,8 +5,13 @@ import be.duncanc.discordmodbot.discord.nicknameAndUsername
 import be.duncanc.discordmodbot.logging.GuildLogger
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionHook
@@ -15,6 +20,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import net.dv8tion.jda.api.modals.Modal
 import net.dv8tion.jda.api.requests.RestAction
 import org.springframework.stereotype.Component
 import java.awt.Color
@@ -26,7 +32,8 @@ class KickCommand : ListenerAdapter(), SlashCommand {
         private const val COMMAND = "kick"
         private const val DESCRIPTION = "This command will kick the mentioned user and log this to the log channel."
         private const val OPTION_USER = "user"
-        private const val OPTION_REASON = "reason"
+        private const val MODAL_ID = "kick_reason"
+        private const val REASON_INPUT_ID = "reason"
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
@@ -54,8 +61,55 @@ class KickCommand : ListenerAdapter(), SlashCommand {
             return
         }
 
-        val reason = event.getOption(OPTION_REASON)?.asString ?: "No reason provided"
+        event.replyModal(createReasonModal(targetMember)).queue()
+    }
 
+    override fun onModalInteraction(event: ModalInteractionEvent) {
+        if (!event.modalId.startsWith("$MODAL_ID:")) return
+
+        val targetMemberId = event.modalId.removePrefix("$MODAL_ID:").toLongOrNull()
+        if (targetMemberId == null) {
+            event.reply("This form is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+
+        val member = event.member
+        if (member == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.hasPermission(Permission.KICK_MEMBERS)) {
+            event.reply("You need kick members permission to use this command.").setEphemeral(true).queue()
+            return
+        }
+
+        val targetMember = event.guild?.getMemberById(targetMemberId)
+        if (targetMember == null) {
+            event.reply("User not found.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.canInteract(targetMember)) {
+            event.reply("You can't kick a user that you can't interact with.").setEphemeral(true).queue()
+            return
+        }
+
+        val reason = event.getValue(REASON_INPUT_ID)?.asString?.trim().orEmpty()
+        if (reason.isBlank()) {
+            event.reply("Please provide a reason.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reason.length > 1024) {
+            event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
+            return
+        }
+
+        processKick(event, member, targetMember, reason)
+    }
+
+    private fun processKick(event: ModalInteractionEvent, member: Member, targetMember: Member, reason: String) {
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
             val kickRestAction = guild.kick(targetMember)
@@ -83,7 +137,7 @@ class KickCommand : ListenerAdapter(), SlashCommand {
         }
     }
 
-    private fun logKick(event: SlashCommandInteractionEvent, reason: String, toKick: Member) {
+    private fun logKick(event: ModalInteractionEvent, reason: String, toKick: Member) {
         val guild = event.guild!!
         val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
         if (guildLogger != null) {
@@ -100,7 +154,7 @@ class KickCommand : ListenerAdapter(), SlashCommand {
     }
 
     private fun onSuccessfulInformUser(
-        event: SlashCommandInteractionEvent,
+        event: ModalInteractionEvent,
         reason: String,
         hook: InteractionHook,
         toKick: Member,
@@ -121,7 +175,7 @@ class KickCommand : ListenerAdapter(), SlashCommand {
     }
 
     private fun onFailToInformUser(
-        event: SlashCommandInteractionEvent,
+        event: ModalInteractionEvent,
         reason: String,
         hook: InteractionHook,
         toKick: Member,
@@ -145,9 +199,23 @@ class KickCommand : ListenerAdapter(), SlashCommand {
             Commands.slash(COMMAND, DESCRIPTION)
                 .addOptions(
                     OptionData(OptionType.USER, OPTION_USER, "The user to kick").setRequired(true),
-                    OptionData(OptionType.STRING, OPTION_REASON, "The reason for the kick").setRequired(true)
                 )
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.KICK_MEMBERS))
         )
+    }
+
+    private fun createReasonModal(targetMember: Member): Modal {
+        val targetText = TextDisplay.of(
+            "Kicking: ${targetMember.nicknameAndUsername} (<@${targetMember.idLong}>, ID: ${targetMember.idLong})"
+        )
+        val reasonInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
+            .setPlaceholder("Enter the reason for this kick...")
+            .setMinLength(1)
+            .setMaxLength(1024)
+            .build()
+
+        return Modal.create("$MODAL_ID:${targetMember.idLong}", "Enter Reason")
+            .addComponents(targetText, Label.of("Reason", reasonInput))
+            .build()
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteByIdCommand.kt
@@ -5,6 +5,12 @@ import be.duncanc.discordmodbot.discord.nicknameAndUsername
 import be.duncanc.discordmodbot.logging.GuildLogger
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
@@ -12,6 +18,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import net.dv8tion.jda.api.modals.Modal
 import org.springframework.stereotype.Component
 import java.awt.Color
 import java.util.*
@@ -26,7 +33,8 @@ class MuteByIdCommand(
         private const val COMMAND = "mutebyid"
         private const val DESCRIPTION = "Mute a user by their ID (for users who left the server)"
         private const val OPTION_USER_ID = "user_id"
-        private const val OPTION_REASON = "reason"
+        private const val MODAL_ID = "mutebyid_reason"
+        private const val REASON_INPUT_ID = "reason"
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
@@ -53,8 +61,49 @@ class MuteByIdCommand(
             return
         }
 
-        val reason = event.getOption(OPTION_REASON)?.asString ?: "No reason provided"
+        event.replyModal(createReasonModal(userId)).queue()
+    }
 
+    override fun onModalInteraction(event: ModalInteractionEvent) {
+        if (!event.modalId.startsWith("$MODAL_ID:")) return
+
+        val userId = event.modalId.removePrefix("$MODAL_ID:").toLongOrNull()
+        if (userId == null) {
+            event.reply("This form is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+
+        val member = event.member
+        if (member == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.hasPermission(Permission.MANAGE_ROLES)) {
+            event.reply("You need manage roles permission to mute.").setEphemeral(true).queue()
+            return
+        }
+
+        val reason = event.getValue(REASON_INPUT_ID)?.asString?.trim().orEmpty()
+        if (reason.isBlank()) {
+            event.reply("Please provide a reason.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reason.length > 1024) {
+            event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
+            return
+        }
+
+        processMuteById(event, member, userId, reason)
+    }
+
+    private fun processMuteById(
+        event: ModalInteractionEvent,
+        member: Member,
+        userId: Long,
+        reason: String
+    ) {
         event.deferReply(true).queue { hook ->
             val guild = member.guild
 
@@ -67,11 +116,10 @@ class MuteByIdCommand(
 
             muteService.muteUserById(guild.idLong, userId)
 
-            val targetMember = event.getOption(OPTION_USER_ID)?.asMember
+            val targetMember = guild.getMemberById(userId)
             targetMember?.let {
                 guild.addRoleToMember(it, muteRole).reason(reason).queue()
             }
-
 
             val logEmbed = EmbedBuilder()
                 .setColor(Color.YELLOW)
@@ -103,9 +151,21 @@ class MuteByIdCommand(
             Commands.slash(COMMAND, DESCRIPTION)
                 .addOptions(
                     OptionData(OptionType.USER, OPTION_USER_ID, "The user's Discord ID to mute").setRequired(true),
-                    OptionData(OptionType.STRING, OPTION_REASON, "Reason for mute").setRequired(true)
                 )
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
         )
+    }
+
+    private fun createReasonModal(userId: Long): Modal {
+        val targetText = TextDisplay.of("Muting: <@$userId> (ID: $userId)")
+        val reasonInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
+            .setPlaceholder("Enter the reason for this mute...")
+            .setMinLength(1)
+            .setMaxLength(1024)
+            .build()
+
+        return Modal.create("$MODAL_ID:$userId", "Enter Reason")
+            .addComponents(targetText, Label.of("Reason", reasonInput))
+            .build()
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteCommand.kt
@@ -5,8 +5,13 @@ import be.duncanc.discordmodbot.discord.nicknameAndUsername
 import be.duncanc.discordmodbot.logging.GuildLogger
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionHook
@@ -15,6 +20,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import net.dv8tion.jda.api.modals.Modal
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import org.springframework.stereotype.Component
 import java.awt.Color
@@ -29,7 +35,8 @@ class MuteCommand(
         private const val DESCRIPTION =
             "This command will put a user in the muted role and log the mute to the log channel."
         private const val OPTION_USER = "user"
-        private const val OPTION_REASON = "reason"
+        private const val MODAL_ID = "mute_reason"
+        private const val REASON_INPUT_ID = "reason"
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
@@ -57,8 +64,55 @@ class MuteCommand(
             return
         }
 
-        val reason = event.getOption(OPTION_REASON)?.asString ?: "No reason provided"
+        event.replyModal(createReasonModal(targetMember)).queue()
+    }
 
+    override fun onModalInteraction(event: ModalInteractionEvent) {
+        if (!event.modalId.startsWith("$MODAL_ID:")) return
+
+        val targetMemberId = event.modalId.removePrefix("$MODAL_ID:").toLongOrNull()
+        if (targetMemberId == null) {
+            event.reply("This form is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+
+        val member = event.member
+        if (member == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.hasPermission(Permission.MANAGE_ROLES)) {
+            event.reply("You need manage roles permission to mute.").setEphemeral(true).queue()
+            return
+        }
+
+        val targetMember = event.guild?.getMemberById(targetMemberId)
+        if (targetMember == null) {
+            event.reply("User not found.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.canInteract(targetMember)) {
+            event.reply("You can't mute a user that you can't interact with.").setEphemeral(true).queue()
+            return
+        }
+
+        val reason = event.getValue(REASON_INPUT_ID)?.asString?.trim().orEmpty()
+        if (reason.isBlank()) {
+            event.reply("Please provide a reason.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reason.length > 1024) {
+            event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
+            return
+        }
+
+        processMute(event, member, targetMember, reason)
+    }
+
+    private fun processMute(event: ModalInteractionEvent, member: Member, targetMember: Member, reason: String) {
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
             val muteRole = try {
@@ -142,9 +196,23 @@ Error: ${throwable.message}"""
             Commands.slash(COMMAND, DESCRIPTION)
                 .addOptions(
                     OptionData(OptionType.USER, OPTION_USER, "The user to mute").setRequired(true),
-                    OptionData(OptionType.STRING, OPTION_REASON, "The reason for the mute").setRequired(true)
                 )
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
         )
+    }
+
+    private fun createReasonModal(targetMember: Member): Modal {
+        val targetText = TextDisplay.of(
+            "Muting: ${targetMember.nicknameAndUsername} (<@${targetMember.idLong}>, ID: ${targetMember.idLong})"
+        )
+        val reasonInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
+            .setPlaceholder("Enter the reason for this mute...")
+            .setMinLength(1)
+            .setMaxLength(1024)
+            .build()
+
+        return Modal.create("$MODAL_ID:${targetMember.idLong}", "Enter Reason")
+            .addComponents(targetText, Label.of("Reason", reasonInput))
+            .build()
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteCommand.kt
@@ -28,7 +28,8 @@ import java.util.*
 
 @Component
 class MuteCommand(
-    private val muteRoleCommandAndEventsListener: MuteRoleCommandAndEventsListener
+    private val muteRoleCommandAndEventsListener: MuteRoleCommandAndEventsListener,
+    private val muteService: MuteService
 ) : ListenerAdapter(), SlashCommand {
     companion object {
         private const val COMMAND = "mute"
@@ -88,12 +89,7 @@ class MuteCommand(
         }
 
         val targetMember = event.guild?.getMemberById(targetMemberId)
-        if (targetMember == null) {
-            event.reply("User not found.").setEphemeral(true).queue()
-            return
-        }
-
-        if (!member.canInteract(targetMember)) {
+        if (targetMember != null && !member.canInteract(targetMember)) {
             event.reply("You can't mute a user that you can't interact with.").setEphemeral(true).queue()
             return
         }
@@ -109,10 +105,16 @@ class MuteCommand(
             return
         }
 
-        processMute(event, member, targetMember, reason)
+        processMute(event, member, targetMemberId, targetMember, reason)
     }
 
-    private fun processMute(event: ModalInteractionEvent, member: Member, targetMember: Member, reason: String) {
+    private fun processMute(
+        event: ModalInteractionEvent,
+        member: Member,
+        targetUserId: Long,
+        targetMember: Member?,
+        reason: String
+    ) {
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
             val muteRole = try {
@@ -122,7 +124,30 @@ class MuteCommand(
                 return@queue
             }
 
+            if (targetMember == null) {
+                muteService.muteUserById(guild.idLong, targetUserId)
+
+                val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
+                if (guildLogger != null) {
+                    val logEmbed = EmbedBuilder()
+                        .setColor(Color.YELLOW)
+                        .setTitle("User muted")
+                        .addField("UUID", UUID.randomUUID().toString(), false)
+                        .addField("User", "<@$targetUserId> (left server)", true)
+                        .addField("Moderator", event.member!!.nicknameAndUsername, true)
+                        .addField("Reason", reason, false)
+
+                    guildLogger.log(logEmbed, null, guild, null, GuildLogger.LogTypeAction.MODERATOR)
+                }
+
+                hook.editOriginal(
+                    "User <@$targetUserId> left before the mute could be applied. The mute was recorded and will be applied when they rejoin."
+                ).queue()
+                return@queue
+            }
+
             guild.addRoleToMember(targetMember, muteRole).queue({
+                muteService.muteUserById(guild.idLong, targetUserId)
                 val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
                 if (guildLogger != null) {
                     val logEmbed = EmbedBuilder()

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/RevokeWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/RevokeWarnPointsCommand.kt
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.components.label.Label
 import net.dv8tion.jda.api.components.selections.StringSelectMenu
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
 import net.dv8tion.jda.api.components.textinput.TextInput
 import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Guild
@@ -37,7 +38,6 @@ private const val SUBCOMMAND_DIRECT = "direct"
 private const val SUBCOMMAND_GUIDED = "guided"
 private const val OPTION_USER = "user"
 private const val OPTION_WARN_POINT_ID = "warn_point_id"
-private const val OPTION_REASON = "reason"
 private const val SELECT_MENU_PREFIX = "revokewarnpoints-select"
 private const val PAGE_BUTTON_PREFIX = "revokewarnpoints-page"
 private const val MODAL_PREFIX = "revokewarnpoints-reason"
@@ -200,36 +200,13 @@ class RevokeWarnPointsCommand(
             return
         }
 
-        val reason = event.getOption(OPTION_REASON)?.asString?.trim()
-        if (reason.isNullOrBlank()) {
-            event.reply("You need to provide a reason.").setEphemeral(true).queue()
-            return
-        }
-
-        if (reason.length > 1024) {
-            event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
-            return
-        }
-
         val targetWarning = guildWarnPointsService.getWarningById(warnPointId)
         if (targetWarning == null || targetWarning.guildId != guild.idLong || targetWarning.userId != targetUserId) {
             event.reply("No warn point found with ID `$warnPointIdStr` for this user.").setEphemeral(true).queue()
             return
         }
 
-        guildWarnPointsService.revokePoint(warnPointId)
-        logRevoke(
-            event.jda,
-            guild,
-            targetWarning.id,
-            targetWarning.points,
-            reason,
-            moderator
-        )
-
-        event.reply("Revoked ${targetWarning.points} warn point(s) from <@$targetUserId>. Reason: $reason")
-            .setEphemeral(true)
-            .queue()
+        event.replyModal(createReasonModal(moderator.idLong, targetUserId, warnPointId)).queue()
     }
 
     private fun handleGuidedRevoke(event: SlashCommandInteractionEvent, moderator: Member) {
@@ -347,6 +324,7 @@ class RevokeWarnPointsCommand(
     }
 
     private fun createReasonModal(moderatorId: Long, targetUserId: Long, warnPointId: UUID): Modal {
+        val targetText = TextDisplay.of("Revoking warning from <@$targetUserId>")
         val textInput = TextInput.create(MODAL_REASON_INPUT, TextInputStyle.PARAGRAPH)
             .setPlaceholder("Enter the reason for revoking this warning...")
             .setMinLength(1)
@@ -354,7 +332,7 @@ class RevokeWarnPointsCommand(
             .build()
 
         return Modal.create("$MODAL_PREFIX:$moderatorId:$targetUserId:$warnPointId", "Enter Reason")
-            .addComponents(Label.of("Reason", textInput))
+            .addComponents(targetText, Label.of("Reason", textInput))
             .build()
     }
 
@@ -422,8 +400,7 @@ class RevokeWarnPointsCommand(
                                 OPTION_WARN_POINT_ID,
                                 "The warn point ID to revoke",
                                 true
-                            ),
-                            OptionData(OptionType.STRING, OPTION_REASON, "Reason for revoking points", true)
+                            )
                         ),
                     SubcommandData(SUBCOMMAND_GUIDED, "Select a warn point and then provide a reason")
                         .addOptions(

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/WarnCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/WarnCommand.kt
@@ -7,8 +7,13 @@ import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettings
 import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettingsRepository
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionHook
@@ -17,6 +22,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import net.dv8tion.jda.api.modals.Modal
 import org.springframework.stereotype.Component
 import java.awt.Color
 import java.util.*
@@ -29,7 +35,8 @@ class WarnCommand(
         private const val COMMAND = "warn"
         private const val DESCRIPTION = "Warns a user by sending them a DM and logging the warning to the log channel."
         private const val OPTION_USER = "user"
-        private const val OPTION_REASON = "reason"
+        private const val MODAL_ID = "warn_reason"
+        private const val REASON_INPUT_ID = "reason"
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
@@ -66,8 +73,69 @@ class WarnCommand(
             return
         }
 
-        val reason = event.getOption(OPTION_REASON)?.asString ?: "No reason provided"
+        event.replyModal(createReasonModal(targetMember)).queue()
+    }
 
+    override fun onModalInteraction(event: ModalInteractionEvent) {
+        if (!event.modalId.startsWith("$MODAL_ID:")) return
+
+        val guild = event.guild
+        if (guild == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        val targetMemberId = event.modalId.removePrefix("$MODAL_ID:").toLongOrNull()
+        if (targetMemberId == null) {
+            event.reply("This form is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+
+        val moderator = event.member
+        if (moderator == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!moderator.hasPermission(Permission.MANAGE_ROLES)) {
+            event.reply("You need manage roles permission to use this command.").setEphemeral(true).queue()
+            return
+        }
+
+        val guildWarnPointsSettings = guildWarnPointsSettingsRepository.findById(guild.idLong)
+            .orElse(GuildWarnPointsSettings(guild.idLong, announceChannelId = -1))
+
+        if (guildWarnPointsSettings.overrideWarnCommand) {
+            event.reply("This command has been disabled. Use /addwarnpoints instead.").setEphemeral(true).queue()
+            return
+        }
+
+        val targetMember = guild.getMemberById(targetMemberId)
+        if (targetMember == null) {
+            event.reply("User not found.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!moderator.canInteract(targetMember)) {
+            event.reply("You can't warn a user that you can't interact with.").setEphemeral(true).queue()
+            return
+        }
+
+        val reason = event.getValue(REASON_INPUT_ID)?.asString?.trim().orEmpty()
+        if (reason.isBlank()) {
+            event.reply("Please provide a reason.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reason.length > 1024) {
+            event.reply("Reason must be 1024 characters or less.").setEphemeral(true).queue()
+            return
+        }
+
+        processWarn(event, targetMember, reason)
+    }
+
+    private fun processWarn(event: ModalInteractionEvent, targetMember: Member, reason: String) {
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
             val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
@@ -125,9 +193,23 @@ class WarnCommand(
             Commands.slash(COMMAND, DESCRIPTION)
                 .addOptions(
                     OptionData(OptionType.USER, OPTION_USER, "The user to warn").setRequired(true),
-                    OptionData(OptionType.STRING, OPTION_REASON, "The reason for the warning").setRequired(true)
                 )
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
         )
+    }
+
+    private fun createReasonModal(targetMember: Member): Modal {
+        val targetText = TextDisplay.of(
+            "Warning: ${targetMember.nicknameAndUsername} (<@${targetMember.idLong}>, ID: ${targetMember.idLong})"
+        )
+        val reasonInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
+            .setPlaceholder("Enter the reason for this warning...")
+            .setMinLength(1)
+            .setMaxLength(1024)
+            .build()
+
+        return Modal.create("$MODAL_ID:${targetMember.idLong}", "Enter Reason")
+            .addComponents(targetText, Label.of("Reason", reasonInput))
+            .build()
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/WarnCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/WarnCommand.kt
@@ -111,12 +111,7 @@ class WarnCommand(
         }
 
         val targetMember = guild.getMemberById(targetMemberId)
-        if (targetMember == null) {
-            event.reply("User not found.").setEphemeral(true).queue()
-            return
-        }
-
-        if (!moderator.canInteract(targetMember)) {
+        if (targetMember != null && !moderator.canInteract(targetMember)) {
             event.reply("You can't warn a user that you can't interact with.").setEphemeral(true).queue()
             return
         }
@@ -132,23 +127,20 @@ class WarnCommand(
             return
         }
 
-        processWarn(event, targetMember, reason)
+        processWarn(event, targetMember, targetMemberId, reason)
     }
 
-    private fun processWarn(event: ModalInteractionEvent, targetMember: Member, reason: String) {
+    private fun processWarn(event: ModalInteractionEvent, targetMember: Member?, targetUserId: Long, reason: String) {
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
-            val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
-            if (guildLogger != null) {
-                val logEmbed = EmbedBuilder()
-                    .setColor(Color.YELLOW)
-                    .setTitle("User warned")
-                    .addField("UUID", UUID.randomUUID().toString(), false)
-                    .addField("User", targetMember.nicknameAndUsername, true)
-                    .addField("Moderator", event.member!!.nicknameAndUsername, true)
-                    .addField("Reason", reason, false)
+            logWarn(event, guild, targetMember, targetUserId, reason)
 
-                guildLogger.log(logEmbed, targetMember.user, guild, null, GuildLogger.LogTypeAction.MODERATOR)
+            if (targetMember == null) {
+                hook.editOriginal(
+                    "Warning logged for <@$targetUserId>, but the user left the server before the warning could be delivered. " +
+                        "Warn them manually if they rejoin."
+                ).queue()
+                return@queue
             }
 
             val userWarning = EmbedBuilder()
@@ -165,6 +157,27 @@ class WarnCommand(
                     ) { throwable -> onFailToWarnUser(hook, targetMember, throwable) }
                 }
             ) { throwable -> onFailToWarnUser(hook, targetMember, throwable) }
+        }
+    }
+
+    private fun logWarn(
+        event: ModalInteractionEvent,
+        guild: net.dv8tion.jda.api.entities.Guild,
+        targetMember: Member?,
+        targetUserId: Long,
+        reason: String
+    ) {
+        val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
+        if (guildLogger != null) {
+            val logEmbed = EmbedBuilder()
+                .setColor(Color.YELLOW)
+                .setTitle("User warned")
+                .addField("UUID", UUID.randomUUID().toString(), false)
+                .addField("User", targetMember?.nicknameAndUsername ?: "<@$targetUserId> (left server)", true)
+                .addField("Moderator", event.member!!.nicknameAndUsername, true)
+                .addField("Reason", reason, false)
+
+            guildLogger.log(logEmbed, targetMember?.user, guild, null, GuildLogger.LogTypeAction.MODERATOR)
         }
     }
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
@@ -140,7 +140,11 @@ class AddWarnPointsByIdCommandTest {
 
         command.onSlashCommandInteraction(slashEvent)
 
-        verify(slashEvent).replyModal(argThat { id == "addwarnpointsbyid_reason:99:2:3:0" })
+        verify(slashEvent).replyModal(argThat {
+            id == "addwarnpointsbyid_reason:99:2:3:0" &&
+                components.size == 2 &&
+                components[0].asTextDisplay().content == "Warning: <@99> (ID: 99)"
+        })
     }
 
     @Test
@@ -151,7 +155,9 @@ class AddWarnPointsByIdCommandTest {
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent).replyModal(argThat {
-            id == "addwarnpointsbyid_reason:99:2:3:1" && components.size == 2
+            id == "addwarnpointsbyid_reason:99:2:3:1" &&
+                components.size == 3 &&
+                components[0].asTextDisplay().content == "Warning: <@99> (ID: 99)"
         })
     }
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
@@ -60,6 +60,9 @@ class AddWarnPointsCommandTest {
     private lateinit var unmutePlanningService: UnmutePlanningService
 
     @Mock
+    private lateinit var muteService: MuteService
+
+    @Mock
     private lateinit var slashEvent: SlashCommandInteractionEvent
 
     @Mock
@@ -123,6 +126,9 @@ class AddWarnPointsCommandTest {
     private lateinit var openPrivateChannelAction: CacheRestAction<PrivateChannel>
 
     @Mock
+    private lateinit var retrieveUserAction: CacheRestAction<User>
+
+    @Mock
     private lateinit var privateChannel: PrivateChannel
 
     @Mock
@@ -142,6 +148,7 @@ class AddWarnPointsCommandTest {
             guildWarnPointsService,
             guildWarnPointsSettingsRepository,
             muteRoleCommandAndEventsListener,
+            muteService,
             unmutePlanningService
         )
     }
@@ -408,6 +415,23 @@ class AddWarnPointsCommandTest {
         kotlin.test.assertEquals(false, resultCaptor.firstValue.contains("Logger unavailable"))
     }
 
+    @Test
+    fun `mute modal for departed target records mute and tells moderator it applies on rejoin`() {
+        val resultCaptor = argumentCaptor<String>()
+
+        stubSuccessfulMuteModalFlow(unmuteDays = 3, targetStillPresent = false)
+        whenever(unmutePlanningService.planUnmute(guild, 99L, member, 3)).thenReturn(OffsetDateTime.now().plusDays(3))
+
+        command.onModalInteraction(modalEvent)
+
+        verify(muteService).muteUserById(1L, 99L)
+        verify(hook).sendMessage(resultCaptor.capture())
+        kotlin.test.assertEquals(
+            true,
+            resultCaptor.firstValue.contains("User left before the mute could be applied. The mute will be applied when they rejoin.")
+        )
+    }
+
     private fun stubSlashCommand(action: Int) {
         whenever(slashEvent.name).thenReturn("addwarnpoints")
         whenever(slashEvent.member).thenReturn(member)
@@ -432,7 +456,7 @@ class AddWarnPointsCommandTest {
         whenever(modalEvent.guild).thenReturn(guild)
         whenever(modalEvent.member).thenReturn(member)
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
-        whenever(guild.getMemberById("99")).thenReturn(targetMember)
+        whenever(guild.getMemberById(99L)).thenReturn(targetMember)
         whenever(member.canInteract(targetMember)).thenReturn(true)
     }
 
@@ -440,7 +464,8 @@ class AddWarnPointsCommandTest {
     private fun stubSuccessfulMuteModalFlow(
         unmuteDays: Int?,
         muteRoleConfigured: Boolean = true,
-        muteRoleAssignmentSucceeds: Boolean = true
+        muteRoleAssignmentSucceeds: Boolean = true,
+        targetStillPresent: Boolean = true
     ) {
         val settings = GuildWarnPointsSettings(
             guildId = 1L,
@@ -474,6 +499,8 @@ class AddWarnPointsCommandTest {
         whenever(targetUser.name).thenReturn("TargetUser")
         whenever(jda.registeredListeners).thenReturn(listOf(guildLogger))
         whenever(jda.getTextChannelById(1L)).thenReturn(mockTextChannel())
+        whenever(jda.retrieveUserById(99L)).thenReturn(retrieveUserAction)
+        whenever(retrieveUserAction.complete()).thenReturn(targetUser)
         whenever(guildWarnPointsSettingsRepository.findById(1L)).thenReturn(Optional.of(settings))
         whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
         whenever(reasonValue.asString).thenReturn("Spamming")
@@ -483,6 +510,7 @@ class AddWarnPointsCommandTest {
         whenever(guildWarnPointsService.addWarnPoint(eq(99L), eq(1L), eq(2), eq(12L), eq("Spamming"), any()))
             .thenReturn(warnPoint)
         whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
+        whenever(guild.getMemberById(99L)).thenReturn(if (targetStillPresent) targetMember else null)
         if (muteRoleConfigured) {
             whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
         } else {
@@ -496,13 +524,13 @@ class AddWarnPointsCommandTest {
             consumer.accept(hook)
             null
         }.whenever(replyAction).queue(any<Consumer<InteractionHook>>())
-        if (muteRoleAssignmentSucceeds) {
+        if (targetStillPresent && muteRoleAssignmentSucceeds) {
             doAnswer {
                 val success = it.arguments[0] as Consumer<Void?>
                 success.accept(null)
                 null
             }.whenever(addRoleAction).queue(any<Consumer<Void?>>(), any<Consumer<Throwable>>())
-        } else {
+        } else if (targetStillPresent) {
             doAnswer {
                 val failure = it.arguments[1] as Consumer<Throwable>
                 failure.accept(IllegalStateException("Missing permissions"))

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
@@ -178,7 +178,9 @@ class AddWarnPointsCommandTest {
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent).replyModal(argThat {
-            id == "addwarnpoints_reason:99:2:3:1" && components.size == 2
+            id == "addwarnpoints_reason:99:2:3:1" &&
+                components.size == 3 &&
+                components[0].asTextDisplay().content == "Warning: TargetUser (<@99>, ID: 99)"
         })
     }
 
@@ -191,7 +193,9 @@ class AddWarnPointsCommandTest {
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent).replyModal(argThat {
-            id == "addwarnpoints_reason:99:2:3:2" && components.size == 1
+            id == "addwarnpoints_reason:99:2:3:2" &&
+                components.size == 2 &&
+                components[0].asTextDisplay().content == "Warning: TargetUser (<@99>, ID: 99)"
         })
     }
 
@@ -411,6 +415,9 @@ class AddWarnPointsCommandTest {
         whenever(slashEvent.getOption("user")).thenReturn(userOption)
         whenever(userOption.asMember).thenReturn(targetMember)
         whenever(targetMember.idLong).thenReturn(99L)
+        whenever(targetMember.user).thenReturn(targetUser)
+        whenever(targetMember.nickname).thenReturn(null)
+        whenever(targetUser.name).thenReturn("TargetUser")
         whenever(member.canInteract(targetMember)).thenReturn(true)
         whenever(slashEvent.getOption("points")).thenReturn(pointsOption)
         whenever(pointsOption.asInt).thenReturn(2)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/MuteByIdCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/MuteByIdCommandTest.kt
@@ -3,10 +3,13 @@ package be.duncanc.discordmodbot.moderation
 import be.duncanc.discordmodbot.logging.GuildLogger
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.*
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,6 +38,9 @@ class MuteByIdCommandTest {
     private lateinit var slashEvent: SlashCommandInteractionEvent
 
     @Mock
+    private lateinit var modalEvent: ModalInteractionEvent
+
+    @Mock
     private lateinit var member: Member
 
     @Mock
@@ -46,6 +52,9 @@ class MuteByIdCommandTest {
     @Mock
     private lateinit var replyAction: ReplyCallbackAction
 
+    @Mock
+    private lateinit var modalAction: ModalCallbackAction
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private lateinit var interactionHook: InteractionHook
 
@@ -56,7 +65,7 @@ class MuteByIdCommandTest {
     private lateinit var userIdOption: OptionMapping
 
     @Mock
-    private lateinit var reasonOption: OptionMapping
+    private lateinit var reasonValue: ModalMapping
 
     @Mock
     private lateinit var muteRoleEntity: Role
@@ -70,30 +79,46 @@ class MuteByIdCommandTest {
     }
 
     @Test
-    fun `mutes a user by id and confirms the request`() {
+    fun `slash command opens a reason modal`() {
         whenever(slashEvent.name).thenReturn("mutebyid")
         whenever(slashEvent.member).thenReturn(member)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(slashEvent.getOption("user_id")).thenReturn(userIdOption)
+        whenever(userIdOption.asLong).thenReturn(99L)
+        whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(slashEvent).replyModal(org.mockito.kotlin.argThat {
+            id == "mutebyid_reason:99" &&
+                    components.size == 2 &&
+                    components[0].asTextDisplay().content == "Muting: <@99> (ID: 99)"
+        })
+    }
+
+    @Test
+    fun `modal submission mutes a user by id and confirms the request`() {
+        whenever(modalEvent.modalId).thenReturn("mutebyid_reason:99")
+        whenever(modalEvent.member).thenReturn(member)
         whenever(member.guild).thenReturn(guild)
         whenever(member.nickname).thenReturn("Moderator")
         whenever(member.user).thenReturn(user)
         whenever(user.name).thenReturn("ModeratorUser")
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
         whenever(guild.idLong).thenReturn(1L)
-        whenever(slashEvent.deferReply(true)).thenReturn(replyAction)
+        whenever(guild.getMemberById(99L)).thenReturn(null)
+        whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
+        whenever(reasonValue.asString).thenReturn("Spamming")
+        whenever(modalEvent.deferReply(true)).thenReturn(replyAction)
         doAnswer {
             val consumer = it.arguments[0] as Consumer<InteractionHook>
             consumer.accept(interactionHook)
             null
         }.whenever(replyAction).queue(any<Consumer<InteractionHook>>())
         whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
-        whenever(slashEvent.getOption("user_id")).thenReturn(userIdOption)
-        whenever(slashEvent.getOption("reason")).thenReturn(reasonOption)
-        whenever(userIdOption.asLong).thenReturn(99L)
-        whenever(userIdOption.asMember).thenReturn(null)
-        whenever(reasonOption.asString).thenReturn("Spamming")
         whenever(muteRoleCommandAndEventsListenerService.getMuteRole(guild)).thenReturn(muteRoleEntity)
 
-        command.onSlashCommandInteraction(slashEvent)
+        command.onModalInteraction(modalEvent)
 
         verify(muteService).muteUserById(1L, 99L)
         verify(interactionHook).editOriginal("User (ID: 99) has been muted. The mute will be applied when they rejoin.")

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReasonModalCommandDataTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReasonModalCommandDataTest.kt
@@ -14,7 +14,7 @@ class ReasonModalCommandDataTest {
             BanCommand().getCommandsData().single(),
             BanUserByIdCommand().getCommandsData().single(),
             KickCommand().getCommandsData().single(),
-            MuteCommand(mock()).getCommandsData().single(),
+            MuteCommand(mock(), mock()).getCommandsData().single(),
             MuteByIdCommand(mock(), mock(), mock<GuildLogger>()).getCommandsData().single(),
             WarnCommand(mock<GuildWarnPointsSettingsRepository>()).getCommandsData().single()
         )

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReasonModalCommandDataTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReasonModalCommandDataTest.kt
@@ -1,0 +1,38 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.logging.GuildLogger
+import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettingsRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+
+class ReasonModalCommandDataTest {
+    @Test
+    fun `moderation commands collect reasons through modals`() {
+        val commands = listOf(
+            BanCommand().getCommandsData().single(),
+            BanUserByIdCommand().getCommandsData().single(),
+            KickCommand().getCommandsData().single(),
+            MuteCommand(mock()).getCommandsData().single(),
+            MuteByIdCommand(mock(), mock(), mock<GuildLogger>()).getCommandsData().single(),
+            WarnCommand(mock<GuildWarnPointsSettingsRepository>()).getCommandsData().single()
+        )
+
+        assertEquals(
+            mapOf(
+                "ban" to listOf("user"),
+                "banbyid" to listOf("user_id"),
+                "kick" to listOf("user"),
+                "mute" to listOf("user"),
+                "mutebyid" to listOf("user_id"),
+                "warn" to listOf("user")
+            ),
+            commands.associate { it.name to it.options.map { option -> option.name } }
+        )
+
+        commands.forEach { command ->
+            assertFalse(command.options.any { it.name == "reason" })
+        }
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/RevokeWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/RevokeWarnPointsCommandTest.kt
@@ -94,10 +94,14 @@ class RevokeWarnPointsCommandTest {
 
         assertEquals("revokewarnpoints", commandData.name)
         assertEquals(listOf("direct", "guided"), commandData.subcommands.map { it.name })
+        assertEquals(
+            listOf("user", "warn_point_id"),
+            commandData.subcommands.single { it.name == "direct" }.options.map { it.name }
+        )
     }
 
     @Test
-    fun `direct revoke removes the targeted warn point`() {
+    fun `direct revoke opens a reason modal`() {
         val warnPointId = UUID.fromString("11111111-1111-1111-1111-111111111111")
         val warnPoint = warnPoint(warnPointId)
 
@@ -107,19 +111,21 @@ class RevokeWarnPointsCommandTest {
         whenever(slashEvent.guild).thenReturn(guild)
         whenever(slashEvent.jda).thenReturn(jda)
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(member.idLong).thenReturn(12L)
         whenever(slashEvent.getOption("user")).thenReturn(optionLong(99L))
         whenever(slashEvent.getOption("warn_point_id")).thenReturn(stringOption(warnPointId.toString()))
-        whenever(slashEvent.getOption("reason")).thenReturn(stringOption("Spamming"))
         whenever(guild.idLong).thenReturn(1L)
-        whenever(jda.registeredListeners).thenReturn(emptyList())
         whenever(guildWarnPointsService.getWarningById(warnPointId)).thenReturn(warnPoint)
-        whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)
-        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
 
         command.onSlashCommandInteraction(slashEvent)
 
-        verify(guildWarnPointsService).revokePoint(warnPointId)
-        verify(slashEvent).reply("Revoked 2 warn point(s) from <@99>. Reason: Spamming")
+        verify(guildWarnPointsService, never()).revokePoint(any())
+        verify(slashEvent).replyModal(argThat {
+            id == "revokewarnpoints-reason:12:99:$warnPointId" &&
+                    components.size == 2 &&
+                    components[0].asTextDisplay().content == "Revoking warning from <@99>"
+        })
     }
 
     @Test
@@ -180,7 +186,6 @@ class RevokeWarnPointsCommandTest {
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
         whenever(slashEvent.getOption("user")).thenReturn(optionLong(99L))
         whenever(slashEvent.getOption("warn_point_id")).thenReturn(stringOption(warnPointId.toString()))
-        whenever(slashEvent.getOption("reason")).thenReturn(stringOption("Spamming"))
         whenever(guild.idLong).thenReturn(1L)
         whenever(guildWarnPointsService.getWarningById(warnPointId)).thenReturn(null)
         whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/WarnCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/WarnCommandTest.kt
@@ -1,21 +1,36 @@
 package be.duncanc.discordmodbot.moderation
 
+import be.duncanc.discordmodbot.logging.GuildLogger
 import be.duncanc.discordmodbot.moderation.persistence.GuildWarnPointsSettingsRepository
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.util.Optional
+import java.util.function.Consumer
 
 @ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class WarnCommandTest {
     @Mock
     private lateinit var guildWarnPointsSettingsRepository: GuildWarnPointsSettingsRepository
@@ -24,13 +39,34 @@ class WarnCommandTest {
     private lateinit var slashEvent: SlashCommandInteractionEvent
 
     @Mock
+    private lateinit var modalEvent: ModalInteractionEvent
+
+    @Mock
     private lateinit var guild: Guild
 
     @Mock
     private lateinit var member: Member
 
     @Mock
+    private lateinit var moderatorUser: User
+
+    @Mock
     private lateinit var replyAction: ReplyCallbackAction
+
+    @Mock
+    private lateinit var modalReason: ModalMapping
+
+    @Mock
+    private lateinit var jda: JDA
+
+    @Mock
+    private lateinit var hook: net.dv8tion.jda.api.interactions.InteractionHook
+
+    @Mock
+    private lateinit var editAction: WebhookMessageEditAction<Message>
+
+    @Mock
+    private lateinit var guildLogger: GuildLogger
 
     private lateinit var command: WarnCommand
 
@@ -51,5 +87,37 @@ class WarnCommandTest {
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent).reply("You need manage roles permission to use this command.")
+    }
+
+    @Test
+    fun `modal submit logs warning when target left and tells moderator to warn manually`() {
+        whenever(modalEvent.modalId).thenReturn("warn_reason:99")
+        whenever(modalEvent.guild).thenReturn(guild)
+        whenever(modalEvent.member).thenReturn(member)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(member.user).thenReturn(moderatorUser)
+        whenever(member.nickname).thenReturn(null)
+        whenever(moderatorUser.name).thenReturn("ModeratorUser")
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guild.getMemberById(99L)).thenReturn(null)
+        whenever(guildWarnPointsSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+        whenever(modalEvent.getValue("reason")).thenReturn(modalReason)
+        whenever(modalReason.asString).thenReturn("Spamming")
+        whenever(modalEvent.jda).thenReturn(jda)
+        whenever(jda.registeredListeners).thenReturn(listOf(guildLogger))
+        whenever(modalEvent.deferReply(true)).thenReturn(replyAction)
+        whenever(hook.editOriginal(any<String>())).thenReturn(editAction)
+        doAnswer {
+            val consumer = it.arguments[0] as Consumer<net.dv8tion.jda.api.interactions.InteractionHook>
+            consumer.accept(hook)
+            null
+        }.whenever(replyAction).queue(any<Consumer<net.dv8tion.jda.api.interactions.InteractionHook>>())
+
+        command.onModalInteraction(modalEvent)
+
+        verify(guildLogger).log(any(), isNull(), eq(guild), isNull(), eq(GuildLogger.LogTypeAction.MODERATOR), isNull())
+        verify(hook).editOriginal(
+            "Warning logged for <@99>, but the user left the server before the warning could be delivered. Warn them manually if they rejoin."
+        )
     }
 }


### PR DESCRIPTION
**Summary**

This PR moves remaining moderation command reason inputs from slash command parameters into Discord modals.

**Changes**

- Removed `reason` slash options from:
  - `/ban`
  - `/banbyid`
  - `/kick`
  - `/mute`
  - `/mutebyid`
  - `/warn`
  - `/revokewarnpoints direct`
- Added reason modals with:
  - Required paragraph reason input
  - 1024-character max length
  - Read-only target context using `TextDisplay`
- Revalidates permissions and target state on modal submission before executing moderation actions.
- Reused the existing revoke warning modal flow for `/revokewarnpoints direct`.
- Preserved existing moderation behavior, including DMs, logging, ban cleanup windows, mute-role behavior, and user-facing result messages.
- Added/updated tests for modal-based reason collection and command option registration.

**Validation**

- Ran `./gradlew.bat test`
- Ran IntelliJ build for touched files
- Confirmed no remaining main-source slash `reason` options or `getOption("reason")` usage.