### PR TITLE
feat: encrypt stored discord messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-flyway")
     implementation("org.springframework.boot:spring-boot-starter-restclient")
+    implementation("org.springframework.security:spring-security-crypto")
     implementation("org.flywaydb:flyway-mysql")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("net.dv8tion:JDA:$jdaVersion") {

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageContentEncryptor.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageContentEncryptor.kt
@@ -1,0 +1,18 @@
+package be.duncanc.discordmodbot.logging
+
+import org.springframework.security.crypto.encrypt.Encryptors
+import org.springframework.stereotype.Component
+
+@Component
+class MessageContentEncryptor(
+    messageEncryptionProperties: MessageEncryptionProperties,
+) {
+    private val textEncryptor = Encryptors.delux(
+        messageEncryptionProperties.password,
+        messageEncryptionProperties.salt,
+    )
+
+    fun encrypt(content: String): String = textEncryptor.encrypt(content)
+
+    fun decrypt(content: String): String = textEncryptor.decrypt(content)
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageEncryptionProperties.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageEncryptionProperties.kt
@@ -1,0 +1,16 @@
+package be.duncanc.discordmodbot.logging
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+
+@ConfigurationProperties("discord-mod-bot.message-encryption")
+@Validated
+class MessageEncryptionProperties(
+    @field:NotBlank
+    val password: String = throw IllegalStateException("message encryption password not configured"),
+    @field:NotBlank
+    @field:Pattern(regexp = "([0-9a-fA-F]{2}){16,}", message = "must be an even-length hex value of at least 32 characters")
+    val salt: String = throw IllegalStateException("message encryption salt not configured"),
+)

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageHistory.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageHistory.kt
@@ -22,7 +22,8 @@ class MessageHistory
 @Autowired
 constructor(
     private val discordMessageRepository: DiscordMessageRepository,
-    private val attachmentProxyCreator: AttachmentProxyCreator
+    private val attachmentProxyCreator: AttachmentProxyCreator,
+    private val messageContentEncryptor: MessageContentEncryptor
 ) {
     /**
      * Used to add a message to the list
@@ -43,7 +44,7 @@ constructor(
             message.guild.idLong,
             message.channel.idLong,
             message.author.idLong,
-            message.contentDisplay,
+            messageContentEncryptor.encrypt(message.contentDisplay),
             linkEmotes(message.mentions.customEmojis)
         )
         discordMessageRepository.save(discordMessage)
@@ -70,7 +71,7 @@ constructor(
                 message.guild.idLong,
                 message.channel.idLong,
                 message.author.idLong,
-                message.contentDisplay,
+                messageContentEncryptor.encrypt(message.contentDisplay),
                 existingMessage?.emotes
             )
             discordMessageRepository.save(discordMessage)
@@ -89,7 +90,7 @@ constructor(
         if (discordMessage != null && delete) {
             discordMessageRepository.deleteById(messageId)
         }
-        return discordMessage
+        return discordMessage?.copy(content = messageContentEncryptor.decrypt(discordMessage.content))
     }
 
     internal fun getAttachmentsString(id: Long): String? {

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageHistoryTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageHistoryTest.kt
@@ -1,0 +1,184 @@
+package be.duncanc.discordmodbot.logging
+
+import be.duncanc.discordmodbot.logging.persistence.DiscordMessage
+import be.duncanc.discordmodbot.logging.persistence.DiscordMessageRepository
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.Mentions
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageUpdateEvent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class MessageHistoryTest {
+    @Mock
+    private lateinit var discordMessageRepository: DiscordMessageRepository
+
+    @Mock
+    private lateinit var attachmentProxyCreator: AttachmentProxyCreator
+
+    @Mock
+    private lateinit var receivedEvent: MessageReceivedEvent
+
+    @Mock
+    private lateinit var updateEvent: MessageUpdateEvent
+
+    @Mock
+    private lateinit var message: Message
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var channel: MessageChannelUnion
+
+    @Mock
+    private lateinit var author: User
+
+    @Mock
+    private lateinit var mentions: Mentions
+
+    private lateinit var messageContentEncryptor: MessageContentEncryptor
+    private lateinit var messageHistory: MessageHistory
+
+    @BeforeEach
+    fun setUp() {
+        messageContentEncryptor = MessageContentEncryptor(
+            MessageEncryptionProperties(
+                password = "test-message-encryption-password",
+                salt = "0123456789abcdef0123456789abcdef"
+            )
+        )
+        messageHistory = MessageHistory(discordMessageRepository, attachmentProxyCreator, messageContentEncryptor)
+    }
+
+    @Test
+    fun `store message encrypts content before saving`() {
+        stubReceivedMessage(content = "hello from discord")
+
+        messageHistory.storeMessage(receivedEvent)
+
+        val messageCaptor = argumentCaptor<DiscordMessage>()
+        verify(discordMessageRepository).save(messageCaptor.capture())
+        assertNotEquals("hello from discord", messageCaptor.firstValue.content)
+        assertEquals("hello from discord", messageContentEncryptor.decrypt(messageCaptor.firstValue.content))
+    }
+
+    @Test
+    fun `update message encrypts content before saving`() {
+        stubUpdatedMessage(content = "updated content")
+        whenever(discordMessageRepository.existsById(100L)).thenReturn(true)
+        whenever(discordMessageRepository.findById(100L)).thenReturn(
+            Optional.of(
+                DiscordMessage(
+                    messageId = 100L,
+                    guildId = 1L,
+                    channelId = 10L,
+                    userId = 20L,
+                    content = messageContentEncryptor.encrypt("old content"),
+                    emotes = "[wave](https://cdn.discordapp.com/emote.png)"
+                )
+            )
+        )
+
+        messageHistory.updateMessage(updateEvent)
+
+        val messageCaptor = argumentCaptor<DiscordMessage>()
+        verify(discordMessageRepository).save(messageCaptor.capture())
+        assertNotEquals("updated content", messageCaptor.firstValue.content)
+        assertEquals("updated content", messageContentEncryptor.decrypt(messageCaptor.firstValue.content))
+        assertEquals("[wave](https://cdn.discordapp.com/emote.png)", messageCaptor.firstValue.emotes)
+    }
+
+    @Test
+    fun `get message decrypts content before returning`() {
+        whenever(discordMessageRepository.findById(100L)).thenReturn(
+            Optional.of(
+                DiscordMessage(
+                    messageId = 100L,
+                    guildId = 1L,
+                    channelId = 10L,
+                    userId = 20L,
+                    content = messageContentEncryptor.encrypt("deleted content")
+                )
+            )
+        )
+
+        val result = messageHistory.getMessage(textChannelId = 10L, messageId = 100L)
+
+        assertEquals("deleted content", result?.content)
+        verify(discordMessageRepository).deleteById(100L)
+    }
+
+    @Test
+    fun `bot messages are not encrypted or saved`() {
+        stubReceivedMessage(content = "bot message", isBot = true)
+
+        messageHistory.storeMessage(receivedEvent)
+
+        verify(discordMessageRepository, never()).save(any())
+    }
+
+    private fun stubReceivedMessage(content: String, isBot: Boolean = false) {
+        whenever(receivedEvent.isFromGuild).thenReturn(true)
+        whenever(receivedEvent.message).thenReturn(message)
+        stubMessage(
+            content = content,
+            isBot = isBot,
+            includeStoredFields = !isBot,
+            includeMentions = !isBot,
+            includeAttachments = !isBot
+        )
+    }
+
+    private fun stubUpdatedMessage(content: String) {
+        whenever(updateEvent.isFromGuild).thenReturn(true)
+        whenever(updateEvent.messageIdLong).thenReturn(100L)
+        whenever(updateEvent.message).thenReturn(message)
+        stubMessage(content = content, includeMentions = false, includeAttachments = false, includeBotCheck = false)
+    }
+
+    private fun stubMessage(
+        content: String,
+        isBot: Boolean = false,
+        includeStoredFields: Boolean = true,
+        includeMentions: Boolean = true,
+        includeAttachments: Boolean = true,
+        includeBotCheck: Boolean = true
+    ) {
+        whenever(message.author).thenReturn(author)
+        whenever(message.contentDisplay).thenReturn(content)
+        if (includeBotCheck) {
+            whenever(author.isBot).thenReturn(isBot)
+        }
+        if (includeStoredFields) {
+            whenever(message.idLong).thenReturn(100L)
+            whenever(message.guild).thenReturn(guild)
+            whenever(message.channel).thenReturn(channel)
+            whenever(guild.idLong).thenReturn(1L)
+            whenever(channel.idLong).thenReturn(10L)
+            whenever(author.idLong).thenReturn(20L)
+        }
+        if (includeMentions) {
+            whenever(message.mentions).thenReturn(mentions)
+            whenever(mentions.customEmojis).thenReturn(emptyList())
+        }
+        if (includeAttachments) {
+            whenever(message.attachments).thenReturn(emptyList())
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -16,3 +16,6 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.properties.hibernate.use_sql_comments=true
 # Modulith
 spring.modulith.detection-strategy=explicitly-annotated
+# Discord message encryption
+discord-mod-bot.message-encryption.password=test-message-encryption-password
+discord-mod-bot.message-encryption.salt=0123456789abcdef0123456789abcdef


### PR DESCRIPTION
## Summary
- encrypt Discord message content before storing it in Redis
- decrypt message content at the MessageHistory read boundary
- add mandatory encryption properties and focused MessageHistory tests

## Tests
- .\\gradlew.bat check