### PR TITLE
fix(moderation): show active warning count in warn modals

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
@@ -110,7 +110,7 @@ class AddWarnPointsByIdCommand(
             return
         }
 
-        event.replyModal(createReasonModal(targetUserId, points, days, action)).queue()
+        event.replyModal(createReasonModal(moderator.guild.idLong, targetUserId, points, days, action)).queue()
     }
 
     override fun onModalInteraction(event: ModalInteractionEvent) {
@@ -567,8 +567,11 @@ class AddWarnPointsByIdCommand(
         }
     }
 
-    private fun createReasonModal(targetUserId: Long, points: Int, days: Int, action: Int): Modal {
+    private fun createReasonModal(guildId: Long, targetUserId: Long, points: Int, days: Int, action: Int): Modal {
         val targetText = TextDisplay.of("Warning: <@$targetUserId> (ID: $targetUserId)")
+        val activeWarningsText = TextDisplay.of(
+            "Active warnings: ${guildWarnPointsService.getActivePointsCount(guildId, targetUserId)}"
+        )
         val textInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
             .setPlaceholder("Enter the reason for this warning...")
             .setMinLength(1)
@@ -576,7 +579,7 @@ class AddWarnPointsByIdCommand(
             .build()
 
         val modalBuilder = Modal.create("$MODAL_ID:$targetUserId:$points:$days:$action", "Enter Reason")
-            .addComponents(targetText, Label.of("Reason", textInput))
+            .addComponents(targetText, activeWarningsText, Label.of("Reason", textInput))
 
         if (action == 1) {
             val unmuteDaysInput = TextInput.create(UNMUTE_DAYS_INPUT_ID, TextInputStyle.SHORT)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -107,7 +107,7 @@ class AddWarnPointsCommand(
             return
         }
 
-        event.replyModal(createReasonModal(targetMember, points, days, action)).queue()
+        event.replyModal(createReasonModal(moderator.guild.idLong, targetMember, points, days, action)).queue()
     }
 
     override fun onModalInteraction(event: ModalInteractionEvent) {
@@ -641,10 +641,13 @@ class AddWarnPointsCommand(
             .queue()
     }
 
-    private fun createReasonModal(targetMember: Member, points: Int, days: Int, action: Int): Modal {
+    private fun createReasonModal(guildId: Long, targetMember: Member, points: Int, days: Int, action: Int): Modal {
         val modalId = "$MODAL_ID:${targetMember.idLong}:$points:$days:$action"
         val targetText = TextDisplay.of(
             "Warning: ${targetMember.nicknameAndUsername} (<@${targetMember.idLong}>, ID: ${targetMember.idLong})"
+        )
+        val activeWarningsText = TextDisplay.of(
+            "Active warnings: ${guildWarnPointsService.getActivePointsCount(guildId, targetMember.idLong)}"
         )
         val textInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
             .setPlaceholder("Enter the reason for this warning...")
@@ -653,7 +656,7 @@ class AddWarnPointsCommand(
             .build()
 
         val modalBuilder = Modal.create(modalId, "Enter Reason")
-            .addComponents(targetText, Label.of("Reason", textInput))
+            .addComponents(targetText, activeWarningsText, Label.of("Reason", textInput))
 
         if (action == 1) {
             val unmuteDaysInput = TextInput.create(UNMUTE_DAYS_INPUT_ID, TextInputStyle.SHORT)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommandTest.kt
@@ -136,28 +136,32 @@ class AddWarnPointsByIdCommandTest {
     @Test
     fun `opens a reason modal`() {
         stubSlashContext(targetMember = null)
+        whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(2)
         whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
 
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent).replyModal(argThat {
             id == "addwarnpointsbyid_reason:99:2:3:0" &&
-                components.size == 2 &&
-                components[0].asTextDisplay().content == "Warning: <@99> (ID: 99)"
+                components.size == 3 &&
+                components[0].asTextDisplay().content == "Warning: <@99> (ID: 99)" &&
+                components[1].asTextDisplay().content == "Active warnings: 2"
         })
     }
 
     @Test
     fun `mute slash command opens a combined modal`() {
         stubSlashContext(targetMember = null, action = 1)
+        whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(4)
         whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
 
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent).replyModal(argThat {
             id == "addwarnpointsbyid_reason:99:2:3:1" &&
-                components.size == 3 &&
-                components[0].asTextDisplay().content == "Warning: <@99> (ID: 99)"
+                components.size == 4 &&
+                components[0].asTextDisplay().content == "Warning: <@99> (ID: 99)" &&
+                components[1].asTextDisplay().content == "Active warnings: 4"
         })
     }
 
@@ -467,7 +471,9 @@ The user was not warned by DM, please do so manually when they rejoin.""",
     ) {
         whenever(slashEvent.name).thenReturn("addwarnpointsbyid")
         whenever(slashEvent.member).thenReturn(member)
+        whenever(member.guild).thenReturn(guild)
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(guild.idLong).thenReturn(1L)
         whenever(slashEvent.getOption("user")).thenReturn(userOption)
         whenever(slashEvent.getOption("points")).thenReturn(pointsOption)
         whenever(slashEvent.getOption("days")).thenReturn(daysOption)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommandTest.kt
@@ -180,20 +180,23 @@ class AddWarnPointsCommandTest {
     @Test
     fun `mute slash command opens a combined modal`() {
         stubSlashCommand(action = 1)
+        whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(3)
         whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
 
         command.onSlashCommandInteraction(slashEvent)
 
         verify(slashEvent).replyModal(argThat {
             id == "addwarnpoints_reason:99:2:3:1" &&
-                components.size == 3 &&
-                components[0].asTextDisplay().content == "Warning: TargetUser (<@99>, ID: 99)"
+                components.size == 4 &&
+                components[0].asTextDisplay().content == "Warning: TargetUser (<@99>, ID: 99)" &&
+                components[1].asTextDisplay().content == "Active warnings: 3"
         })
     }
 
     @Test
     fun `kick slash command opens a reason only modal`() {
         stubSlashCommand(action = 2)
+        whenever(guildWarnPointsService.getActivePointsCount(1L, 99L)).thenReturn(1)
         whenever(member.hasPermission(Permission.KICK_MEMBERS)).thenReturn(true)
         whenever(slashEvent.replyModal(any())).thenReturn(modalAction)
 
@@ -201,8 +204,9 @@ class AddWarnPointsCommandTest {
 
         verify(slashEvent).replyModal(argThat {
             id == "addwarnpoints_reason:99:2:3:2" &&
-                components.size == 2 &&
-                components[0].asTextDisplay().content == "Warning: TargetUser (<@99>, ID: 99)"
+                components.size == 3 &&
+                components[0].asTextDisplay().content == "Warning: TargetUser (<@99>, ID: 99)" &&
+                components[1].asTextDisplay().content == "Active warnings: 1"
         })
     }
 
@@ -435,12 +439,15 @@ class AddWarnPointsCommandTest {
     private fun stubSlashCommand(action: Int) {
         whenever(slashEvent.name).thenReturn("addwarnpoints")
         whenever(slashEvent.member).thenReturn(member)
+        whenever(member.guild).thenReturn(guild)
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(guild.idLong).thenReturn(1L)
         whenever(slashEvent.getOption("user")).thenReturn(userOption)
         whenever(userOption.asMember).thenReturn(targetMember)
         whenever(targetMember.idLong).thenReturn(99L)
         whenever(targetMember.user).thenReturn(targetUser)
         whenever(targetMember.nickname).thenReturn(null)
+        whenever(targetMember.guild).thenReturn(guild)
         whenever(targetUser.name).thenReturn("TargetUser")
         whenever(member.canInteract(targetMember)).thenReturn(true)
         whenever(slashEvent.getOption("points")).thenReturn(pointsOption)


### PR DESCRIPTION
## Summary
- show the current active warning count in the add-warn modal
- show the same count in the add-warn-by-id modal
- update modal-opening tests for both command paths

## Testing
- .\gradlew.bat test --tests "be.duncanc.discordmodbot.moderation.AddWarnPointsCommandTest" --tests "be.duncanc.discordmodbot.moderation.AddWarnPointsByIdCommandTest"