### PR TITLE
feat(moderation): log purgechannel transcripts

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommand.kt
@@ -85,9 +85,10 @@ class PurgeChannelCommand : ListenerAdapter(), SlashCommand {
                 try {
                     val messagesToDelete = messages ?: ArrayList()
                     val deletingCount = messagesToDelete.size
+                    val transcript = buildPurgeTranscript(channel, messagesToDelete)
                     channel.purgeMessages(messagesToDelete)
                     hook.editOriginal("Attempting to delete $deletingCount message(s) from <@$targetUserId>.").queue()
-                    logPurge(event, guild, channel, targetUserId)
+                    logPurge(event, guild, channel, targetUserId, deletingCount, transcript)
                 } catch (e: Exception) {
                     hook.editOriginal("Failed to purge messages: ${e.message ?: "unknown error"}").queue()
                 }
@@ -108,9 +109,10 @@ class PurgeChannelCommand : ListenerAdapter(), SlashCommand {
                 try {
                     val messagesToDelete = messages ?: ArrayList()
                     val deletingCount = messagesToDelete.size
+                    val transcript = buildPurgeTranscript(channel, messagesToDelete)
                     channel.purgeMessages(messagesToDelete)
                     hook.editOriginal("Attempting to delete $deletingCount message(s).").queue()
-                    logPurge(event, guild, channel, null)
+                    logPurge(event, guild, channel, null, deletingCount, transcript)
                 } catch (e: Exception) {
                     hook.editOriginal("Failed to purge messages: ${e.message ?: "unknown error"}").queue()
                 }
@@ -157,20 +159,55 @@ class PurgeChannelCommand : ListenerAdapter(), SlashCommand {
         event: SlashCommandInteractionEvent,
         guild: Guild,
         channel: TextChannel,
-        targetUserId: Long?
+        targetUserId: Long?,
+        deletingCount: Int,
+        transcript: ByteArray
     ) {
-        val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as? GuildLogger ?: return
+        val guildLogger = runCatching {
+            event.jda.registeredListeners.firstOrNull { it is GuildLogger } as? GuildLogger
+        }.getOrNull() ?: return
         val logEmbed = EmbedBuilder()
             .setColor(Color.YELLOW)
             .setTitle(if (targetUserId == null) "Channel purge" else "Filtered channel purge")
             .addField("Moderator", event.member!!.nicknameAndUsername, true)
             .addField("Channel", channel.name, true)
+            .addField("Amount of deleted messages", deletingCount.toString(), true)
 
         if (targetUserId != null) {
             logEmbed.addField("Filter", "<@$targetUserId>", true)
         }
 
-        guildLogger.log(logEmbed, event.user, guild, null, GuildLogger.LogTypeAction.MODERATOR)
+        guildLogger.log(logEmbed, event.user, guild, null, GuildLogger.LogTypeAction.MODERATOR, transcript)
+    }
+
+    private fun buildPurgeTranscript(channel: TextChannel, messages: List<Message>): ByteArray {
+        val logWriter = StringBuilder(channel.toString()).append("\n")
+
+        messages.forEach { message ->
+            logWriter.append(message.author.toString()).append(":\n")
+                .append(message.contentDisplay).append("\n\n")
+
+            if (message.attachments.isNotEmpty()) {
+                logWriter.append("Attachment(s):\n")
+                message.attachments.forEach { attachment ->
+                    logWriter.append("[").append(attachment.fileName)
+                        .append("](").append(attachment.url).append(")\n")
+                }
+                logWriter.append("\n")
+            }
+
+            if (message.mentions.customEmojis.isNotEmpty()) {
+                logWriter.append("Emote(s):\n")
+                message.mentions.customEmojis.forEach { emote ->
+                    logWriter.append("[").append(emote.name)
+                        .append("](").append(emote.imageUrl).append(")\n")
+                }
+                logWriter.append("\n")
+            }
+        }
+
+        logWriter.append("Logged on ").append(OffsetDateTime.now().toString())
+        return logWriter.toString().toByteArray()
     }
 
     override fun getCommandsData(): List<SlashCommandData> {

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommandTest.kt
@@ -1,5 +1,7 @@
 package be.duncanc.discordmodbot.moderation
 
+import be.duncanc.discordmodbot.logging.GuildLogger
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.*
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
@@ -11,6 +13,7 @@ import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import net.dv8tion.jda.api.requests.restaction.pagination.MessagePaginationAction
 import net.dv8tion.jda.api.utils.Procedure
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -65,6 +68,18 @@ class PurgeChannelCommandTest {
 
     @Mock
     private lateinit var author: User
+
+    @Mock
+    private lateinit var moderatorUser: User
+
+    @Mock
+    private lateinit var mentions: Mentions
+
+    @Mock
+    private lateinit var jda: JDA
+
+    @Mock
+    private lateinit var guildLogger: GuildLogger
 
     @Mock
     private lateinit var amountOption: OptionMapping
@@ -172,6 +187,7 @@ class PurgeChannelCommandTest {
         }.whenever(replyAction).queue(any<Consumer<InteractionHook>>())
         whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
         whenever(textChannel.iterableHistory.cache(false)).thenReturn(messagePaginationAction)
+        whenever(textChannel.name).thenReturn("general")
         doAnswer {
             val procedure = it.arguments[0] as Procedure<Message>
             procedure.execute(message)
@@ -179,14 +195,34 @@ class PurgeChannelCommandTest {
             CompletableFuture.completedFuture(null)
         }.whenever(messagePaginationAction).forEachAsync(any())
         whenever(message.author).thenReturn(author)
+        whenever(message.contentDisplay).thenReturn("message to remove")
+        whenever(message.attachments).thenReturn(emptyList())
+        whenever(message.mentions).thenReturn(mentions)
         whenever(message.timeCreated).thenReturn(OffsetDateTime.now().minusDays(1))
         whenever(oldMessage.timeCreated).thenReturn(OffsetDateTime.now().minusWeeks(3))
         whenever(author.idLong).thenReturn(99L)
+        whenever(mentions.customEmojis).thenReturn(emptyList())
+        whenever(member.nickname).thenReturn(null)
+        whenever(member.user).thenReturn(moderatorUser)
+        whenever(moderatorUser.name).thenReturn("ModeratorUser")
+        whenever(slashEvent.user).thenReturn(moderatorUser)
+        whenever(slashEvent.jda).thenReturn(jda)
+        whenever(jda.registeredListeners).thenReturn(listOf(guildLogger))
 
         command.onSlashCommandInteraction(slashEvent)
 
+        val transcriptCaptor = argumentCaptor<ByteArray>()
         verify(textChannel).purgeMessages(listOf(message))
         verify(interactionHook).editOriginal("Attempting to delete 1 message(s) from <@99>.")
+        verify(guildLogger).log(
+            any(),
+            eq(moderatorUser),
+            eq(guild),
+            isNull(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            transcriptCaptor.capture()
+        )
+        assertTrue(String(transcriptCaptor.firstValue).contains("message to remove"))
     }
 
     private fun stubGuildContext(subcommandName: String) {


### PR DESCRIPTION
## Summary
- attach a chat log transcript when purgechannel deletes messages
- include deleted message counts in purgechannel moderator logs
- cover transcript logging in PurgeChannelCommandTest

## Tests
- .\gradlew.bat test --tests "be.duncanc.discordmodbot.moderation.PurgeChannelCommandTest"