### PR TITLE
fix(voting): collect vote prompt via modal

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/voting/VoteCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/voting/VoteCommand.kt
@@ -2,8 +2,12 @@ package be.duncanc.discordmodbot.voting
 
 import be.duncanc.discordmodbot.discord.SlashCommand
 import be.duncanc.discordmodbot.voting.persistence.VotingEmotesRepository
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.emoji.Emoji
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionContextType
@@ -12,6 +16,7 @@ import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import net.dv8tion.jda.api.modals.Modal
 import org.springframework.stereotype.Component
 
 @Component
@@ -25,6 +30,7 @@ class VoteCommand(
         private const val SUBCOMMAND_NUMERIC = "numeric"
         private const val OPTION_PROMPT = "prompt"
         private const val OPTION_COUNT = "count"
+        private const val MODAL_PREFIX = "vote"
         private const val PROMPT_MAX_LENGTH = 1000
 
         private val DEFAULT_YES_NO_REACTIONS = listOf(
@@ -59,18 +65,8 @@ class VoteCommand(
             return
         }
 
-        val prompt = getPrompt(event)?.trim()
-        if (prompt.isNullOrBlank()) {
-            event.reply("Please provide a vote prompt.").setEphemeral(true).queue()
-            return
-        }
-
         when (event.subcommandName) {
-            SUBCOMMAND_YES_NO -> createVote(
-                event = event,
-                content = buildVoteMessage(member.asMention, prompt, null),
-                reactions = resolveYesNoReactions(guild.idLong, event)
-            )
+            SUBCOMMAND_YES_NO -> event.replyModal(createVoteModal(member.asMention, SUBCOMMAND_YES_NO)).queue()
 
             SUBCOMMAND_NUMERIC -> {
                 val count = getCount(event)
@@ -81,6 +77,51 @@ class VoteCommand(
                     return
                 }
 
+                event.replyModal(createVoteModal(member.asMention, SUBCOMMAND_NUMERIC, count)).queue()
+            }
+
+            else -> event.reply("Please choose a valid /vote subcommand.").setEphemeral(true).queue()
+        }
+    }
+
+    override fun onModalInteraction(event: ModalInteractionEvent) {
+        if (!event.modalId.startsWith("$MODAL_PREFIX:")) {
+            return
+        }
+
+        val member = event.member
+        val guild = event.guild
+        if (guild == null || member == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        val modalAction = parseModalAction(event.modalId)
+        if (modalAction == null) {
+            event.reply("This vote form is no longer valid. Run `/vote` again.").setEphemeral(true).queue()
+            return
+        }
+
+        val prompt = event.getValue(OPTION_PROMPT)?.asString?.trim().orEmpty()
+        if (prompt.isBlank()) {
+            event.reply("Please provide a vote prompt.").setEphemeral(true).queue()
+            return
+        }
+
+        when (modalAction.subcommand) {
+            SUBCOMMAND_YES_NO -> createVote(
+                event = event,
+                content = buildVoteMessage(member.asMention, prompt, null),
+                reactions = resolveYesNoReactions(guild.idLong, event)
+            )
+
+            SUBCOMMAND_NUMERIC -> {
+                val count = modalAction.count
+                if (count == null || count !in 2..11) {
+                    event.reply("This vote form is no longer valid. Run `/vote` again.").setEphemeral(true).queue()
+                    return
+                }
+
                 createVote(
                     event = event,
                     content = buildVoteMessage(member.asMention, prompt, count),
@@ -88,7 +129,7 @@ class VoteCommand(
                 )
             }
 
-            else -> event.reply("Please choose a valid /vote subcommand.").setEphemeral(true).queue()
+            else -> event.reply("This vote form is no longer valid. Run `/vote` again.").setEphemeral(true).queue()
         }
     }
 
@@ -97,11 +138,9 @@ class VoteCommand(
             Commands.slash(COMMAND, DESCRIPTION)
                 .setContexts(InteractionContextType.GUILD)
                 .addSubcommands(
-                    SubcommandData(SUBCOMMAND_YES_NO, "Create a yes or no vote")
-                        .addOptions(promptOption()),
+                    SubcommandData(SUBCOMMAND_YES_NO, "Create a yes or no vote"),
                     SubcommandData(SUBCOMMAND_NUMERIC, "Create a numeric vote")
                         .addOptions(
-                            promptOption(),
                             OptionData(OptionType.INTEGER, OPTION_COUNT, "Amount of options, from 2 to 11", true)
                                 .setMinValue(2)
                                 .setMaxValue(11)
@@ -110,21 +149,17 @@ class VoteCommand(
         )
     }
 
-    internal fun getPrompt(event: SlashCommandInteractionEvent): String? {
-        return event.getOption(OPTION_PROMPT)?.asString
-    }
-
     internal fun getCount(event: SlashCommandInteractionEvent): Int? {
         return event.getOption(OPTION_COUNT)?.asInt
     }
 
     internal fun createVoteMessage(
-        event: SlashCommandInteractionEvent,
+        deferReply: (Boolean) -> net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction,
         content: String,
         onSuccess: (Message) -> Unit,
         onFailure: (Throwable) -> Unit
     ) {
-        event.deferReply(false).queue(
+        deferReply(false).queue(
             { hook ->
                 hook.editOriginal(content).queue(onSuccess, onFailure)
             },
@@ -133,6 +168,17 @@ class VoteCommand(
     }
 
     internal fun resolveYesNoReactions(guildId: Long, event: SlashCommandInteractionEvent): List<Emoji> {
+        val config = votingEmotesRepository.findById(guildId).orElse(null) ?: return DEFAULT_YES_NO_REACTIONS
+        val yesEmoji = event.jda.getEmojiById(config.voteYesEmote)
+        val noEmoji = event.jda.getEmojiById(config.voteNoEmote)
+        return if (yesEmoji != null && noEmoji != null) {
+            listOf(Emoji.fromCustom(yesEmoji), Emoji.fromCustom(noEmoji))
+        } else {
+            DEFAULT_YES_NO_REACTIONS
+        }
+    }
+
+    internal fun resolveYesNoReactions(guildId: Long, event: ModalInteractionEvent): List<Emoji> {
         val config = votingEmotesRepository.findById(guildId).orElse(null) ?: return DEFAULT_YES_NO_REACTIONS
         val yesEmoji = event.jda.getEmojiById(config.voteYesEmote)
         val noEmoji = event.jda.getEmojiById(config.voteNoEmote)
@@ -153,8 +199,31 @@ class VoteCommand(
     }
 
     private fun createVote(event: SlashCommandInteractionEvent, content: String, reactions: List<Emoji>) {
+        createVote(
+            deferReply = event::deferReply,
+            hookProvider = { event.hook },
+            content = content,
+            reactions = reactions
+        )
+    }
+
+    private fun createVote(event: ModalInteractionEvent, content: String, reactions: List<Emoji>) {
+        createVote(
+            deferReply = event::deferReply,
+            hookProvider = { event.hook },
+            content = content,
+            reactions = reactions
+        )
+    }
+
+    private fun createVote(
+        deferReply: (Boolean) -> net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction,
+        hookProvider: () -> net.dv8tion.jda.api.interactions.InteractionHook,
+        content: String,
+        reactions: List<Emoji>
+    ) {
         createVoteMessage(
-            event = event,
+            deferReply = deferReply,
             content = content,
             onSuccess = { message ->
                 addReactions(
@@ -162,14 +231,14 @@ class VoteCommand(
                     reactions = reactions,
                     onSuccess = {},
                     onFailure = {
-                        event.hook.sendMessage("The vote message was posted, but I could not add all reactions.")
+                        hookProvider().sendMessage("The vote message was posted, but I could not add all reactions.")
                             .setEphemeral(true)
                             .queue()
                     }
                 )
             },
             onFailure = {
-                event.hook.sendMessage("I could not post the vote message in this channel.").setEphemeral(true).queue()
+                hookProvider().sendMessage("I could not post the vote message in this channel.").setEphemeral(true).queue()
             }
         )
     }
@@ -208,8 +277,44 @@ class VoteCommand(
         return NUMERIC_VOTE_EMOTES.take(count).map(Emoji::fromUnicode)
     }
 
-    private fun promptOption(): OptionData {
-        return OptionData(OptionType.STRING, OPTION_PROMPT, "The vote question or prompt", true)
+    private fun createVoteModal(authorMention: String, subcommand: String, count: Int? = null): Modal {
+        val promptInput = TextInput.create(OPTION_PROMPT, TextInputStyle.PARAGRAPH)
+            .setPlaceholder("Enter the vote question or prompt...")
+            .setMinLength(1)
             .setMaxLength(PROMPT_MAX_LENGTH)
+            .build()
+
+        val title = when (subcommand) {
+            SUBCOMMAND_NUMERIC -> "Create Numeric Vote"
+            else -> "Create Vote"
+        }
+
+        return Modal.create(buildModalId(subcommand, count), title)
+            .addComponents(Label.of("Vote prompt", "Posting as $authorMention", promptInput))
+            .build()
     }
+
+    private fun buildModalId(subcommand: String, count: Int? = null): String {
+        return if (count == null) {
+            "$MODAL_PREFIX:$subcommand"
+        } else {
+            "$MODAL_PREFIX:$subcommand:$count"
+        }
+    }
+
+    private fun parseModalAction(modalId: String): VoteModalAction? {
+        val parts = modalId.split(":")
+        if (parts.size !in 2..3 || parts[0] != MODAL_PREFIX) {
+            return null
+        }
+
+        val subcommand = parts[1]
+        val count = parts.getOrNull(2)?.toIntOrNull()
+        return VoteModalAction(subcommand, count)
+    }
+
+    private data class VoteModalAction(
+        val subcommand: String,
+        val count: Int?
+    )
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/voting/VoteCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/voting/VoteCommandTest.kt
@@ -5,12 +5,15 @@ import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.emoji.Emoji
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
-import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
+import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -37,6 +40,9 @@ class VoteCommandTest {
     private lateinit var slashEvent: SlashCommandInteractionEvent
 
     @Mock
+    private lateinit var modalEvent: ModalInteractionEvent
+
+    @Mock
     private lateinit var guild: Guild
 
     @Mock
@@ -46,6 +52,9 @@ class VoteCommandTest {
     private lateinit var replyAction: ReplyCallbackAction
 
     @Mock
+    private lateinit var modalAction: ModalCallbackAction
+
+    @Mock
     private lateinit var interactionHook: InteractionHook
 
     @Mock
@@ -53,6 +62,9 @@ class VoteCommandTest {
 
     @Mock
     private lateinit var followupAction: WebhookMessageCreateAction<Message>
+
+    @Mock
+    private lateinit var promptValue: ModalMapping
 
     private lateinit var command: TestVoteCommand
 
@@ -68,40 +80,42 @@ class VoteCommandTest {
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent, never()).reply(any<String>())
+        verify(slashEvent, never()).replyModal(any())
     }
 
     @Test
-    fun `yesno creates plain text vote with default reactions`() {
+    fun `yesno opens vote modal`() {
         stubSlashCommandContext("yesno")
-        stubGuildId()
-        stubVoteMessageContext()
-        command.prompt = "Should we do this?"
-        whenever(votingEmotesRepository.findById(1L)).thenReturn(Optional.empty())
+        whenever(member.asMention).thenReturn("<@99>")
+        whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
 
         command.onSlashCommandInteraction(slashEvent)
 
-        assertEquals("Vote started by <@99>\n\nShould we do this?", command.createdContent)
-        assertEquals(listOf("✅", "❎"), command.capturedReactions)
+        verify(slashEvent).replyModal(org.mockito.kotlin.argThat {
+            id == "vote:yesno" &&
+                    title == "Create Vote" &&
+                    components.single().asLabel().label == "Vote prompt"
+        })
     }
 
     @Test
-    fun `yesno uses configured custom emoji when available`() {
-        stubSlashCommandContext("yesno")
-        stubGuildId()
-        stubVoteMessageContext()
-        command.prompt = "Use custom emoji?"
-        command.yesNoReactionsOverride = listOf(Emoji.fromFormatted("<:yes:100>"), Emoji.fromFormatted("<:no:101>"))
+    fun `numeric opens vote modal with count in id`() {
+        stubSlashCommandContext("numeric")
+        whenever(member.asMention).thenReturn("<@99>")
+        command.count = 5
+        whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
 
         command.onSlashCommandInteraction(slashEvent)
 
-        assertEquals(listOf("<:yes:100>", "<:no:101>"), command.capturedReactions)
+        verify(slashEvent).replyModal(org.mockito.kotlin.argThat {
+            id == "vote:numeric:5" && title == "Create Numeric Vote"
+        })
     }
 
     @Test
     fun `numeric rejects invalid count`() {
         stubSlashCommandContext("numeric")
-        stubReply()
-        command.prompt = "Pick one"
+        stubReply(slash = true)
         command.count = 1
 
         command.onSlashCommandInteraction(slashEvent)
@@ -110,13 +124,51 @@ class VoteCommandTest {
     }
 
     @Test
-    fun `numeric vote preserves eleven option sequence`() {
-        stubSlashCommandContext("numeric")
-        stubVoteMessageContext()
-        command.prompt = "Pick a number"
-        command.count = 11
+    fun `modal rejects blank prompt`() {
+        stubModalContext("vote:yesno")
+        stubReply(modal = true)
+        whenever(modalEvent.getValue("prompt")).thenReturn(promptValue)
+        whenever(promptValue.asString).thenReturn("   ")
 
-        command.onSlashCommandInteraction(slashEvent)
+        command.onModalInteraction(modalEvent)
+
+        verify(modalEvent).reply("Please provide a vote prompt.")
+    }
+
+    @Test
+    fun `yesno modal creates plain text vote with default reactions`() {
+        stubModalContext("vote:yesno")
+        stubGuildId()
+        stubVoteMessageContext()
+        command.modalPrompt = "Should we do this?"
+        whenever(votingEmotesRepository.findById(1L)).thenReturn(Optional.empty())
+
+        command.onModalInteraction(modalEvent)
+
+        assertEquals("Vote started by <@99>\n\nShould we do this?", command.createdContent)
+        assertEquals(listOf("✅", "❎"), command.capturedReactions)
+    }
+
+    @Test
+    fun `yesno modal uses configured custom emoji when available`() {
+        stubModalContext("vote:yesno")
+        stubGuildId()
+        stubVoteMessageContext()
+        command.modalPrompt = "Use custom emoji?"
+        command.yesNoReactionsOverride = listOf(Emoji.fromFormatted("<:yes:100>"), Emoji.fromFormatted("<:no:101>"))
+
+        command.onModalInteraction(modalEvent)
+
+        assertEquals(listOf("<:yes:100>", "<:no:101>"), command.capturedReactions)
+    }
+
+    @Test
+    fun `numeric modal preserves eleven option sequence`() {
+        stubModalContext("vote:numeric:11")
+        stubVoteMessageContext()
+        command.modalPrompt = "Pick a number"
+
+        command.onModalInteraction(modalEvent)
 
         assertTrue(command.createdContent!!.contains("Options: 1-11"))
         assertEquals(listOf("1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣", "7⃣", "8⃣", "9⃣", "🔟", "0⃣"), command.capturedReactions)
@@ -124,16 +176,16 @@ class VoteCommandTest {
 
     @Test
     fun `reaction failure sends ephemeral followup`() {
-        stubSlashCommandContext("yesno")
+        stubModalContext("vote:yesno")
         stubGuildId()
         stubVoteMessageContext()
         stubFollowupReply()
-        command.prompt = "Should we do this?"
+        command.modalPrompt = "Should we do this?"
         command.reactionFailure = IllegalStateException("boom")
-        whenever(slashEvent.hook).thenReturn(interactionHook)
+        whenever(modalEvent.hook).thenReturn(interactionHook)
         whenever(votingEmotesRepository.findById(1L)).thenReturn(Optional.empty())
 
-        command.onSlashCommandInteraction(slashEvent)
+        command.onModalInteraction(modalEvent)
 
         verify(interactionHook).sendMessage("The vote message was posted, but I could not add all reactions.")
         verify(followupAction).setEphemeral(true)
@@ -141,16 +193,16 @@ class VoteCommandTest {
 
     @Test
     fun `vote message failure falls back to ephemeral reply`() {
-        stubSlashCommandContext("yesno")
+        stubModalContext("vote:yesno")
         stubGuildId()
         stubVoteMessageContext()
         stubFollowupReply()
-        command.prompt = "Should we do this?"
+        command.modalPrompt = "Should we do this?"
         command.voteMessageFailure = IllegalStateException("boom")
-        whenever(slashEvent.hook).thenReturn(interactionHook)
+        whenever(modalEvent.hook).thenReturn(interactionHook)
         whenever(votingEmotesRepository.findById(1L)).thenReturn(Optional.empty())
 
-        command.onSlashCommandInteraction(slashEvent)
+        command.onModalInteraction(modalEvent)
 
         verify(interactionHook).sendMessage("I could not post the vote message in this channel.")
         verify(followupAction).setEphemeral(true)
@@ -178,7 +230,7 @@ class VoteCommandTest {
         var capturedMessage: Message? = null
 
         realCommand.createVoteMessage(
-            event = slashEvent,
+            deferReply = slashEvent::deferReply,
             content = "Vote content",
             onSuccess = { capturedMessage = it },
             onFailure = { throw AssertionError("Unexpected failure", it) }
@@ -196,6 +248,8 @@ class VoteCommandTest {
         assertEquals("vote", commandData.name)
         assertEquals(setOf(InteractionContextType.GUILD), commandData.contexts)
         assertEquals(listOf("yesno", "numeric"), commandData.subcommands.map(SubcommandData::getName))
+        assertTrue(commandData.subcommands.flatMap { it.options }.none { it.name == "prompt" })
+        assertEquals(listOf("count"), commandData.subcommands.single { it.name == "numeric" }.options.map { it.name })
     }
 
     private fun stubSlashCommandContext(subcommandName: String) {
@@ -203,6 +257,14 @@ class VoteCommandTest {
         whenever(slashEvent.guild).thenReturn(guild)
         whenever(slashEvent.member).thenReturn(member)
         whenever(slashEvent.subcommandName).thenReturn(subcommandName)
+    }
+
+    private fun stubModalContext(modalId: String) {
+        whenever(modalEvent.modalId).thenReturn(modalId)
+        whenever(modalEvent.guild).thenReturn(guild)
+        whenever(modalEvent.member).thenReturn(member)
+        whenever(modalEvent.getValue("prompt")).thenReturn(promptValue)
+        whenever(promptValue.asString).thenAnswer { command.modalPrompt }
     }
 
     private fun stubGuildId() {
@@ -213,8 +275,13 @@ class VoteCommandTest {
         whenever(member.asMention).thenReturn("<@99>")
     }
 
-    private fun stubReply() {
-        whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)
+    private fun stubReply(slash: Boolean = false, modal: Boolean = false) {
+        if (slash) {
+            whenever(slashEvent.reply(any<String>())).thenReturn(replyAction)
+        }
+        if (modal) {
+            whenever(modalEvent.reply(any<String>())).thenReturn(replyAction)
+        }
         whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
     }
 
@@ -226,17 +293,13 @@ class VoteCommandTest {
     private class TestVoteCommand(
         votingEmotesRepository: VotingEmotesRepository
     ) : VoteCommand(votingEmotesRepository) {
-        var prompt: String? = null
         var count: Int? = null
+        var modalPrompt: String? = null
         var createdContent: String? = null
         var capturedReactions: List<String> = emptyList()
         var yesNoReactionsOverride: List<Emoji>? = null
         var voteMessageFailure: Throwable? = null
         var reactionFailure: Throwable? = null
-
-        override fun getPrompt(event: SlashCommandInteractionEvent): String? {
-            return prompt
-        }
 
         override fun getCount(event: SlashCommandInteractionEvent): Int? {
             return count
@@ -246,8 +309,12 @@ class VoteCommandTest {
             return yesNoReactionsOverride ?: super.resolveYesNoReactions(guildId, event)
         }
 
+        override fun resolveYesNoReactions(guildId: Long, event: ModalInteractionEvent): List<Emoji> {
+            return yesNoReactionsOverride ?: super.resolveYesNoReactions(guildId, event)
+        }
+
         override fun createVoteMessage(
-            event: SlashCommandInteractionEvent,
+            deferReply: (Boolean) -> ReplyCallbackAction,
             content: String,
             onSuccess: (Message) -> Unit,
             onFailure: (Throwable) -> Unit


### PR DESCRIPTION
## Summary
- open a modal to collect the vote prompt for /vote yesno
- keep /vote numeric count as a slash option and collect the prompt through the modal
- update vote command tests for the modal-based flow

## Testing
- .\gradlew.bat test --tests be.duncanc.discordmodbot.voting.VoteCommandTest