### PR TITLE
fix(member-gate): improve review queue handling and logging

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/MemberGate.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/MemberGate.kt
@@ -170,7 +170,7 @@ class MemberGate(
             return
         }
         val userId = event.user.idLong
-        reviewManager.clearInformPrompt(event.guild.idLong, event.jda, userId)
+        reviewManager.clearPendingQuestion(event.guild.idLong, event.jda, userId)
         cleanMessagesFromUser(gateChannel, event.user)
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
@@ -1,12 +1,17 @@
 package be.duncanc.discordmodbot.member.gate
 
 import be.duncanc.discordmodbot.discord.SlashCommand
+import be.duncanc.discordmodbot.discord.nicknameAndUsername
+import be.duncanc.discordmodbot.logging.GuildLogger
 import be.duncanc.discordmodbot.member.gate.persistence.MemberGateQuestion
+import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
@@ -16,11 +21,14 @@ import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import net.dv8tion.jda.api.utils.MarkdownUtil
 import org.springframework.stereotype.Component
+import java.awt.Color
+import java.util.UUID
 
 @Component
 class ReviewCommand(
     private val reviewManager: ReviewManager,
-    private val reviewSessionRegistry: ReviewSessionRegistry
+    private val reviewSessionRegistry: ReviewSessionRegistry,
+    private val guildLogger: GuildLogger
 ) : ListenerAdapter(), SlashCommand {
     companion object {
         private const val COMMAND = "review"
@@ -68,7 +76,10 @@ class ReviewCommand(
             return
         }
 
+        reviewSessionRegistry.forgetOtherSessions(guild.idLong, event.user.idLong)
+            .forEach { logReviewInterrupted(guild, it) }
         reviewSessionRegistry.remember(guild.idLong, event.user.idLong, session)
+        logReviewStarted(guild, event.member!!, session)
 
         event.reply(buildReviewMessage(guild, session, pendingQuestion))
             .setEphemeral(true)
@@ -126,18 +137,21 @@ class ReviewCommand(
         val feedback = when (buttonAction.action) {
             APPROVE_ACTION -> {
                 val result = reviewManager.approve(guild, event.jda, currentUserId)
+                session.recordApproval()
                 session.advanceAfterReview()
                 result
             }
 
             REJECT_ACTION -> {
                 val result = reviewManager.reject(guild, event.jda, currentUserId)
+                session.recordRejection()
                 session.advanceAfterReview()
                 result
             }
 
             MANUAL_ACTION -> {
                 val result = reviewManager.reject(guild, event.jda, currentUserId, manualAction = true)
+                session.recordManualAction()
                 session.advanceAfterReview()
                 result
             }
@@ -152,6 +166,7 @@ class ReviewCommand(
 
         val pendingQuestion = resolveCurrentQuestion(guild, event.jda, session)
         if (pendingQuestion == null) {
+            logReviewCompleted(guild, event.member!!, session)
             reviewSessionRegistry.forget(guild.idLong, event.user.idLong)
             event.editMessage(buildCompletionMessage(feedback)).setComponents(emptyList()).queue()
             return
@@ -219,6 +234,51 @@ class ReviewCommand(
 
     private fun buildCompletionMessage(feedback: String): String {
         return "$feedback\n\nThere are no more pending applicants in the queue."
+    }
+
+    private fun logReviewStarted(guild: Guild, moderator: Member, session: ReviewSession) {
+        val logEmbed = EmbedBuilder()
+            .setColor(Color.YELLOW)
+            .setTitle("Member gate review started")
+            .addField("UUID", UUID.randomUUID().toString(), false)
+            .addField("Moderator", moderator.nicknameAndUsername, true)
+            .addField("Pending applicants", session.toPendingUserIds().size.toString(), true)
+
+        guildLogger.log(logEmbed, moderator.user, guild, null, GuildLogger.LogTypeAction.MODERATOR)
+    }
+
+    private fun logReviewCompleted(guild: Guild, moderator: Member, session: ReviewSession) {
+        logReviewSummary(guild, moderator.user, moderator.nicknameAndUsername, "Member gate review completed", session)
+    }
+
+    private fun logReviewInterrupted(guild: Guild, storedSession: ReviewSessionRegistry.StoredReviewSession) {
+        val reviewer = guild.getMemberById(storedSession.reviewerId)
+        logReviewSummary(
+            guild = guild,
+            moderatorUser = reviewer?.user,
+            moderatorName = reviewer?.nicknameAndUsername ?: "<@${storedSession.reviewerId}>",
+            title = "Member gate review interrupted",
+            session = storedSession.session
+        )
+    }
+
+    private fun logReviewSummary(
+        guild: Guild,
+        moderatorUser: User?,
+        moderatorName: String,
+        title: String,
+        session: ReviewSession
+    ) {
+        val logEmbed = EmbedBuilder()
+            .setColor(Color.YELLOW)
+            .setTitle(title)
+            .addField("UUID", UUID.randomUUID().toString(), false)
+            .addField("Moderator", moderatorName, true)
+            .addField("Approved", session.approvedCount.toString(), true)
+            .addField("Rejected", session.rejectedCount.toString(), true)
+            .addField("Manual action", session.manualActionCount.toString(), true)
+
+        guildLogger.log(logEmbed, moderatorUser, guild, null, GuildLogger.LogTypeAction.MODERATOR)
     }
 
     private fun buildButtons(question: MemberGateQuestion) = listOf(

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
@@ -2,6 +2,7 @@ package be.duncanc.discordmodbot.member.gate
 
 import be.duncanc.discordmodbot.discord.SlashCommand
 import be.duncanc.discordmodbot.member.gate.persistence.MemberGateQuestion
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
@@ -60,7 +61,7 @@ class ReviewCommand(
             return
         }
 
-        val pendingQuestion = resolveCurrentQuestion(guild.idLong, session)
+        val pendingQuestion = resolveCurrentQuestion(guild, event.jda, session)
         if (pendingQuestion == null) {
             reviewSessionRegistry.forget(guild.idLong, event.user.idLong)
             event.reply("Nobody is currently waiting for approval.").setEphemeral(true).queue()
@@ -149,7 +150,7 @@ class ReviewCommand(
             }
         }
 
-        val pendingQuestion = resolveCurrentQuestion(guild.idLong, session)
+        val pendingQuestion = resolveCurrentQuestion(guild, event.jda, session)
         if (pendingQuestion == null) {
             reviewSessionRegistry.forget(guild.idLong, event.user.idLong)
             event.editMessage(buildCompletionMessage(feedback)).setComponents(emptyList()).queue()
@@ -178,12 +179,16 @@ class ReviewCommand(
         return ReviewButtonAction(segments[0], expectedUserId, expectedQueuedAt)
     }
 
-    private fun resolveCurrentQuestion(guildId: Long, session: ReviewSession): MemberGateQuestion? {
+    private fun resolveCurrentQuestion(guild: Guild, jda: JDA, session: ReviewSession): MemberGateQuestion? {
         while (true) {
             val currentUserId = session.getCurrentUserId() ?: return null
-            val question = reviewManager.getPendingQuestion(guildId, currentUserId)
-            if (question != null) {
+            val question = reviewManager.getPendingQuestion(guild.idLong, currentUserId)
+            if (question != null && guild.getMemberById(currentUserId) != null) {
                 return question
+            }
+
+            if (question != null) {
+                reviewManager.clearPendingQuestion(guild.idLong, jda, currentUserId)
             }
 
             session.advancePastResolvedCurrent()

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
@@ -127,7 +127,13 @@ class ReviewCommand(
         }
 
         val currentQuestion = reviewManager.getPendingQuestion(guild.idLong, currentUserId)
-        if (currentQuestion == null || currentQuestion.queuedAt != buttonAction.expectedQueuedAt) {
+        if (currentQuestion == null) {
+            session.advancePastResolvedCurrent()
+            continueAfterRemovedCurrent(event, guild, session)
+            return
+        }
+
+        if (currentQuestion.queuedAt != buttonAction.expectedQueuedAt) {
             event.reply("This review message is out of date. Run `/review` again.")
                 .setEphemeral(true)
                 .queue()
@@ -174,6 +180,22 @@ class ReviewCommand(
 
         reviewSessionRegistry.remember(guild.idLong, event.user.idLong, session)
 
+        event.editMessage(buildReviewMessage(guild, session, pendingQuestion, feedback))
+            .setComponents(ActionRow.of(buildButtons(pendingQuestion)))
+            .queue()
+    }
+
+    private fun continueAfterRemovedCurrent(event: ButtonInteractionEvent, guild: Guild, session: ReviewSession) {
+        val feedback = "The applicant left; no further action is needed."
+        val pendingQuestion = resolveCurrentQuestion(guild, event.jda, session)
+        if (pendingQuestion == null) {
+            logReviewCompleted(guild, event.member!!, session)
+            reviewSessionRegistry.forget(guild.idLong, event.user.idLong)
+            event.editMessage(buildCompletionMessage(feedback)).setComponents(emptyList()).queue()
+            return
+        }
+
+        reviewSessionRegistry.remember(guild.idLong, event.user.idLong, session)
         event.editMessage(buildReviewMessage(guild, session, pendingQuestion, feedback))
             .setComponents(ActionRow.of(buildButtons(pendingQuestion)))
             .queue()

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSession.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSession.kt
@@ -3,8 +3,17 @@ package be.duncanc.discordmodbot.member.gate
 class ReviewSession(
     pendingUserIds: List<Long>,
     val oldestPendingUserId: Long = pendingUserIds.firstOrNull()
-        ?: throw IllegalArgumentException("A review session requires at least one pending user.")
+        ?: throw IllegalArgumentException("A review session requires at least one pending user."),
+    var approvedCount: Int = 0,
+    var rejectedCount: Int = 0,
+    var manualActionCount: Int = 0
 ) {
+    init {
+        if (pendingUserIds.isEmpty()) {
+            throw IllegalArgumentException("A review session requires at least one pending user.")
+        }
+    }
+
     private val queuedUserIds = ArrayDeque(pendingUserIds)
 
     private var currentUserId: Long? = queuedUserIds.removeFirstOrNull()
@@ -14,6 +23,18 @@ class ReviewSession(
     fun isCurrentOldest(): Boolean = currentUserId == oldestPendingUserId
 
     fun toPendingUserIds(): List<Long> = listOfNotNull(currentUserId) + queuedUserIds.toList()
+
+    fun recordApproval() {
+        approvedCount++
+    }
+
+    fun recordRejection() {
+        rejectedCount++
+    }
+
+    fun recordManualAction() {
+        manualActionCount++
+    }
 
     fun advanceAfterReview(): Long? {
         currentUserId = queuedUserIds.removeFirstOrNull()

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistry.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistry.kt
@@ -8,6 +8,11 @@ import org.springframework.stereotype.Component
 class ReviewSessionRegistry(
     private val reviewSessionStateRepository: ReviewSessionStateRepository
 ) {
+    data class StoredReviewSession(
+        val reviewerId: Long,
+        val session: ReviewSession
+    )
+
     fun remember(guildId: Long, reviewerId: Long, session: ReviewSession) {
         val pendingUserIds = session.toPendingUserIds()
         if (pendingUserIds.isEmpty()) {
@@ -21,7 +26,10 @@ class ReviewSessionRegistry(
                 guildId = guildId,
                 reviewerId = reviewerId,
                 oldestPendingUserId = session.oldestPendingUserId,
-                pendingUserIds = pendingUserIds
+                pendingUserIds = pendingUserIds,
+                approvedCount = session.approvedCount,
+                rejectedCount = session.rejectedCount,
+                manualActionCount = session.manualActionCount
             )
         )
     }
@@ -41,12 +49,33 @@ class ReviewSessionRegistry(
         reviewSessionStateRepository.deleteById(createId(guildId, reviewerId))
     }
 
+    fun forgetOtherSessions(guildId: Long, reviewerId: Long): List<StoredReviewSession> {
+        return reviewSessionStateRepository.findAll()
+            .filterNotNull()
+            .filter { it.guildId == guildId && it.reviewerId != reviewerId }
+            .mapNotNull { state ->
+                reviewSessionStateRepository.deleteById(state.id)
+                state.toStoredSession()
+            }
+    }
+
     private fun createId(guildId: Long, reviewerId: Long): String = "$guildId:$reviewerId"
+
+    private fun ReviewSessionState.toStoredSession(): StoredReviewSession? {
+        if (pendingUserIds.isEmpty()) {
+            return null
+        }
+
+        return StoredReviewSession(reviewerId, toSession())
+    }
 
     private fun ReviewSessionState.toSession(): ReviewSession {
         return ReviewSession(
             pendingUserIds = pendingUserIds,
-            oldestPendingUserId = oldestPendingUserId
+            oldestPendingUserId = oldestPendingUserId,
+            approvedCount = approvedCount,
+            rejectedCount = rejectedCount,
+            manualActionCount = manualActionCount
         )
     }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewSessionState.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewSessionState.kt
@@ -3,12 +3,15 @@ package be.duncanc.discordmodbot.member.gate.persistence
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 
-@RedisHash("memberGateReviewSession", timeToLive = 1800)
+@RedisHash("memberGateReviewSession", timeToLive = 43200)
 data class ReviewSessionState(
     @Id
     val id: String,
     val guildId: Long,
     val reviewerId: Long,
     val oldestPendingUserId: Long,
-    val pendingUserIds: List<Long>
+    val pendingUserIds: List<Long>,
+    val approvedCount: Int = 0,
+    val rejectedCount: Int = 0,
+    val manualActionCount: Int = 0
 )

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
@@ -1,11 +1,14 @@
 package be.duncanc.discordmodbot.member.gate
 
+import be.duncanc.discordmodbot.logging.GuildLogger
 import be.duncanc.discordmodbot.member.gate.persistence.MemberGateQuestion
+import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
@@ -26,6 +29,9 @@ class ReviewCommandTest {
 
     @Mock
     private lateinit var reviewSessionRegistry: ReviewSessionRegistry
+
+    @Mock
+    private lateinit var guildLogger: GuildLogger
 
     @Mock
     private lateinit var slashEvent: SlashCommandInteractionEvent
@@ -55,7 +61,7 @@ class ReviewCommandTest {
 
     @BeforeEach
     fun setUp() {
-        command = ReviewCommand(reviewManager, reviewSessionRegistry)
+        command = ReviewCommand(reviewManager, reviewSessionRegistry, guildLogger)
     }
 
     private fun pendingQuestion(guildId: Long, userId: Long, question: String, answer: String, queuedAt: Long): MemberGateQuestion {
@@ -83,13 +89,21 @@ class ReviewCommandTest {
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
     }
 
+    private fun stubModeratorName() {
+        whenever(user.name).thenReturn("Moderator")
+        whenever(member.user).thenReturn(user)
+        whenever(member.nickname).thenReturn(null)
+    }
+
     private fun stubSlashReviewStart() {
         stubCommonIdentity()
+        stubModeratorName()
         whenever(slashEvent.name).thenReturn("review")
         whenever(slashEvent.guild).thenReturn(guild)
         whenever(slashEvent.member).thenReturn(member)
         whenever(slashEvent.user).thenReturn(user)
         whenever(slashEvent.jda).thenReturn(jda)
+        whenever(reviewSessionRegistry.forgetOtherSessions(1L, 99L)).thenReturn(emptyList())
         whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
         whenever(replyAction.addComponents(any<ActionRow>())).thenReturn(replyAction)
         whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)
@@ -191,6 +205,51 @@ class ReviewCommandTest {
         assertTrue(completionMessage.contains("Approved <@10>."))
         assertTrue(completionMessage.contains("There are no more pending applicants in the queue."))
         verify(reviewSessionRegistry).forget(1L, 99L)
+        verifyReviewLog("Member gate review completed", "Approved", "1")
+    }
+
+    @Test
+    fun `starting review logs moderator and pending applicant count`() {
+        stubSlashReviewStart()
+
+        val session = ReviewSession(listOf(10L, 20L))
+        whenever(reviewManager.createSession(1L)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        stubApplicantPresent(10L, "<@10>")
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verifyReviewLog("Member gate review started", "Pending applicants", "2")
+    }
+
+    @Test
+    fun `starting review logs and removes another moderator's unfinished session`() {
+        stubSlashReviewStart()
+
+        val interruptedSession = ReviewSession(
+            pendingUserIds = listOf(50L),
+            approvedCount = 2,
+            rejectedCount = 1,
+            manualActionCount = 3
+        )
+        whenever(reviewSessionRegistry.forgetOtherSessions(1L, 99L)).thenReturn(
+            listOf(ReviewSessionRegistry.StoredReviewSession(42L, interruptedSession))
+        )
+        val session = ReviewSession(listOf(10L))
+        whenever(reviewManager.createSession(1L)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        whenever(guild.getMemberById(42L)).thenReturn(null)
+        stubApplicantPresent(10L, "<@10>")
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verifyReviewLog("Member gate review interrupted", "Approved", "2")
+        verifyReviewLog("Member gate review interrupted", "Rejected", "1")
+        verifyReviewLog("Member gate review interrupted", "Manual action", "3")
     }
 
     @Test
@@ -304,5 +363,22 @@ class ReviewCommandTest {
         verify(buttonEvent).editMessage(messageCaptor.capture())
         assertTrue(messageCaptor.firstValue.contains("Applicant: <@30> (`30`)"))
         verify(reviewManager).clearPendingQuestion(1L, jda, 20L)
+    }
+
+    private fun verifyReviewLog(title: String, fieldName: String, fieldValue: String) {
+        val embedCaptor = argumentCaptor<EmbedBuilder>()
+        verify(guildLogger, atLeastOnce()).log(
+            embedCaptor.capture(),
+            anyOrNull(),
+            any<Guild>(),
+            anyOrNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            anyOrNull<ByteArray>()
+        )
+        val matchingEmbed = embedCaptor.allValues
+            .map { it.build() }
+            .firstOrNull { embed -> embed.title == title && embed.fields.any { it.name == fieldName && it.value == fieldValue } }
+
+        assertTrue(matchingEmbed != null, "Expected $title log with $fieldName=$fieldValue")
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
@@ -69,6 +69,14 @@ class ReviewCommandTest {
         )
     }
 
+    private fun stubApplicantPresent(userId: Long, mention: String) {
+        val applicantMember = mock<Member>()
+        val applicantUser = mock<User>()
+        whenever(guild.getMemberById(userId)).thenReturn(applicantMember)
+        whenever(applicantMember.user).thenReturn(applicantUser)
+        whenever(applicantUser.asMention).thenReturn(mention)
+    }
+
     private fun stubCommonIdentity() {
         whenever(guild.idLong).thenReturn(1L)
         whenever(user.idLong).thenReturn(99L)
@@ -81,6 +89,7 @@ class ReviewCommandTest {
         whenever(slashEvent.guild).thenReturn(guild)
         whenever(slashEvent.member).thenReturn(member)
         whenever(slashEvent.user).thenReturn(user)
+        whenever(slashEvent.jda).thenReturn(jda)
         whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
         whenever(replyAction.addComponents(any<ActionRow>())).thenReturn(replyAction)
         whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)
@@ -141,6 +150,8 @@ class ReviewCommandTest {
         whenever(reviewManager.getPendingQuestion(1L, 20L)).thenReturn(
             pendingQuestion(guildId = 1L, userId = 20L, question = "Q2", answer = "A2", queuedAt = 20L)
         )
+        stubApplicantPresent(10L, "<@10>")
+        stubApplicantPresent(20L, "<@20>")
         whenever(reviewManager.approve(eq(guild), eq(jda), eq(10L))).thenReturn("Approved <@10>.")
 
         command.onSlashCommandInteraction(slashEvent)
@@ -167,6 +178,7 @@ class ReviewCommandTest {
         whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
             pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
         )
+        stubApplicantPresent(10L, "<@10>")
         whenever(reviewManager.approve(eq(guild), eq(jda), eq(10L))).thenReturn("Approved <@10>.")
 
         command.onSlashCommandInteraction(slashEvent)
@@ -236,5 +248,61 @@ class ReviewCommandTest {
 
         verify(buttonEvent).reply("This review message is out of date. Run `/review` again.")
         verify(reviewManager, never()).approve(any(), any(), any())
+    }
+
+    @Test
+    fun `starting review skips applicants that already left`() {
+        stubSlashReviewStart()
+
+        val session = ReviewSession(listOf(10L, 20L))
+        whenever(reviewManager.createSession(1L)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        whenever(reviewManager.getPendingQuestion(1L, 20L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 20L, question = "Q2", answer = "A2", queuedAt = 20L)
+        )
+        whenever(guild.getMemberById(10L)).thenReturn(null)
+        stubApplicantPresent(20L, "<@20>")
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val messageCaptor = argumentCaptor<String>()
+        verify(slashEvent).reply(messageCaptor.capture())
+        assertTrue(messageCaptor.firstValue.contains("Applicant: <@20> (`20`)"))
+        verify(reviewManager).clearPendingQuestion(1L, jda, 10L)
+        verify(reviewSessionRegistry).remember(eq(1L), eq(99L), any())
+    }
+
+    @Test
+    fun `continuing review skips applicants that left after the current review`() {
+        stubSlashReviewStart()
+        stubApproveButtonInteraction()
+        stubButtonEditWithActionRow()
+
+        val session = ReviewSession(listOf(10L, 20L, 30L))
+        whenever(reviewManager.createSession(1L)).thenReturn(session)
+        whenever(reviewSessionRegistry.get(1L, 99L)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        whenever(reviewManager.getPendingQuestion(1L, 20L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 20L, question = "Q2", answer = "A2", queuedAt = 20L)
+        )
+        whenever(reviewManager.getPendingQuestion(1L, 30L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 30L, question = "Q3", answer = "A3", queuedAt = 30L)
+        )
+        stubApplicantPresent(10L, "<@10>")
+        whenever(guild.getMemberById(20L)).thenReturn(null)
+        stubApplicantPresent(30L, "<@30>")
+        whenever(reviewManager.approve(eq(guild), eq(jda), eq(10L))).thenReturn("Approved <@10>.")
+
+        command.onSlashCommandInteraction(slashEvent)
+        command.onButtonInteraction(buttonEvent)
+
+        val messageCaptor = argumentCaptor<String>()
+        verify(buttonEvent).editMessage(messageCaptor.capture())
+        assertTrue(messageCaptor.firstValue.contains("Applicant: <@30> (`30`)"))
+        verify(reviewManager).clearPendingQuestion(1L, jda, 20L)
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
@@ -310,6 +310,52 @@ class ReviewCommandTest {
     }
 
     @Test
+    fun `button advances when current applicant left before review action`() {
+        stubApproveButtonInteraction()
+        stubButtonEditWithActionRow()
+
+        val session = ReviewSession(listOf(10L, 20L))
+        whenever(reviewSessionRegistry.get(1L, 99L)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(null)
+        whenever(reviewManager.getPendingQuestion(1L, 20L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 20L, question = "Q2", answer = "A2", queuedAt = 20L)
+        )
+        stubApplicantPresent(20L, "<@20>")
+
+        command.onButtonInteraction(buttonEvent)
+
+        val messageCaptor = argumentCaptor<String>()
+        verify(buttonEvent).editMessage(messageCaptor.capture())
+        val editedMessage = messageCaptor.firstValue
+        assertTrue(editedMessage.contains("The applicant left; no further action is needed."))
+        assertTrue(editedMessage.contains("Applicant: <@20> (`20`)"))
+        verify(reviewSessionRegistry).remember(eq(1L), eq(99L), any())
+        verify(reviewManager, never()).approve(any(), any(), any())
+    }
+
+    @Test
+    fun `button completes review when final current applicant already left`() {
+        stubApproveButtonInteraction()
+        stubModeratorName()
+        stubButtonEditWithList()
+
+        val session = ReviewSession(listOf(10L), approvedCount = 2, rejectedCount = 1, manualActionCount = 1)
+        whenever(reviewSessionRegistry.get(1L, 99L)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(null)
+
+        command.onButtonInteraction(buttonEvent)
+
+        val messageCaptor = argumentCaptor<String>()
+        verify(buttonEvent).editMessage(messageCaptor.capture())
+        val editedMessage = messageCaptor.firstValue
+        assertTrue(editedMessage.contains("The applicant left; no further action is needed."))
+        assertTrue(editedMessage.contains("There are no more pending applicants in the queue."))
+        verify(reviewSessionRegistry).forget(1L, 99L)
+        verifyReviewLog("Member gate review completed", "Approved", "2")
+        verify(reviewManager, never()).approve(any(), any(), any())
+    }
+
+    @Test
     fun `starting review skips applicants that already left`() {
         stubSlashReviewStart()
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistryTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistryTest.kt
@@ -30,7 +30,10 @@ class ReviewSessionRegistryTest {
     fun `remember stores session state in redis repository`() {
         val session = ReviewSession(
             pendingUserIds = listOf(20L, 10L),
-            oldestPendingUserId = 10L
+            oldestPendingUserId = 10L,
+            approvedCount = 1,
+            rejectedCount = 2,
+            manualActionCount = 3
         )
 
         reviewSessionRegistry.remember(1L, 99L, session)
@@ -41,6 +44,9 @@ class ReviewSessionRegistryTest {
         assertEquals("1:99", state.id)
         assertEquals(10L, state.oldestPendingUserId)
         assertEquals(listOf(20L, 10L), state.pendingUserIds)
+        assertEquals(1, state.approvedCount)
+        assertEquals(2, state.rejectedCount)
+        assertEquals(3, state.manualActionCount)
     }
 
     @Test
@@ -52,7 +58,10 @@ class ReviewSessionRegistryTest {
                     guildId = 1L,
                     reviewerId = 99L,
                     oldestPendingUserId = 10L,
-                    pendingUserIds = listOf(20L, 10L)
+                    pendingUserIds = listOf(20L, 10L),
+                    approvedCount = 1,
+                    rejectedCount = 2,
+                    manualActionCount = 3
                 )
             )
         )
@@ -62,6 +71,9 @@ class ReviewSessionRegistryTest {
         assertEquals(20L, session?.getCurrentUserId())
         assertEquals(false, session?.isCurrentOldest())
         assertEquals(listOf(20L, 10L), session?.toPendingUserIds())
+        assertEquals(1, session?.approvedCount)
+        assertEquals(2, session?.rejectedCount)
+        assertEquals(3, session?.manualActionCount)
     }
 
     @Test
@@ -79,5 +91,47 @@ class ReviewSessionRegistryTest {
         whenever(reviewSessionStateRepository.findById("1:99")).thenReturn(Optional.empty())
 
         assertNull(reviewSessionRegistry.get(1L, 99L))
+    }
+
+    @Test
+    fun `forget other sessions returns and deletes sessions from other reviewers in guild`() {
+        whenever(reviewSessionStateRepository.findAll()).thenReturn(
+            listOf(
+                ReviewSessionState(
+                    id = "1:42",
+                    guildId = 1L,
+                    reviewerId = 42L,
+                    oldestPendingUserId = 10L,
+                    pendingUserIds = listOf(10L),
+                    approvedCount = 1,
+                    rejectedCount = 2,
+                    manualActionCount = 3
+                ),
+                ReviewSessionState(
+                    id = "1:99",
+                    guildId = 1L,
+                    reviewerId = 99L,
+                    oldestPendingUserId = 20L,
+                    pendingUserIds = listOf(20L)
+                ),
+                ReviewSessionState(
+                    id = "2:43",
+                    guildId = 2L,
+                    reviewerId = 43L,
+                    oldestPendingUserId = 30L,
+                    pendingUserIds = listOf(30L)
+                )
+            )
+        )
+
+        val sessions = reviewSessionRegistry.forgetOtherSessions(1L, 99L)
+
+        assertEquals(1, sessions.size)
+        assertEquals(42L, sessions.first().reviewerId)
+        assertEquals(10L, sessions.first().session.getCurrentUserId())
+        assertEquals(1, sessions.first().session.approvedCount)
+        assertEquals(2, sessions.first().session.rejectedCount)
+        assertEquals(3, sessions.first().session.manualActionCount)
+        verify(reviewSessionStateRepository).deleteById("1:42")
     }
 }


### PR DESCRIPTION
## Summary
- remove departed applicants from the member gate review queue and skip them during review
- log review starts, completions, and interrupted reviewer sessions to the mod log
- persist approve/reject/manual action counts with a 12-hour review session TTL

## Verification
- ./gradlew.bat test --tests "be.duncanc.discordmodbot.member.gate.ReviewCommandTest" --tests "be.duncanc.discordmodbot.member.gate.ReviewSessionRegistryTest" --tests "be.duncanc.discordmodbot.member.gate.ReviewSessionTest"
- ./gradlew.bat test --tests "be.duncanc.discordmodbot.ApplicationModulesTest.verifiesApplicationModules"
- IntelliJ build for touched files