### PR TITLE
fix: stop purge scan at to boundary

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
@@ -22,7 +22,7 @@ class ReviewManager(
         val pendingUserIds = storedQuestions
             .asSequence()
             .filterNotNull()
-            .filter { it.guildId == guildId && it.userId > 0L }
+            .filter { it.guildId == guildId && it.userId.toULong() > 0uL }
             .sortedBy { it.queuedAt }
             .map { it.userId }
             .toList()

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommand.kt
@@ -227,6 +227,10 @@ class PurgeChannelCommand : ListenerAdapter(), SlashCommand {
                     }
                 }
 
+                if (toMessageId != null && messageId == toMessageId) {
+                    return@forEachAsync false
+                }
+
                 true
             }
             .thenApply { messages }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommand.kt
@@ -37,7 +37,7 @@ class PurgeChannelCommand : ListenerAdapter(), SlashCommand {
             data object Omitted : MessageIdOption
             data object Invalid : MessageIdOption
 
-            data class Present(val messageId: Long) : MessageIdOption
+            data class Present(val messageId: ULong) : MessageIdOption
         }
     }
 
@@ -152,7 +152,7 @@ class PurgeChannelCommand : ListenerAdapter(), SlashCommand {
         return amount
     }
 
-    private fun getValidatedMessageRange(event: SlashCommandInteractionEvent): Pair<Long?, Long?>? {
+    private fun getValidatedMessageRange(event: SlashCommandInteractionEvent): Pair<ULong?, ULong?>? {
         val fromMessageId = getValidatedMessageId(event, OPTION_FROM)
         val toMessageId = getValidatedMessageId(event, OPTION_TO)
         if (fromMessageId == MessageIdOption.Invalid || toMessageId == MessageIdOption.Invalid) {
@@ -180,7 +180,7 @@ class PurgeChannelCommand : ListenerAdapter(), SlashCommand {
             return MessageIdOption.Invalid
         }
 
-        val messageId = rawValue.toLongOrNull()
+        val messageId = rawValue.toULongOrNull()
         if (messageId == null) {
             event.reply("Please provide a valid message ID for $optionName.").setEphemeral(true).queue()
             return MessageIdOption.Invalid
@@ -193,8 +193,8 @@ class PurgeChannelCommand : ListenerAdapter(), SlashCommand {
         channel: TextChannel,
         amount: Int,
         targetUserId: Long? = null,
-        fromMessageId: Long? = null,
-        toMessageId: Long? = null
+        fromMessageId: ULong? = null,
+        toMessageId: ULong? = null
     ): CompletableFuture<ArrayList<Message>> {
         val messages = ArrayList<Message>()
         val oldestPurgeableMessageDate = OffsetDateTime.now().minusWeeks(2)
@@ -202,7 +202,7 @@ class PurgeChannelCommand : ListenerAdapter(), SlashCommand {
 
         return channel.iterableHistory.cache(false)
             .forEachAsync { message ->
-                val messageId = message.idLong
+                val messageId = message.idLong.toULong()
 
                 if (message.timeCreated.isBefore(oldestPurgeableMessageDate)) {
                     return@forEachAsync false

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommandTest.kt
@@ -82,6 +82,9 @@ class PurgeChannelCommandTest {
     private lateinit var veryOldMessage: Message
 
     @Mock
+    private lateinit var pastBoundaryMessage: Message
+
+    @Mock
     private lateinit var author: User
 
     @Mock
@@ -319,6 +322,47 @@ class PurgeChannelCommandTest {
     }
 
     @Test
+    fun `filtered mode stops scanning after the to message`() {
+        stubGuildContext(subcommandName = "filtered")
+        stubMemberPermission()
+        stubBotPermissions()
+        whenever(slashEvent.getOption("amount")).thenReturn(amountOption)
+        whenever(amountOption.asInt).thenReturn(10)
+        whenever(slashEvent.getOption("target")).thenReturn(targetOption)
+        whenever(targetOption.asLong).thenReturn(99L)
+        whenever(slashEvent.getOption("from")).thenReturn(fromOption)
+        whenever(fromOption.asString).thenReturn("300")
+        whenever(slashEvent.getOption("to")).thenReturn(toOption)
+        whenever(toOption.asString).thenReturn("200")
+        whenever(slashEvent.deferReply(true)).thenReturn(replyAction)
+        doAnswer {
+            val consumer = it.arguments[0] as Consumer<InteractionHook>
+            consumer.accept(interactionHook)
+            null
+        }.whenever(replyAction).queue(any<Consumer<InteractionHook>>())
+        whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
+        whenever(textChannel.name).thenReturn("general")
+        stubHistory(message, otherMessage, oldMessage, pastBoundaryMessage)
+        stubMessage(message, author, 300L, "message to remove")
+        stubMessage(otherMessage, moderatorUser, 250L, "message from someone else")
+        stubMessage(oldMessage, author, 200L, "message in range")
+        whenever(author.idLong).thenReturn(99L)
+        whenever(moderatorUser.idLong).thenReturn(77L)
+        whenever(member.nickname).thenReturn(null)
+        whenever(member.user).thenReturn(moderatorUser)
+        whenever(moderatorUser.name).thenReturn("ModeratorUser")
+        whenever(slashEvent.user).thenReturn(moderatorUser)
+        whenever(slashEvent.jda).thenReturn(jda)
+        whenever(jda.registeredListeners).thenReturn(listOf(guildLogger))
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(textChannel).purgeMessages(listOf(message, oldMessage))
+        verify(interactionHook).editOriginal("Attempting to delete 2 message(s) from <@99>.")
+        verify(interactionHook, never()).editOriginal(argThat<String> { startsWith("Failed to purge messages:") })
+    }
+
+    @Test
     fun `invalid from message id returns error and aborts purge`() {
         stubGuildContext(subcommandName = "all")
         stubImmediateReply()
@@ -406,7 +450,11 @@ class PurgeChannelCommandTest {
         whenever(textChannel.iterableHistory.cache(false)).thenReturn(messagePaginationAction)
         doAnswer {
             val procedure = it.arguments[0] as Procedure<Message>
-            messages.forEach { message -> procedure.execute(message) }
+            messages.forEach { message ->
+                if (!procedure.execute(message)) {
+                    return@doAnswer CompletableFuture.completedFuture(null)
+                }
+            }
             CompletableFuture.completedFuture(null)
         }.whenever(messagePaginationAction).forEachAsync(any())
     }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/PurgeChannelCommandTest.kt
@@ -397,6 +397,47 @@ class PurgeChannelCommandTest {
     }
 
     @Test
+    fun `all mode handles unsigned snowflake overflow correctly`() {
+        stubGuildContext(subcommandName = "all")
+        stubMemberPermission()
+        stubBotPermissions()
+        whenever(slashEvent.getOption("amount")).thenReturn(amountOption)
+        whenever(amountOption.asInt).thenReturn(10)
+        whenever(slashEvent.getOption("from")).thenReturn(fromOption)
+        whenever(fromOption.asString).thenReturn("18446744073709551615")
+        whenever(slashEvent.getOption("to")).thenReturn(toOption)
+        whenever(toOption.asString).thenReturn("100")
+        whenever(slashEvent.deferReply(true)).thenReturn(replyAction)
+        doAnswer {
+            val consumer = it.arguments[0] as Consumer<InteractionHook>
+            consumer.accept(interactionHook)
+            null
+        }.whenever(replyAction).queue(any<Consumer<InteractionHook>>())
+        whenever(interactionHook.editOriginal(any<String>())).thenReturn(editAction)
+        whenever(textChannel.name).thenReturn("general")
+        val overflowMessage = message
+        val middleMessage = oldMessage
+        val toMessage = veryOldMessage
+        val pastMessage = pastBoundaryMessage
+        stubHistory(overflowMessage, middleMessage, toMessage, pastMessage)
+        stubMessage(overflowMessage, author, -1L, "overflow message")
+        stubMessage(middleMessage, author, 150L, "middle message")
+        stubMessage(toMessage, author, 100L, "to message")
+        stubMessage(pastMessage, author, 50L, "past message")
+        whenever(member.nickname).thenReturn(null)
+        whenever(member.user).thenReturn(moderatorUser)
+        whenever(moderatorUser.name).thenReturn("ModeratorUser")
+        whenever(slashEvent.user).thenReturn(moderatorUser)
+        whenever(slashEvent.jda).thenReturn(jda)
+        whenever(jda.registeredListeners).thenReturn(listOf(guildLogger))
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(textChannel).purgeMessages(listOf(overflowMessage, middleMessage, toMessage))
+        verify(interactionHook).editOriginal("Attempting to delete 3 message(s).")
+    }
+
+    @Test
     fun `from must be newer than to`() {
         stubGuildContext(subcommandName = "all")
         stubImmediateReply()


### PR DESCRIPTION
## Summary
- stop purge history traversal immediately after processing the exact `to` message
- keep the `to` boundary inclusive for both purge modes
- add a regression test that verifies filtered purges do not continue scanning past the boundary

## Testing
- `./gradlew.bat test --tests "be.duncanc.discordmodbot.moderation.PurgeChannelCommandTest"`
