### PR TITLE
feat: add message reporting workflow

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -625,6 +625,28 @@ class GuildLogger
         guild: Guild,
         embeds: List<MessageEmbed>? = null,
         actionType: LogTypeAction,
+        bytes: ByteArray? = null
+    ) {
+        logInternal(logEmbed, associatedUser, guild, embeds, actionType, bytes, null)
+    }
+
+    fun logWithContent(
+        logEmbed: EmbedBuilder,
+        associatedUser: User? = null,
+        guild: Guild,
+        embeds: List<MessageEmbed>? = null,
+        actionType: LogTypeAction,
+        content: String
+    ) {
+        logInternal(logEmbed, associatedUser, guild, embeds, actionType, null, content)
+    }
+
+    private fun logInternal(
+        logEmbed: EmbedBuilder,
+        associatedUser: User? = null,
+        guild: Guild,
+        embeds: List<MessageEmbed>? = null,
+        actionType: LogTypeAction,
         bytes: ByteArray? = null,
         content: String? = null
     ) {
@@ -648,7 +670,9 @@ class GuildLogger
                     .setEmbeds(logEmbed.build())
                 if (content != null) {
                     message.addContent(content)
-                        .setAllowedMentions(setOf(Message.MentionType.EVERYONE, Message.MentionType.HERE))
+                        .setAllowedMentions(
+                            setOf(Message.MentionType.EVERYONE, Message.MentionType.HERE, Message.MentionType.ROLE)
+                        )
                 }
                 targetChannel.sendMessage(message.build()).queue()
             } else {

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.audit.AuditLogEntry
 import net.dv8tion.jda.api.audit.AuditLogOption
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
@@ -624,7 +625,8 @@ class GuildLogger
         guild: Guild,
         embeds: List<MessageEmbed>? = null,
         actionType: LogTypeAction,
-        bytes: ByteArray? = null
+        bytes: ByteArray? = null,
+        content: String? = null
     ) {
         val logSettings = loggingSettingsRepository.findById(guild.idLong).orElse(null)
             ?: return
@@ -642,7 +644,13 @@ class GuildLogger
                 logEmbed.setFooter(associatedUser.id, associatedUser.effectiveAvatarUrl)
             }
             if (bytes == null) {
-                targetChannel.sendMessageEmbeds(logEmbed.build()).queue()
+                val message = MessageCreateBuilder()
+                    .setEmbeds(logEmbed.build())
+                if (content != null) {
+                    message.addContent(content)
+                        .setAllowedMentions(setOf(Message.MentionType.EVERYONE, Message.MentionType.HERE))
+                }
+                targetChannel.sendMessage(message.build()).queue()
             } else {
                 targetChannel.sendFiles(FileUpload.fromData(bytes, "chat.log")).queue {
                     it.editMessage(MessageEditData.fromEmbeds(logEmbed.build())).queue()

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -641,6 +641,11 @@ class GuildLogger
         logInternal(logEmbed, associatedUser, guild, embeds, actionType, null, content)
     }
 
+    fun hasModeratorLogChannel(guild: Guild): Boolean {
+        val channelId = loggingSettingsRepository.findById(guild.idLong).orElse(null)?.modLogChannel ?: return false
+        return guild.getTextChannelById(channelId) != null
+    }
+
     private fun logInternal(
         logEmbed: EmbedBuilder,
         associatedUser: User? = null,

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -6,6 +6,7 @@ import be.duncanc.discordmodbot.logging.persistence.LoggingSettings
 import be.duncanc.discordmodbot.logging.persistence.LoggingSettingsRepository
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.audit.ActionType
 import net.dv8tion.jda.api.audit.AuditLogEntry
 import net.dv8tion.jda.api.audit.AuditLogOption
@@ -641,9 +642,15 @@ class GuildLogger
         logInternal(logEmbed, associatedUser, guild, embeds, actionType, null, content)
     }
 
-    fun hasModeratorLogChannel(guild: Guild): Boolean {
+    fun canSendModeratorLog(guild: Guild): Boolean {
         val channelId = loggingSettingsRepository.findById(guild.idLong).orElse(null)?.modLogChannel ?: return false
-        return guild.getTextChannelById(channelId) != null
+        val channel = guild.getTextChannelById(channelId) ?: return false
+        return guild.selfMember.hasPermission(
+            channel,
+            Permission.VIEW_CHANNEL,
+            Permission.MESSAGE_SEND,
+            Permission.MESSAGE_EMBED_LINKS
+        )
     }
 
     private fun logInternal(

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -92,6 +92,12 @@ class ReportMessageContextMenu(
         }
 
         if (existingState == ReportedMessageState.NON_URGENT) {
+            if (reportRateLimitService.hasActiveToken(guild.idLong, reporter.idLong)) {
+                event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
+                    .setEphemeral(true)
+                    .queue()
+                return
+            }
             event.reply("This message was already reported as non-urgent. Confirm if you want to report it as urgent.")
                 .setEphemeral(true)
                 .addComponents(ActionRow.of(buildUrgentConfirmationButtons(guild.idLong, target, reporter.idLong)))
@@ -170,7 +176,7 @@ class ReportMessageContextMenu(
             return
         }
 
-        if (!tryConsumeRateLimitForConfirmation(event, guild, reporter)) {
+        if (!tryConsumeRateLimit(event, guild, reporter)) {
             return
         }
 
@@ -236,14 +242,6 @@ class ReportMessageContextMenu(
             .setEphemeral(true)
             .queue()
         return false
-    }
-
-    private fun tryConsumeRateLimitForConfirmation(event: ButtonInteractionEvent, guild: Guild, reporter: Member): Boolean {
-        if (reportRateLimitService.hasActiveToken(guild.idLong, reporter.idLong)) {
-            return true
-        }
-
-        return tryConsumeRateLimit(event, guild, reporter)
     }
 
     private fun buildUrgentConfirmationButtons(guildId: Long, target: Message, reporterId: Long): List<Button> {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
+import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
@@ -98,9 +99,20 @@ class ReportMessageContextMenu(
                     .queue()
                 return
             }
+            if (!guildLogger.canSendModeratorLog(guild)) {
+                event.reply(NO_MOD_LOG_CHANNEL_MESSAGE).setEphemeral(true).queue()
+                return
+            }
             event.reply("This message was already reported as non-urgent. Confirm if you want to report it as urgent.")
                 .setEphemeral(true)
                 .addComponents(ActionRow.of(buildUrgentConfirmationButtons(guild.idLong, target, reporter.idLong)))
+                .queue()
+            return
+        }
+
+        if (reportRateLimitService.hasActiveToken(guild.idLong, reporter.idLong)) {
+            event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
+                .setEphemeral(true)
                 .queue()
             return
         }
@@ -110,11 +122,12 @@ class ReportMessageContextMenu(
             return
         }
 
+        logReport(guild, reporter, target, urgent)
+
         if (!tryConsumeRateLimit(event, guild, reporter)) {
             return
         }
 
-        logReport(guild, reporter, target, urgent)
         reportedMessageService.markReported(guild.idLong, target.guildChannel.idLong, target.idLong, urgent)
         event.reply("Your report has been sent to the moderation team.").setEphemeral(true).queue()
     }
@@ -171,12 +184,15 @@ class ReportMessageContextMenu(
             return
         }
 
-        if (!guildLogger.canSendModeratorLog(guild)) {
-            event.editMessage(NO_MOD_LOG_CHANNEL_MESSAGE).setComponents(emptyList()).queue()
+        if (reportRateLimitService.hasActiveToken(guild.idLong, reporter.idLong)) {
+            event.editMessage("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
+                .setComponents(emptyList())
+                .queue()
             return
         }
 
-        if (!tryConsumeRateLimit(event, guild, reporter)) {
+        if (!guildLogger.canSendModeratorLog(guild)) {
+            event.editMessage(NO_MOD_LOG_CHANNEL_MESSAGE).setComponents(emptyList()).queue()
             return
         }
 
@@ -190,6 +206,9 @@ class ReportMessageContextMenu(
             channel.retrieveMessageById(action.messageId).queue(
                 { message ->
                     logReport(guild, reporter, message, urgent = true)
+                    if (!tryConsumeRateLimit(hook, guild, reporter)) {
+                        return@queue
+                    }
                     reportedMessageService.markUrgent(guild.idLong, action.channelId, action.messageId)
                     hook.editOriginal("Your urgent report has been sent to the moderation team.")
                         .setComponents(emptyList())
@@ -240,6 +259,17 @@ class ReportMessageContextMenu(
 
         event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
             .setEphemeral(true)
+            .queue()
+        return false
+    }
+
+    private fun tryConsumeRateLimit(hook: InteractionHook, guild: Guild, reporter: Member): Boolean {
+        if (reportRateLimitService.tryConsume(guild.idLong, reporter.idLong)) {
+            return true
+        }
+
+        hook.editOriginal("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
+            .setComponents(emptyList())
             .queue()
         return false
     }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -4,8 +4,14 @@ import be.duncanc.discordmodbot.discord.DiscordCommand
 import be.duncanc.discordmodbot.discord.nicknameAndUsername
 import be.duncanc.discordmodbot.logging.GuildLogger
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.commands.build.CommandData
@@ -18,13 +24,25 @@ class ReportMessageContextMenu(
     private val guildLogger: GuildLogger,
     private val muteService: MuteService,
     private val reportSettingsService: ReportSettingsService,
-    private val reportRateLimitService: ReportRateLimitService
+    private val reportRateLimitService: ReportRateLimitService,
+    private val reportedMessageService: ReportedMessageService
 ) : ListenerAdapter(), DiscordCommand {
     companion object {
         private const val NON_URGENT_COMMAND = "Report Message"
         private const val URGENT_COMMAND = "Urgent Report Message"
         private const val MAX_FIELD_LENGTH = 1024
+        private const val BUTTON_CONFIRM_PREFIX = "report:urgent:"
+        private const val BUTTON_CANCEL_PREFIX = "report:cancel:"
+        private const val ALREADY_REPORTED_MESSAGE = "This issue was already reported."
     }
+
+    private data class UrgentConfirmationAction(
+        val confirm: Boolean,
+        val guildId: Long,
+        val channelId: Long,
+        val messageId: Long,
+        val reporterId: Long
+    )
 
     override fun onMessageContextInteraction(event: MessageContextInteractionEvent) {
         val urgent = when (event.name) {
@@ -50,24 +68,95 @@ class ReportMessageContextMenu(
             return
         }
 
-        if (!reportRateLimitService.tryConsume(guild.idLong, reporter.idLong)) {
-            event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
+        val target = event.target
+        val existingState = reportedMessageService.getState(guild.idLong, target.guildChannel.idLong, target.idLong)
+        if (existingState == ReportedMessageState.URGENT || existingState == ReportedMessageState.NON_URGENT && !urgent) {
+            event.reply(ALREADY_REPORTED_MESSAGE).setEphemeral(true).queue()
+            return
+        }
+
+        if (existingState == ReportedMessageState.NON_URGENT) {
+            event.reply("This message was already reported as non-urgent. Confirm if you want to report it as urgent.")
                 .setEphemeral(true)
+                .addComponents(ActionRow.of(buildUrgentConfirmationButtons(guild.idLong, target, reporter.idLong)))
                 .queue()
             return
         }
 
-        val target = event.target
-        val ping = if (urgent) reportSettingsService.getUrgentMention(guild) else "@here"
-        guildLogger.logWithContent(
-            logEmbed = createReportEmbed(target, reporter.nicknameAndUsername, urgent),
-            associatedUser = target.author,
-            guild = guild,
-            actionType = GuildLogger.LogTypeAction.MODERATOR,
-            content = ping
-        )
+        if (!tryConsumeRateLimit(event, guild, reporter)) {
+            return
+        }
 
+        logReport(guild, reporter, target, urgent)
+        reportedMessageService.markReported(guild.idLong, target.guildChannel.idLong, target.idLong, urgent)
         event.reply("Your report has been sent to the moderation team.").setEphemeral(true).queue()
+    }
+
+    override fun onButtonInteraction(event: ButtonInteractionEvent) {
+        val action = parseUrgentConfirmationAction(event.componentId) ?: return
+
+        if (event.user.idLong != action.reporterId) {
+            event.reply("This confirmation is only for the user who requested it.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!action.confirm) {
+            event.editMessage("Urgent report cancelled.").setComponents(emptyList()).queue()
+            return
+        }
+
+        val guild = event.guild
+        val reporter = event.member
+        if (guild == null || reporter == null || guild.idLong != action.guildId) {
+            event.reply("This report confirmation is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reporter.isTimedOut || muteService.isUserMuted(guild.idLong, reporter.idLong)) {
+            event.reply("You cannot report messages while timed out or muted.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reportSettingsService.isUserBlocked(guild.idLong, reporter.idLong)) {
+            event.reply("You are not allowed to report messages in this server.").setEphemeral(true).queue()
+            return
+        }
+
+        val existingState = reportedMessageService.getState(guild.idLong, action.channelId, action.messageId)
+        if (existingState == ReportedMessageState.URGENT) {
+            event.editMessage(ALREADY_REPORTED_MESSAGE).setComponents(emptyList()).queue()
+            return
+        }
+
+        if (existingState != ReportedMessageState.NON_URGENT) {
+            event.editMessage("This report confirmation expired. Report the message again.")
+                .setComponents(emptyList())
+                .queue()
+            return
+        }
+
+        if (!tryConsumeRateLimit(event, guild, reporter)) {
+            return
+        }
+
+        val channel = event.jda.getChannelById(MessageChannel::class.java, action.channelId)
+        if (channel == null) {
+            event.editMessage("I could not find that message anymore.").setComponents(emptyList()).queue()
+            return
+        }
+
+        channel.retrieveMessageById(action.messageId).queue(
+            { message ->
+                logReport(guild, reporter, message, urgent = true)
+                reportedMessageService.markUrgent(guild.idLong, action.channelId, action.messageId)
+                event.editMessage("Your urgent report has been sent to the moderation team.")
+                    .setComponents(emptyList())
+                    .queue()
+            },
+            {
+                event.editMessage("I could not find that message anymore.").setComponents(emptyList()).queue()
+            }
+        )
     }
 
     override fun getCommandsData(): List<CommandData> {
@@ -76,6 +165,68 @@ class ReportMessageContextMenu(
                 .setContexts(InteractionContextType.GUILD),
             Commands.message(URGENT_COMMAND)
                 .setContexts(InteractionContextType.GUILD)
+        )
+    }
+
+    private fun logReport(guild: Guild, reporter: Member, target: Message, urgent: Boolean) {
+        val ping = if (urgent) reportSettingsService.getUrgentMention(guild) else "@here"
+        guildLogger.logWithContent(
+            logEmbed = createReportEmbed(target, reporter.nicknameAndUsername, urgent),
+            associatedUser = target.author,
+            guild = guild,
+            actionType = GuildLogger.LogTypeAction.MODERATOR,
+            content = ping
+        )
+    }
+
+    private fun tryConsumeRateLimit(event: MessageContextInteractionEvent, guild: Guild, reporter: Member): Boolean {
+        if (reportRateLimitService.tryConsume(guild.idLong, reporter.idLong)) {
+            return true
+        }
+
+        event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
+            .setEphemeral(true)
+            .queue()
+        return false
+    }
+
+    private fun tryConsumeRateLimit(event: ButtonInteractionEvent, guild: Guild, reporter: Member): Boolean {
+        if (reportRateLimitService.tryConsume(guild.idLong, reporter.idLong)) {
+            return true
+        }
+
+        event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
+            .setEphemeral(true)
+            .queue()
+        return false
+    }
+
+    private fun buildUrgentConfirmationButtons(guildId: Long, target: Message, reporterId: Long): List<Button> {
+        val state = "$guildId:${target.guildChannel.idLong}:${target.idLong}:$reporterId"
+        return listOf(
+            Button.danger("$BUTTON_CONFIRM_PREFIX$state", "Report as urgent"),
+            Button.secondary("$BUTTON_CANCEL_PREFIX$state", "Cancel")
+        )
+    }
+
+    private fun parseUrgentConfirmationAction(componentId: String): UrgentConfirmationAction? {
+        val confirm = when {
+            componentId.startsWith(BUTTON_CONFIRM_PREFIX) -> true
+            componentId.startsWith(BUTTON_CANCEL_PREFIX) -> false
+            else -> return null
+        }
+        val prefix = if (confirm) BUTTON_CONFIRM_PREFIX else BUTTON_CANCEL_PREFIX
+        val tokens = componentId.removePrefix(prefix).split(':')
+        if (tokens.size != 4) {
+            return null
+        }
+
+        return UrgentConfirmationAction(
+            confirm = confirm,
+            guildId = tokens[0].toLongOrNull() ?: return null,
+            channelId = tokens[1].toLongOrNull() ?: return null,
+            messageId = tokens[2].toLongOrNull() ?: return null,
+            reporterId = tokens[3].toLongOrNull() ?: return null
         )
     }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -36,7 +36,7 @@ class ReportMessageContextMenu(
         private const val ALREADY_REPORTED_MESSAGE = "This issue was already reported."
         private const val HERE_MENTION = "@here"
         private const val NO_MOD_LOG_CHANNEL_MESSAGE =
-            "Message reporting is not configured on this server. A moderator log channel is required."
+            "Message reporting is not configured on this server. The bot needs a moderator log channel with permission to send messages and embeds."
     }
 
     private data class UrgentConfirmationAction(
@@ -105,7 +105,7 @@ class ReportMessageContextMenu(
             return
         }
 
-        if (!guildLogger.hasModeratorLogChannel(guild)) {
+        if (!guildLogger.canSendModeratorLog(guild)) {
             event.reply(NO_MOD_LOG_CHANNEL_MESSAGE).setEphemeral(true).queue()
             return
         }
@@ -171,7 +171,7 @@ class ReportMessageContextMenu(
             return
         }
 
-        if (!guildLogger.hasModeratorLogChannel(guild)) {
+        if (!guildLogger.canSendModeratorLog(guild)) {
             event.editMessage(NO_MOD_LOG_CHANNEL_MESSAGE).setComponents(emptyList()).queue()
             return
         }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -10,11 +10,11 @@ import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
-import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionContextType
+import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.build.CommandData
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -16,7 +16,8 @@ import java.awt.Color
 @Component
 class ReportMessageContextMenu(
     private val guildLogger: GuildLogger,
-    private val muteService: MuteService
+    private val muteService: MuteService,
+    private val reportSettingsService: ReportSettingsService
 ) : ListenerAdapter(), DiscordCommand {
     companion object {
         private const val NON_URGENT_COMMAND = "Report Message"
@@ -43,9 +44,14 @@ class ReportMessageContextMenu(
             return
         }
 
+        if (reportSettingsService.isUserBlocked(guild.idLong, reporter.idLong)) {
+            event.reply("You are not allowed to report messages in this server.").setEphemeral(true).queue()
+            return
+        }
+
         val target = event.target
-        val ping = if (urgent) "@everyone" else "@here"
-        guildLogger.log(
+        val ping = if (urgent) reportSettingsService.getUrgentMention(guild) else "@here"
+        guildLogger.logWithContent(
             logEmbed = createReportEmbed(target, reporter.nicknameAndUsername, urgent),
             associatedUser = target.author,
             guild = guild,

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -34,6 +34,9 @@ class ReportMessageContextMenu(
         private const val BUTTON_CONFIRM_PREFIX = "report:urgent:"
         private const val BUTTON_CANCEL_PREFIX = "report:cancel:"
         private const val ALREADY_REPORTED_MESSAGE = "This issue was already reported."
+        private const val HERE_MENTION = "@here"
+        private const val NO_MOD_LOG_CHANNEL_MESSAGE =
+            "Message reporting is not configured on this server. A moderator log channel is required."
     }
 
     private data class UrgentConfirmationAction(
@@ -80,7 +83,10 @@ class ReportMessageContextMenu(
         }
 
         val existingState = reportedMessageService.getState(guild.idLong, target.guildChannel.idLong, target.idLong)
-        if (existingState == ReportedMessageState.URGENT || existingState == ReportedMessageState.NON_URGENT && !urgent) {
+        if (
+            existingState == ReportedMessageState.URGENT ||
+            (existingState == ReportedMessageState.NON_URGENT && !urgent)
+        ) {
             event.reply(ALREADY_REPORTED_MESSAGE).setEphemeral(true).queue()
             return
         }
@@ -90,6 +96,11 @@ class ReportMessageContextMenu(
                 .setEphemeral(true)
                 .addComponents(ActionRow.of(buildUrgentConfirmationButtons(guild.idLong, target, reporter.idLong)))
                 .queue()
+            return
+        }
+
+        if (!guildLogger.hasModeratorLogChannel(guild)) {
+            event.reply(NO_MOD_LOG_CHANNEL_MESSAGE).setEphemeral(true).queue()
             return
         }
 
@@ -128,12 +139,16 @@ class ReportMessageContextMenu(
         }
 
         if (reporter.isTimedOut || muteService.isUserMuted(guild.idLong, reporter.idLong)) {
-            event.reply("You cannot report messages while timed out or muted.").setEphemeral(true).queue()
+            event.editMessage("You cannot report messages while timed out or muted.")
+                .setComponents(emptyList())
+                .queue()
             return
         }
 
         if (reportSettingsService.isUserBlocked(guild.idLong, reporter.idLong)) {
-            event.reply("You are not allowed to report messages in this server.").setEphemeral(true).queue()
+            event.editMessage("You are not allowed to report messages in this server.")
+                .setComponents(emptyList())
+                .queue()
             return
         }
 
@@ -150,7 +165,12 @@ class ReportMessageContextMenu(
             return
         }
 
-        if (!tryConsumeRateLimit(event, guild, reporter)) {
+        if (!guildLogger.hasModeratorLogChannel(guild)) {
+            event.editMessage(NO_MOD_LOG_CHANNEL_MESSAGE).setComponents(emptyList()).queue()
+            return
+        }
+
+        if (!tryConsumeRateLimitForConfirmation(event, guild, reporter)) {
             return
         }
 
@@ -186,9 +206,9 @@ class ReportMessageContextMenu(
     }
 
     private fun logReport(guild: Guild, reporter: Member, target: Message, urgent: Boolean) {
-        val ping = if (urgent) reportSettingsService.getUrgentMention(guild) else "@here"
+        val ping = if (urgent) reportSettingsService.getUrgentMention(guild) else HERE_MENTION
         guildLogger.logWithContent(
-            logEmbed = createReportEmbed(target, reporter.nicknameAndUsername, urgent),
+            logEmbed = createReportEmbed(target, reporter, urgent),
             associatedUser = target.author,
             guild = guild,
             actionType = GuildLogger.LogTypeAction.MODERATOR,
@@ -216,6 +236,14 @@ class ReportMessageContextMenu(
             .setEphemeral(true)
             .queue()
         return false
+    }
+
+    private fun tryConsumeRateLimitForConfirmation(event: ButtonInteractionEvent, guild: Guild, reporter: Member): Boolean {
+        if (reportRateLimitService.hasActiveToken(guild.idLong, reporter.idLong)) {
+            return true
+        }
+
+        return tryConsumeRateLimit(event, guild, reporter)
     }
 
     private fun buildUrgentConfirmationButtons(guildId: Long, target: Message, reporterId: Long): List<Button> {
@@ -247,12 +275,12 @@ class ReportMessageContextMenu(
         )
     }
 
-    private fun createReportEmbed(target: Message, reporterName: String, urgent: Boolean): EmbedBuilder {
+    private fun createReportEmbed(target: Message, reporter: Member, urgent: Boolean): EmbedBuilder {
         val authorName = target.member?.nicknameAndUsername ?: target.author.name
         val embed = EmbedBuilder()
             .setColor(if (urgent) Color.RED else Color.YELLOW)
             .setTitle(if (urgent) "Urgent message report" else "Message report")
-            .addField("Reporter", reporterName, true)
+            .addField("Reporter", "${reporter.nicknameAndUsername} (${reporter.id})", true)
             .addField("Reported user", authorName, true)
             .addField("Channel", target.guildChannel.asMention, true)
             .addField("Message URL", "[Link](${target.jumpUrl})", false)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -6,9 +6,9 @@ import be.duncanc.discordmodbot.logging.GuildLogger
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
-import net.dv8tion.jda.api.entities.Message
-import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
@@ -69,6 +69,11 @@ class ReportMessageContextMenu(
         }
 
         val target = event.target
+        if (reporter.idLong == target.author.idLong) {
+            event.reply("You cannot report your own messages.").setEphemeral(true).queue()
+            return
+        }
+
         val existingState = reportedMessageService.getState(guild.idLong, target.guildChannel.idLong, target.idLong)
         if (existingState == ReportedMessageState.URGENT || existingState == ReportedMessageState.NON_URGENT && !urgent) {
             event.reply(ALREADY_REPORTED_MESSAGE).setEphemeral(true).queue()

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -1,0 +1,91 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.discord.DiscordCommand
+import be.duncanc.discordmodbot.discord.nicknameAndUsername
+import be.duncanc.discordmodbot.logging.GuildLogger
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import net.dv8tion.jda.api.interactions.InteractionContextType
+import net.dv8tion.jda.api.interactions.commands.build.CommandData
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+import org.springframework.stereotype.Component
+import java.awt.Color
+
+@Component
+class ReportMessageContextMenu(
+    private val guildLogger: GuildLogger
+) : ListenerAdapter(), DiscordCommand {
+    companion object {
+        private const val NON_URGENT_COMMAND = "Report Message"
+        private const val URGENT_COMMAND = "Urgent Report Message"
+        private const val MAX_FIELD_LENGTH = 1024
+    }
+
+    override fun onMessageContextInteraction(event: MessageContextInteractionEvent) {
+        val urgent = when (event.name) {
+            NON_URGENT_COMMAND -> false
+            URGENT_COMMAND -> true
+            else -> return
+        }
+
+        val guild = event.guild
+        val reporter = event.member
+        if (guild == null || reporter == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        val target = event.target
+        val ping = if (urgent) "@everyone" else "@here"
+        guildLogger.log(
+            logEmbed = createReportEmbed(target, reporter.nicknameAndUsername, urgent),
+            associatedUser = target.author,
+            guild = guild,
+            actionType = GuildLogger.LogTypeAction.MODERATOR,
+            content = ping
+        )
+
+        event.reply("Your report has been sent to the moderation team.").setEphemeral(true).queue()
+    }
+
+    override fun getCommandsData(): List<CommandData> {
+        return listOf(
+            Commands.message(NON_URGENT_COMMAND)
+                .setContexts(InteractionContextType.GUILD),
+            Commands.message(URGENT_COMMAND)
+                .setContexts(InteractionContextType.GUILD)
+        )
+    }
+
+    private fun createReportEmbed(target: Message, reporterName: String, urgent: Boolean): EmbedBuilder {
+        val authorName = target.member?.nicknameAndUsername ?: target.author.name
+        val embed = EmbedBuilder()
+            .setColor(if (urgent) Color.RED else Color.YELLOW)
+            .setTitle(if (urgent) "Urgent message report" else "Message report")
+            .addField("Reporter", reporterName, true)
+            .addField("Reported user", authorName, true)
+            .addField("Channel", target.guildChannel.asMention, true)
+            .addField("Message URL", "[Link](${target.jumpUrl})", false)
+
+        if (target.contentRaw.isNotBlank()) {
+            embed.addField("Message", target.contentRaw.abbreviateField(), false)
+        }
+
+        val attachments = target.attachments.joinToString("\n") { it.url }
+        if (attachments.isNotBlank()) {
+            embed.addField("Attachment(s)", attachments.abbreviateField(), false)
+        }
+
+        return embed
+    }
+
+    private fun String.abbreviateField(): String {
+        if (length <= MAX_FIELD_LENGTH) {
+            return this
+        }
+
+        return take(MAX_FIELD_LENGTH - 3) + "..."
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -145,18 +145,20 @@ class ReportMessageContextMenu(
             return
         }
 
-        channel.retrieveMessageById(action.messageId).queue(
-            { message ->
-                logReport(guild, reporter, message, urgent = true)
-                reportedMessageService.markUrgent(guild.idLong, action.channelId, action.messageId)
-                event.editMessage("Your urgent report has been sent to the moderation team.")
-                    .setComponents(emptyList())
-                    .queue()
-            },
-            {
-                event.editMessage("I could not find that message anymore.").setComponents(emptyList()).queue()
-            }
-        )
+        event.deferEdit().queue { hook ->
+            channel.retrieveMessageById(action.messageId).queue(
+                { message ->
+                    logReport(guild, reporter, message, urgent = true)
+                    reportedMessageService.markUrgent(guild.idLong, action.channelId, action.messageId)
+                    hook.editOriginal("Your urgent report has been sent to the moderation team.")
+                        .setComponents(emptyList())
+                        .queue()
+                },
+                {
+                    hook.editOriginal("I could not find that message anymore.").setComponents(emptyList()).queue()
+                }
+            )
+        }
     }
 
     override fun getCommandsData(): List<CommandData> {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -17,7 +17,8 @@ import java.awt.Color
 class ReportMessageContextMenu(
     private val guildLogger: GuildLogger,
     private val muteService: MuteService,
-    private val reportSettingsService: ReportSettingsService
+    private val reportSettingsService: ReportSettingsService,
+    private val reportRateLimitService: ReportRateLimitService
 ) : ListenerAdapter(), DiscordCommand {
     companion object {
         private const val NON_URGENT_COMMAND = "Report Message"
@@ -46,6 +47,13 @@ class ReportMessageContextMenu(
 
         if (reportSettingsService.isUserBlocked(guild.idLong, reporter.idLong)) {
             event.reply("You are not allowed to report messages in this server.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!reportRateLimitService.tryConsume(guild.idLong, reporter.idLong)) {
+            event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
+                .setEphemeral(true)
+                .queue()
             return
         }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -58,6 +58,11 @@ class ReportMessageContextMenu(
             return
         }
 
+        if (!reportSettingsService.isReportingEnabled(guild.idLong)) {
+            event.reply("Message reporting is not enabled on this server.").setEphemeral(true).queue()
+            return
+        }
+
         if (reporter.isTimedOut || muteService.isUserMuted(guild.idLong, reporter.idLong)) {
             event.reply("You cannot report messages while timed out or muted.").setEphemeral(true).queue()
             return
@@ -114,6 +119,11 @@ class ReportMessageContextMenu(
         val reporter = event.member
         if (guild == null || reporter == null || guild.idLong != action.guildId) {
             event.reply("This report confirmation is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!reportSettingsService.isReportingEnabled(guild.idLong)) {
+            event.editMessage("Message reporting is not enabled on this server.").setComponents(emptyList()).queue()
             return
         }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -15,7 +15,8 @@ import java.awt.Color
 
 @Component
 class ReportMessageContextMenu(
-    private val guildLogger: GuildLogger
+    private val guildLogger: GuildLogger,
+    private val muteService: MuteService
 ) : ListenerAdapter(), DiscordCommand {
     companion object {
         private const val NON_URGENT_COMMAND = "Report Message"
@@ -34,6 +35,11 @@ class ReportMessageContextMenu(
         val reporter = event.member
         if (guild == null || reporter == null) {
             event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reporter.isTimedOut || muteService.isUserMuted(guild.idLong, reporter.idLong)) {
+            event.reply("You cannot report messages while timed out or muted.").setEphemeral(true).queue()
             return
         }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportProperties.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportProperties.kt
@@ -5,5 +5,6 @@ import java.time.Duration
 
 @ConfigurationProperties("discord-mod-bot.reporting")
 data class ReportProperties(
-    val reportRateLimit: Duration = Duration.ofMinutes(5)
+    val reportRateLimit: Duration = Duration.ofMinutes(5),
+    val reportedMessageRetention: Duration = Duration.ofHours(1)
 )

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportProperties.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportProperties.kt
@@ -1,13 +1,10 @@
 package be.duncanc.discordmodbot.moderation
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.bind.DefaultValue
 import java.time.Duration
 
 @ConfigurationProperties("discord-mod-bot.reporting")
 data class ReportProperties(
-    @DefaultValue("5m")
     val reportRateLimit: Duration = Duration.ofMinutes(5),
-    @DefaultValue("1h")
     val reportedMessageRetention: Duration = Duration.ofHours(1)
 )

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportProperties.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportProperties.kt
@@ -1,0 +1,9 @@
+package be.duncanc.discordmodbot.moderation
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties("discord-mod-bot.reporting")
+data class ReportProperties(
+    val reportRateLimit: Duration = Duration.ofMinutes(5)
+)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportProperties.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportProperties.kt
@@ -1,10 +1,13 @@
 package be.duncanc.discordmodbot.moderation
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.DefaultValue
 import java.time.Duration
 
 @ConfigurationProperties("discord-mod-bot.reporting")
 data class ReportProperties(
+    @DefaultValue("5m")
     val reportRateLimit: Duration = Duration.ofMinutes(5),
+    @DefaultValue("1h")
     val reportedMessageRetention: Duration = Duration.ofHours(1)
 )

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitService.kt
@@ -18,6 +18,14 @@ class ReportRateLimitService(
             .setIfAbsent(createKey(guildId, userId), RATE_LIMIT_VALUE, rateLimit) == true
     }
 
+    fun hasActiveToken(guildId: Long, userId: Long): Boolean {
+        if (!reportProperties.reportRateLimit.isPositive) {
+            return false
+        }
+
+        return redisTemplate.hasKey(createKey(guildId, userId)) == true
+    }
+
     fun rateLimitDescription(): String {
         val rateLimit = reportProperties.reportRateLimit
         val days = rateLimit.toDaysPart().toInt()

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitService.kt
@@ -20,18 +20,19 @@ class ReportRateLimitService(
 
     fun rateLimitDescription(): String {
         val rateLimit = reportProperties.reportRateLimit
-        if (rateLimit.toHoursPart() > 0 || rateLimit.toDaysPart() > 0) {
-            val hours = rateLimit.toHours()
-            return "$hours ${if (hours == 1L) "hour" else "hours"}"
+        val days = rateLimit.toDaysPart().toInt()
+        val hours = rateLimit.toHoursPart()
+        val minutes = rateLimit.toMinutesPart()
+        val seconds = rateLimit.toSecondsPart()
+
+        val parts = buildList {
+            if (days > 0) add("$days ${if (days == 1) "day" else "days"}")
+            if (hours > 0) add("$hours ${if (hours == 1) "hour" else "hours"}")
+            if (minutes > 0) add("$minutes ${if (minutes == 1) "minute" else "minutes"}")
+            if (seconds > 0) add("$seconds ${if (seconds == 1) "second" else "seconds"}")
         }
 
-        if (rateLimit.toMinutesPart() > 0) {
-            val minutes = rateLimit.toMinutes()
-            return "$minutes ${if (minutes == 1L) "minute" else "minutes"}"
-        }
-
-        val seconds = rateLimit.seconds.coerceAtLeast(1)
-        return "$seconds ${if (seconds == 1L) "second" else "seconds"}"
+        return parts.joinToString(" ").ifEmpty { "0 seconds" }
     }
 
     internal fun createKey(guildId: Long, userId: Long): String {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitService.kt
@@ -38,9 +38,6 @@ class ReportRateLimitService(
         return "report:rate-limit:$guildId:$userId"
     }
 
-    private val java.time.Duration.isPositive: Boolean
-        get() = !isZero && !isNegative
-
     companion object {
         private const val RATE_LIMIT_VALUE = "1"
     }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitService.kt
@@ -1,0 +1,47 @@
+package be.duncanc.discordmodbot.moderation
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class ReportRateLimitService(
+    private val redisTemplate: StringRedisTemplate,
+    private val reportProperties: ReportProperties
+) {
+    fun tryConsume(guildId: Long, userId: Long): Boolean {
+        val rateLimit = reportProperties.reportRateLimit
+        if (!rateLimit.isPositive) {
+            return true
+        }
+
+        return redisTemplate.opsForValue()
+            .setIfAbsent(createKey(guildId, userId), RATE_LIMIT_VALUE, rateLimit) == true
+    }
+
+    fun rateLimitDescription(): String {
+        val rateLimit = reportProperties.reportRateLimit
+        if (rateLimit.toHoursPart() > 0 || rateLimit.toDaysPart() > 0) {
+            val hours = rateLimit.toHours()
+            return "$hours ${if (hours == 1L) "hour" else "hours"}"
+        }
+
+        if (rateLimit.toMinutesPart() > 0) {
+            val minutes = rateLimit.toMinutes()
+            return "$minutes ${if (minutes == 1L) "minute" else "minutes"}"
+        }
+
+        val seconds = rateLimit.seconds.coerceAtLeast(1)
+        return "$seconds ${if (seconds == 1L) "second" else "seconds"}"
+    }
+
+    internal fun createKey(guildId: Long, userId: Long): String {
+        return "report:rate-limit:$guildId:$userId"
+    }
+
+    private val java.time.Duration.isPositive: Boolean
+        get() = !isZero && !isNegative
+
+    companion object {
+        private const val RATE_LIMIT_VALUE = "1"
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
@@ -26,6 +26,7 @@ class ReportSettingsCommand(
         private const val SUBCOMMAND_ALLOW_USER = "allow-user"
         private const val SUBCOMMAND_SET_URGENT_ROLE = "set-urgent-role"
         private const val SUBCOMMAND_CLEAR_URGENT_ROLE = "clear-urgent-role"
+        private const val SUBCOMMAND_TOGGLE = "toggle"
         private const val OPTION_USER = "user"
         private const val OPTION_ROLE = "role"
         private const val BLOCKED_USER_DISPLAY_LIMIT = 20
@@ -58,6 +59,12 @@ class ReportSettingsCommand(
                     .queue()
             }
 
+            SUBCOMMAND_TOGGLE -> {
+                val enabled = reportSettingsService.toggleReporting(guild.idLong)
+                val status = if (enabled) "enabled" else "disabled"
+                event.reply("Message reporting is now $status.").setEphemeral(true).queue()
+            }
+
             else -> event.reply("Please choose a valid /reportsettings subcommand.").setEphemeral(true).queue()
         }
     }
@@ -75,7 +82,8 @@ class ReportSettingsCommand(
                         .addOption(OptionType.USER, OPTION_USER, "The user to allow", true),
                     SubcommandData(SUBCOMMAND_SET_URGENT_ROLE, "Set the role mentioned by urgent reports")
                         .addOption(OptionType.ROLE, OPTION_ROLE, "The role to mention", true),
-                    SubcommandData(SUBCOMMAND_CLEAR_URGENT_ROLE, "Clear the urgent report role")
+                    SubcommandData(SUBCOMMAND_CLEAR_URGENT_ROLE, "Clear the urgent report role"),
+                    SubcommandData(SUBCOMMAND_TOGGLE, "Enable or disable message reporting")
                 )
         )
     }
@@ -118,6 +126,7 @@ class ReportSettingsCommand(
         val message = buildString {
             appendLine("Report settings for ${guild.name}")
             appendLine()
+            appendLine("- Reporting: ${if (settings.enabled) "enabled" else "disabled"}")
             appendLine("- Urgent mention: ${formatUrgentRole(guild, settings.urgentRoleId)}")
             appendLine("- Blocked users: ${formatBlockedUsers(settings)}")
         }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
@@ -127,19 +127,11 @@ class ReportSettingsCommand(
             appendLine("Report settings for ${guild.name}")
             appendLine()
             appendLine("- Reporting: ${if (settings.enabled) "enabled" else "disabled"}")
-            appendLine("- Urgent mention: ${formatUrgentRole(guild, settings.urgentRoleId)}")
+            appendLine("- Urgent mention: ${reportSettingsService.getUrgentMention(guild)}")
             appendLine("- Blocked users: ${formatBlockedUsers(settings)}")
         }
 
         event.reply(message).setEphemeral(true).queue()
-    }
-
-    private fun formatUrgentRole(guild: Guild, roleId: Long?): String {
-        if (roleId == null) {
-            return "@everyone"
-        }
-
-        return guild.getRoleById(roleId)?.asMention ?: "Role not found (ID: $roleId); using @everyone"
     }
 
     private fun formatBlockedUsers(settings: ReportSettings): String {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
@@ -1,0 +1,151 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.discord.SlashCommand
+import be.duncanc.discordmodbot.moderation.persistence.ReportSettings
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import net.dv8tion.jda.api.interactions.InteractionContextType
+import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
+import net.dv8tion.jda.api.interactions.commands.OptionType
+import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import org.springframework.stereotype.Component
+
+@Component
+class ReportSettingsCommand(
+    private val reportSettingsService: ReportSettingsService
+) : ListenerAdapter(), SlashCommand {
+    companion object {
+        private const val COMMAND = "reportsettings"
+        private const val DESCRIPTION = "Configure message reporting for this server."
+        private const val SUBCOMMAND_SHOW = "show"
+        private const val SUBCOMMAND_BLOCK_USER = "block-user"
+        private const val SUBCOMMAND_ALLOW_USER = "allow-user"
+        private const val SUBCOMMAND_SET_URGENT_ROLE = "set-urgent-role"
+        private const val SUBCOMMAND_CLEAR_URGENT_ROLE = "clear-urgent-role"
+        private const val OPTION_USER = "user"
+        private const val OPTION_ROLE = "role"
+        private const val BLOCKED_USER_DISPLAY_LIMIT = 20
+    }
+
+    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+        if (event.name != COMMAND) return
+
+        val guild = event.guild
+        val member = event.member
+        if (guild == null || member == null) {
+            event.reply("This command only works in a guild.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!member.hasPermission(Permission.MANAGE_ROLES)) {
+            event.reply("You need manage roles permission to use this command.").setEphemeral(true).queue()
+            return
+        }
+
+        when (event.subcommandName) {
+            null, SUBCOMMAND_SHOW -> showCurrentSettings(event, guild)
+            SUBCOMMAND_BLOCK_USER -> blockUser(event, guild.idLong)
+            SUBCOMMAND_ALLOW_USER -> allowUser(event, guild.idLong)
+            SUBCOMMAND_SET_URGENT_ROLE -> setUrgentRole(event, guild.idLong)
+            SUBCOMMAND_CLEAR_URGENT_ROLE -> {
+                reportSettingsService.clearUrgentRole(guild.idLong)
+                event.reply("Urgent report role cleared. Urgent reports will mention @everyone.")
+                    .setEphemeral(true)
+                    .queue()
+            }
+
+            else -> event.reply("Please choose a valid /reportsettings subcommand.").setEphemeral(true).queue()
+        }
+    }
+
+    override fun getCommandsData(): List<SlashCommandData> {
+        return listOf(
+            Commands.slash(COMMAND, DESCRIPTION)
+                .setContexts(InteractionContextType.GUILD)
+                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
+                .addSubcommands(
+                    SubcommandData(SUBCOMMAND_SHOW, "Show current report settings"),
+                    SubcommandData(SUBCOMMAND_BLOCK_USER, "Block a user from reporting messages")
+                        .addOption(OptionType.USER, OPTION_USER, "The user to block", true),
+                    SubcommandData(SUBCOMMAND_ALLOW_USER, "Allow a blocked user to report messages again")
+                        .addOption(OptionType.USER, OPTION_USER, "The user to allow", true),
+                    SubcommandData(SUBCOMMAND_SET_URGENT_ROLE, "Set the role mentioned by urgent reports")
+                        .addOption(OptionType.ROLE, OPTION_ROLE, "The role to mention", true),
+                    SubcommandData(SUBCOMMAND_CLEAR_URGENT_ROLE, "Clear the urgent report role")
+                )
+        )
+    }
+
+    private fun blockUser(event: SlashCommandInteractionEvent, guildId: Long) {
+        val user = event.getOption(OPTION_USER)?.asUser
+        if (user == null) {
+            event.reply("Please choose a user.").setEphemeral(true).queue()
+            return
+        }
+
+        reportSettingsService.blockUser(guildId, user.idLong)
+        event.reply("${user.asMention} can no longer report messages in this server.").setEphemeral(true).queue()
+    }
+
+    private fun allowUser(event: SlashCommandInteractionEvent, guildId: Long) {
+        val user = event.getOption(OPTION_USER)?.asUser
+        if (user == null) {
+            event.reply("Please choose a user.").setEphemeral(true).queue()
+            return
+        }
+
+        reportSettingsService.allowUser(guildId, user.idLong)
+        event.reply("${user.asMention} can report messages in this server again.").setEphemeral(true).queue()
+    }
+
+    private fun setUrgentRole(event: SlashCommandInteractionEvent, guildId: Long) {
+        val role = event.getOption(OPTION_ROLE)?.asRole
+        if (role == null) {
+            event.reply("Please choose a role.").setEphemeral(true).queue()
+            return
+        }
+
+        reportSettingsService.setUrgentRole(guildId, role.idLong)
+        event.reply("Urgent reports will now mention ${role.asMention}.").setEphemeral(true).queue()
+    }
+
+    private fun showCurrentSettings(event: SlashCommandInteractionEvent, guild: Guild) {
+        val settings = reportSettingsService.getSettings(guild.idLong)
+        val message = buildString {
+            appendLine("Report settings for ${guild.name}")
+            appendLine()
+            appendLine("- Urgent mention: ${formatUrgentRole(guild, settings.urgentRoleId)}")
+            appendLine("- Blocked users: ${formatBlockedUsers(settings)}")
+        }
+
+        event.reply(message).setEphemeral(true).queue()
+    }
+
+    private fun formatUrgentRole(guild: Guild, roleId: Long?): String {
+        if (roleId == null) {
+            return "@everyone"
+        }
+
+        return guild.getRoleById(roleId)?.asMention ?: "Role not found (ID: $roleId); using @everyone"
+    }
+
+    private fun formatBlockedUsers(settings: ReportSettings): String {
+        if (settings.blockedUserIds.isEmpty()) {
+            return "None"
+        }
+
+        val displayedUsers = settings.blockedUserIds
+            .take(BLOCKED_USER_DISPLAY_LIMIT)
+            .joinToString(", ") { "<@$it>" }
+        val remaining = settings.blockedUserIds.size - BLOCKED_USER_DISPLAY_LIMIT
+        if (remaining <= 0) {
+            return displayedUsers
+        }
+
+        return "$displayedUsers, and $remaining more"
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsService.kt
@@ -33,7 +33,7 @@ class ReportSettingsService(
 
     @Transactional
     fun allowUser(guildId: Long, userId: Long) {
-        val settings = getSettings(guildId)
+        val settings = reportSettingsRepository.findById(guildId).orElse(null) ?: return
         settings.blockedUserIds.remove(userId)
         reportSettingsRepository.save(settings)
     }
@@ -47,7 +47,7 @@ class ReportSettingsService(
 
     @Transactional
     fun clearUrgentRole(guildId: Long) {
-        val settings = getSettings(guildId)
+        val settings = reportSettingsRepository.findById(guildId).orElse(null) ?: return
         settings.urgentRoleId = null
         reportSettingsRepository.save(settings)
     }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsService.kt
@@ -15,6 +15,10 @@ class ReportSettingsService(
         return reportSettingsRepository.findById(guildId).orElse(ReportSettings(guildId))
     }
 
+    fun isReportingEnabled(guildId: Long): Boolean {
+        return getSettings(guildId).enabled
+    }
+
     fun isUserBlocked(guildId: Long, userId: Long): Boolean {
         return getSettings(guildId).blockedUserIds.contains(userId)
     }
@@ -50,6 +54,14 @@ class ReportSettingsService(
         val settings = reportSettingsRepository.findById(guildId).orElse(null) ?: return
         settings.urgentRoleId = null
         reportSettingsRepository.save(settings)
+    }
+
+    @Transactional
+    fun toggleReporting(guildId: Long): Boolean {
+        val settings = getSettings(guildId)
+        settings.enabled = !settings.enabled
+        reportSettingsRepository.save(settings)
+        return settings.enabled
     }
 
     companion object {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsService.kt
@@ -1,0 +1,58 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.moderation.persistence.ReportSettings
+import be.duncanc.discordmodbot.moderation.persistence.ReportSettingsRepository
+import net.dv8tion.jda.api.entities.Guild
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ReportSettingsService(
+    private val reportSettingsRepository: ReportSettingsRepository
+) {
+    fun getSettings(guildId: Long): ReportSettings {
+        return reportSettingsRepository.findById(guildId).orElse(ReportSettings(guildId))
+    }
+
+    fun isUserBlocked(guildId: Long, userId: Long): Boolean {
+        return getSettings(guildId).blockedUserIds.contains(userId)
+    }
+
+    fun getUrgentMention(guild: Guild): String {
+        val roleId = getSettings(guild.idLong).urgentRoleId ?: return EVERYONE_MENTION
+        return guild.getRoleById(roleId)?.asMention ?: EVERYONE_MENTION
+    }
+
+    @Transactional
+    fun blockUser(guildId: Long, userId: Long) {
+        val settings = getSettings(guildId)
+        settings.blockedUserIds.add(userId)
+        reportSettingsRepository.save(settings)
+    }
+
+    @Transactional
+    fun allowUser(guildId: Long, userId: Long) {
+        val settings = getSettings(guildId)
+        settings.blockedUserIds.remove(userId)
+        reportSettingsRepository.save(settings)
+    }
+
+    @Transactional
+    fun setUrgentRole(guildId: Long, roleId: Long) {
+        val settings = getSettings(guildId)
+        settings.urgentRoleId = roleId
+        reportSettingsRepository.save(settings)
+    }
+
+    @Transactional
+    fun clearUrgentRole(guildId: Long) {
+        val settings = getSettings(guildId)
+        settings.urgentRoleId = null
+        reportSettingsRepository.save(settings)
+    }
+
+    companion object {
+        const val EVERYONE_MENTION = "@everyone"
+    }
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportedMessageService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportedMessageService.kt
@@ -38,7 +38,4 @@ class ReportedMessageService(
 
         redisTemplate.opsForValue().set(createKey(guildId, channelId, messageId), state.name, retention)
     }
-
-    private val java.time.Duration.isPositive: Boolean
-        get() = !isZero && !isNegative
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportedMessageService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportedMessageService.kt
@@ -1,0 +1,44 @@
+package be.duncanc.discordmodbot.moderation
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class ReportedMessageService(
+    private val redisTemplate: StringRedisTemplate,
+    private val reportProperties: ReportProperties
+) {
+    fun getState(guildId: Long, channelId: Long, messageId: Long): ReportedMessageState? {
+        val value = redisTemplate.opsForValue().get(createKey(guildId, channelId, messageId)) ?: return null
+        return runCatching { ReportedMessageState.valueOf(value) }.getOrNull()
+    }
+
+    fun markReported(guildId: Long, channelId: Long, messageId: Long, urgent: Boolean) {
+        markState(
+            guildId = guildId,
+            channelId = channelId,
+            messageId = messageId,
+            state = if (urgent) ReportedMessageState.URGENT else ReportedMessageState.NON_URGENT
+        )
+    }
+
+    fun markUrgent(guildId: Long, channelId: Long, messageId: Long) {
+        markState(guildId, channelId, messageId, ReportedMessageState.URGENT)
+    }
+
+    internal fun createKey(guildId: Long, channelId: Long, messageId: Long): String {
+        return "report:message:$guildId:$channelId:$messageId"
+    }
+
+    private fun markState(guildId: Long, channelId: Long, messageId: Long, state: ReportedMessageState) {
+        val retention = reportProperties.reportedMessageRetention
+        if (!retention.isPositive) {
+            return
+        }
+
+        redisTemplate.opsForValue().set(createKey(guildId, channelId, messageId), state.name, retention)
+    }
+
+    private val java.time.Duration.isPositive: Boolean
+        get() = !isZero && !isNegative
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportedMessageState.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportedMessageState.kt
@@ -1,0 +1,6 @@
+package be.duncanc.discordmodbot.moderation
+
+enum class ReportedMessageState {
+    NON_URGENT,
+    URGENT
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/ReportSettings.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/ReportSettings.kt
@@ -20,6 +20,9 @@ data class ReportSettings(
     @Column(name = "urgent_role_id")
     var urgentRoleId: Long? = null,
 
+    @Column(name = "enabled")
+    var enabled: Boolean = false,
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
         name = "report_settings_blocked_users",
@@ -38,5 +41,5 @@ data class ReportSettings(
 
     override fun hashCode(): Int = Hibernate.getClass(this).hashCode()
 
-    override fun toString(): String = "ReportSettings(guildId=$guildId, urgentRoleId=$urgentRoleId)"
+    override fun toString(): String = "ReportSettings(guildId=$guildId, urgentRoleId=$urgentRoleId, enabled=$enabled)"
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/ReportSettings.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/ReportSettings.kt
@@ -1,0 +1,42 @@
+package be.duncanc.discordmodbot.moderation.persistence
+
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+
+@Entity
+@Table(name = "report_settings")
+data class ReportSettings(
+    @Id
+    @Column(name = "guild_id", updatable = false)
+    val guildId: Long,
+
+    @Column(name = "urgent_role_id")
+    var urgentRoleId: Long? = null,
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+        name = "report_settings_blocked_users",
+        joinColumns = [JoinColumn(name = "guild_id")]
+    )
+    @Column(name = "user_id")
+    val blockedUserIds: MutableSet<Long> = HashSet()
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+        other as ReportSettings
+
+        return guildId == other.guildId
+    }
+
+    override fun hashCode(): Int = Hibernate.getClass(this).hashCode()
+
+    override fun toString(): String = "ReportSettings(guildId=$guildId, urgentRoleId=$urgentRoleId)"
+}

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/ReportSettingsRepository.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/ReportSettingsRepository.kt
@@ -1,0 +1,7 @@
+package be.duncanc.discordmodbot.moderation.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ReportSettingsRepository : JpaRepository<ReportSettings, Long>

--- a/src/main/resources/db/migration/V16__add_report_settings.sql
+++ b/src/main/resources/db/migration/V16__add_report_settings.sql
@@ -1,0 +1,17 @@
+create table `report_settings`
+(
+    `guild_id`       bigint not null,
+    `urgent_role_id` bigint null,
+    primary key (`guild_id`)
+);
+
+create table `report_settings_blocked_users`
+(
+    `guild_id` bigint not null,
+    `user_id`  bigint not null,
+    primary key (`guild_id`, `user_id`)
+);
+
+alter table `report_settings_blocked_users`
+    add constraint `fk_report_settings_blocked_users`
+        foreign key (`guild_id`) references `report_settings` (`guild_id`);

--- a/src/main/resources/db/migration/V16__add_report_settings.sql
+++ b/src/main/resources/db/migration/V16__add_report_settings.sql
@@ -2,6 +2,7 @@ create table `report_settings`
 (
     `guild_id`       bigint not null,
     `urgent_role_id` bigint null,
+    `enabled`        boolean not null default false,
     primary key (`guild_id`)
 );
 

--- a/src/main/resources/db/migration/V17__add_reporting_enabled.sql
+++ b/src/main/resources/db/migration/V17__add_reporting_enabled.sql
@@ -1,2 +1,0 @@
-alter table `report_settings`
-    add column `enabled` boolean not null default false;

--- a/src/main/resources/db/migration/V17__add_reporting_enabled.sql
+++ b/src/main/resources/db/migration/V17__add_reporting_enabled.sql
@@ -1,0 +1,2 @@
+alter table `report_settings`
+    add column `enabled` boolean not null default false;

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/GuildLoggerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/GuildLoggerTest.kt
@@ -1,31 +1,19 @@
 package be.duncanc.discordmodbot.logging
 
-import be.duncanc.discordmodbot.logging.persistence.DiscordMessage
+import be.duncanc.discordmodbot.logging.persistence.LoggingSettings
 import be.duncanc.discordmodbot.logging.persistence.LoggingSettingsRepository
-import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.audit.ActionType
-import net.dv8tion.jda.api.audit.AuditLogEntry
-import net.dv8tion.jda.api.audit.AuditLogOption
+import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.SelfUser
-import net.dv8tion.jda.api.entities.User
-import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion
-import net.dv8tion.jda.api.events.message.MessageDeleteEvent
-import net.dv8tion.jda.api.requests.restaction.CacheRestAction
-import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction
-import net.dv8tion.jda.api.requests.restaction.pagination.PaginationAction
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
+import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.inOrder
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class GuildLoggerTest {
@@ -39,81 +27,99 @@ class GuildLoggerTest {
     private lateinit var messageDeleteAuditStateRegistry: MessageDeleteAuditStateRegistry
 
     @Mock
-    private lateinit var event: MessageDeleteEvent
-
-    @Mock
     private lateinit var guild: Guild
 
     @Mock
-    private lateinit var channel: MessageChannelUnion
+    private lateinit var textChannel: TextChannel
 
     @Mock
-    private lateinit var jda: JDA
+    private lateinit var selfMember: SelfMember
 
-    @Mock
-    private lateinit var selfUser: SelfUser
+    @Test
+    fun `canSendModeratorLog returns false when no logging settings exist`() {
+        val guildLogger = guildLogger()
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(loggingSettingsRepository.findById(1L)).thenReturn(Optional.empty())
 
-    @Mock
-    private lateinit var moderator: User
+        val canSend = guildLogger.canSendModeratorLog(guild)
 
-    @Mock
-    private lateinit var auditLogEntry: AuditLogEntry
-
-    @Mock
-    private lateinit var auditLogPaginationAction: AuditLogPaginationAction
-
-    @Mock
-    private lateinit var auditLogIterator: PaginationAction.PaginationIterator<AuditLogEntry>
-
-    @Mock
-    private lateinit var userLookup: CacheRestAction<User>
-
-    private lateinit var guildLogger: GuildLogger
-
-    @BeforeEach
-    fun setUp() {
-        guildLogger = GuildLogger(messageHistory, loggingSettingsRepository, messageDeleteAuditStateRegistry)
+        assertFalse(canSend)
     }
 
     @Test
-    fun `log deleted message resolves audit state before starting user lookup`() {
-        val deletedMessage = DiscordMessage(
-            messageId = 100L,
-            guildId = 1L,
-            channelId = 10L,
-            userId = 20L,
-            content = "deleted content"
-        )
-
-        whenever(event.guild).thenReturn(guild)
-        whenever(event.channel).thenReturn(channel)
-        whenever(event.jda).thenReturn(jda)
-        whenever(channel.idLong).thenReturn(10L)
+    fun `canSendModeratorLog returns false when moderator log channel is not configured`() {
+        val guildLogger = guildLogger()
         whenever(guild.idLong).thenReturn(1L)
-        whenever(guild.retrieveAuditLogs()).thenReturn(auditLogPaginationAction)
-        whenever(auditLogPaginationAction.cache(false)).thenReturn(auditLogPaginationAction)
-        whenever(auditLogPaginationAction.limit(5)).thenReturn(auditLogPaginationAction)
-        whenever(auditLogPaginationAction.iterator()).thenReturn(auditLogIterator)
-        whenever(auditLogIterator.hasNext()).thenReturn(true, false)
-        whenever(auditLogIterator.next()).thenReturn(auditLogEntry)
-        whenever(auditLogEntry.idLong).thenReturn(42L)
-        whenever(auditLogEntry.type).thenReturn(ActionType.MESSAGE_DELETE)
-        whenever(auditLogEntry.targetIdLong).thenReturn(20L)
-        whenever(auditLogEntry.user).thenReturn(moderator)
-        whenever(auditLogEntry.getOption<String>(AuditLogOption.CHANNEL)).thenReturn("10")
-        whenever(auditLogEntry.getOption<String>(AuditLogOption.COUNT)).thenReturn("1")
-        whenever(messageDeleteAuditStateRegistry.get(1L, 10L, 20L)).thenReturn(null)
-        whenever(jda.selfUser).thenReturn(selfUser)
-        whenever(jda.retrieveUserById(20L)).thenReturn(userLookup)
+        whenever(loggingSettingsRepository.findById(1L))
+            .thenReturn(Optional.of(LoggingSettings(1L, modLogChannel = null)))
 
-        guildLogger.logDeletedMessage(event, deletedMessage, attachmentString = null)
+        val canSend = guildLogger.canSendModeratorLog(guild)
 
-        val stateCaptor = argumentCaptor<MessageDeleteAuditState>()
-        val inOrder = inOrder(messageDeleteAuditStateRegistry, jda)
-        inOrder.verify(messageDeleteAuditStateRegistry).get(1L, 10L, 20L)
-        inOrder.verify(messageDeleteAuditStateRegistry).remember(eq(1L), eq(10L), eq(20L), stateCaptor.capture())
-        inOrder.verify(jda).retrieveUserById(20L)
-        verify(userLookup).queue(any())
-        assertEquals(MessageDeleteAuditState(consumedCounts = mapOf(42L to 1)), stateCaptor.firstValue)
+        assertFalse(canSend)
+    }
+
+    @Test
+    fun `canSendModeratorLog returns false when configured channel does not exist`() {
+        val guildLogger = guildLogger()
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(loggingSettingsRepository.findById(1L))
+            .thenReturn(Optional.of(LoggingSettings(1L, modLogChannel = 123L)))
+        whenever(guild.getTextChannelById(123L)).thenReturn(null)
+
+        val canSend = guildLogger.canSendModeratorLog(guild)
+
+        assertFalse(canSend)
+    }
+
+    @Test
+    fun `canSendModeratorLog returns false when bot lacks required permissions`() {
+        val guildLogger = guildLogger()
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(loggingSettingsRepository.findById(1L))
+            .thenReturn(Optional.of(LoggingSettings(1L, modLogChannel = 123L)))
+        whenever(guild.getTextChannelById(123L)).thenReturn(textChannel)
+        whenever(guild.selfMember).thenReturn(selfMember)
+        whenever(
+            selfMember.hasPermission(
+                textChannel,
+                Permission.VIEW_CHANNEL,
+                Permission.MESSAGE_SEND,
+                Permission.MESSAGE_EMBED_LINKS
+            )
+        ).thenReturn(false)
+
+        val canSend = guildLogger.canSendModeratorLog(guild)
+
+        assertFalse(canSend)
+    }
+
+    @Test
+    fun `canSendModeratorLog returns true when channel exists and bot has permissions`() {
+        val guildLogger = guildLogger()
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(loggingSettingsRepository.findById(1L))
+            .thenReturn(Optional.of(LoggingSettings(1L, modLogChannel = 123L)))
+        whenever(guild.getTextChannelById(123L)).thenReturn(textChannel)
+        whenever(guild.selfMember).thenReturn(selfMember)
+        whenever(
+            selfMember.hasPermission(
+                textChannel,
+                Permission.VIEW_CHANNEL,
+                Permission.MESSAGE_SEND,
+                Permission.MESSAGE_EMBED_LINKS
+            )
+        ).thenReturn(true)
+
+        val canSend = guildLogger.canSendModeratorLog(guild)
+
+        assertTrue(canSend)
+    }
+
+    private fun guildLogger(): GuildLogger {
+        return GuildLogger(
+            messageHistory,
+            loggingSettingsRepository,
+            messageDeleteAuditStateRegistry
+        )
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -162,6 +162,7 @@ class ReportMessageContextMenuTest {
         assertTrue(embed.fields.any { it.name == "Attachment(s)" && it.value == "https://example.invalid/image.png" })
         verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = false)
         verify(event).reply("Your report has been sent to the moderation team.")
+        verify(replyAction).queue()
     }
 
     @Test
@@ -183,6 +184,7 @@ class ReportMessageContextMenuTest {
         verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = true)
         assertEquals("Urgent message report", embedCaptor.firstValue.build().title)
         verify(event).reply("Your report has been sent to the moderation team.")
+        verify(replyAction).queue()
     }
 
     @Test
@@ -202,6 +204,7 @@ class ReportMessageContextMenuTest {
         )
         verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = true)
         verify(event).reply("Your report has been sent to the moderation team.")
+        verify(replyAction).queue()
     }
 
     @Test
@@ -228,12 +231,14 @@ class ReportMessageContextMenuTest {
         stubReporterAndTargetIds("Urgent Report Message")
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
         whenever(reportRateLimitService.hasActiveToken(1L, 99L)).thenReturn(false)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
         whenever(replyAction.addComponents(any<ActionRow>())).thenReturn(replyAction)
 
         command.onMessageContextInteraction(event)
 
         verify(event).reply("This message was already reported as non-urgent. Confirm if you want to report it as urgent.")
         verify(replyAction).addComponents(any<ActionRow>())
+        verify(replyAction).queue()
         verify(reportRateLimitService, never()).tryConsume(any(), any())
     }
 
@@ -255,12 +260,12 @@ class ReportMessageContextMenuTest {
     fun `urgent confirmation is rejected while rate limited`() {
         stubUrgentConfirmationRateLimited()
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
-        whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(false)
-        whenever(reportRateLimitService.rateLimitDescription()).thenReturn("5 minutes")
 
         command.onButtonInteraction(buttonEvent)
 
-        verify(buttonEvent).reply("You can only report one message every 5 minutes.")
+        verify(buttonEvent).editMessage("You can only report one message every 5 minutes.")
+        verify(editAction).setComponents(emptyList<ActionRow>())
+        verify(editAction).queue()
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
@@ -327,15 +332,16 @@ class ReportMessageContextMenuTest {
         )
         verify(reportedMessageService).markUrgent(1L, 123L, 456L)
         verify(buttonEvent).deferEdit()
+        verify(deferredEditAction).queue(any<Consumer<InteractionHook>>())
         verify(interactionHook).editOriginal("Your urgent report has been sent to the moderation team.")
         verify(hookEditAction).setComponents(emptyList<ActionRow>())
+        verify(hookEditAction).queue()
     }
 
     @Test
     fun `urgent confirmation updates deferred response when message retrieval fails`() {
         stubUrgentConfirmation(includeRetrievedMessageDetails = false)
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
-        whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(true)
         whenever(buttonEvent.jda).thenReturn(jda)
         whenever(jda.getChannelById(MessageChannel::class.java, 123L)).thenReturn(messageChannel)
         whenever(messageChannel.retrieveMessageById(456L)).thenReturn(retrieveMessageAction)
@@ -344,8 +350,11 @@ class ReportMessageContextMenuTest {
         command.onButtonInteraction(buttonEvent)
 
         verify(buttonEvent).deferEdit()
+        verify(deferredEditAction).queue(any<Consumer<InteractionHook>>())
         verify(interactionHook).editOriginal("I could not find that message anymore.")
         verify(hookEditAction).setComponents(emptyList<ActionRow>())
+        verify(hookEditAction).queue()
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
@@ -364,6 +373,7 @@ class ReportMessageContextMenuTest {
         command.onMessageContextInteraction(event)
 
         verify(event).reply("You can only report one message every 5 minutes.")
+        verify(replyAction).queue()
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
@@ -472,6 +482,8 @@ class ReportMessageContextMenuTest {
         command.onButtonInteraction(buttonEvent)
 
         verify(buttonEvent).editMessage("Message reporting is not enabled on this server.")
+        verify(editAction).setComponents(emptyList<ActionRow>())
+        verify(editAction).queue()
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
@@ -495,6 +507,7 @@ class ReportMessageContextMenuTest {
 
         verify(buttonEvent).editMessage("Urgent report cancelled.")
         verify(editAction).setComponents(emptyList<ActionRow>())
+        verify(editAction).queue()
     }
 
     @Test
@@ -529,6 +542,7 @@ class ReportMessageContextMenuTest {
         verify(event).reply(
             "Message reporting is not configured on this server. The bot needs a moderator log channel with permission to send messages and embeds."
         )
+        verify(replyAction).queue()
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
@@ -592,10 +606,9 @@ class ReportMessageContextMenuTest {
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
         whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
-        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
         stubTargetMessageIds()
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
-        whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(false)
+        whenever(reportRateLimitService.hasActiveToken(1L, 99L)).thenReturn(true)
         whenever(reportRateLimitService.rateLimitDescription()).thenReturn("5 minutes")
     }
 
@@ -700,15 +713,16 @@ class ReportMessageContextMenuTest {
         whenever(reporterUser.idLong).thenReturn(99L)
         whenever(buttonEvent.guild).thenReturn(guild)
         whenever(buttonEvent.member).thenReturn(reporter)
-        whenever(buttonEvent.reply(any<String>())).thenReturn(replyAction)
-        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(buttonEvent.editMessage(any<String>())).thenReturn(editAction)
+        whenever(editAction.setComponents(any<List<ActionRow>>())).thenReturn(editAction)
         whenever(guild.idLong).thenReturn(1L)
         whenever(reporter.idLong).thenReturn(99L)
         whenever(reporter.isTimedOut).thenReturn(false)
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
         whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
-        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
+        whenever(reportRateLimitService.hasActiveToken(1L, 99L)).thenReturn(true)
+        whenever(reportRateLimitService.rateLimitDescription()).thenReturn("5 minutes")
     }
 
     private fun stubReportWithNullMember(commandName: String) {

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -1,0 +1,167 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.logging.GuildLogger
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion
+import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.Command
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class ReportMessageContextMenuTest {
+    @Mock
+    private lateinit var guildLogger: GuildLogger
+
+    @Mock
+    private lateinit var event: MessageContextInteractionEvent
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var reporter: Member
+
+    @Mock
+    private lateinit var reporterUser: User
+
+    @Mock
+    private lateinit var targetMember: Member
+
+    @Mock
+    private lateinit var targetUser: User
+
+    @Mock
+    private lateinit var targetMessage: Message
+
+    @Mock
+    private lateinit var channel: GuildMessageChannelUnion
+
+    @Mock
+    private lateinit var attachment: Message.Attachment
+
+    @Mock
+    private lateinit var replyAction: ReplyCallbackAction
+
+    private lateinit var command: ReportMessageContextMenu
+
+    @BeforeEach
+    fun setUp() {
+        command = ReportMessageContextMenu(guildLogger)
+    }
+
+    @Test
+    fun `non-matching message context menu returns early`() {
+        whenever(event.name).thenReturn("Other Command")
+
+        command.onMessageContextInteraction(event)
+
+        verify(guildLogger, never()).log(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            isNull(),
+            any<String>()
+        )
+        verify(event, never()).reply(any<String>())
+    }
+
+    @Test
+    fun `non-urgent report logs to moderation channel with here ping`() {
+        stubReport("Report Message")
+
+        command.onMessageContextInteraction(event)
+
+        val embedCaptor = argumentCaptor<EmbedBuilder>()
+        verify(guildLogger).log(
+            embedCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull(),
+            eq("@here")
+        )
+        val embed = embedCaptor.firstValue.build()
+        assertEquals("Message report", embed.title)
+        assertEquals("Reporter", embed.fields[0].name)
+        assertEquals("Duncan(reporter-user)", embed.fields[0].value)
+        assertEquals("Reported user", embed.fields[1].name)
+        assertEquals("ReportedUser", embed.fields[1].value)
+        assertTrue(embed.fields.any { it.name == "Message" && it.value == "This should be reviewed" })
+        assertTrue(embed.fields.any { it.name == "Attachment(s)" && it.value == "https://example.invalid/image.png" })
+        verify(event).reply("Your report has been sent to the moderation team.")
+    }
+
+    @Test
+    fun `urgent report logs to moderation channel with everyone ping`() {
+        stubReport("Urgent Report Message")
+
+        command.onMessageContextInteraction(event)
+
+        val embedCaptor = argumentCaptor<EmbedBuilder>()
+        verify(guildLogger).log(
+            embedCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            isNull(),
+            eq("@everyone")
+        )
+        assertEquals("Urgent message report", embedCaptor.firstValue.build().title)
+        verify(event).reply("Your report has been sent to the moderation team.")
+    }
+
+    @Test
+    fun `command data includes urgent and non-urgent message context menus`() {
+        val commands = command.getCommandsData()
+
+        assertEquals(2, commands.size)
+        assertEquals(listOf(Command.Type.MESSAGE, Command.Type.MESSAGE), commands.map { it.type })
+        assertEquals(listOf("Report Message", "Urgent Report Message"), commands.map { it.name })
+    }
+
+    private fun stubReport(commandName: String) {
+        whenever(event.name).thenReturn(commandName)
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.member).thenReturn(reporter)
+        whenever(event.target).thenReturn(targetMessage)
+        whenever(event.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(reporter.user).thenReturn(reporterUser)
+        whenever(reporter.nickname).thenReturn("Duncan")
+        whenever(reporterUser.name).thenReturn("reporter-user")
+        whenever(targetMessage.author).thenReturn(targetUser)
+        whenever(targetMessage.member).thenReturn(targetMember)
+        whenever(targetMember.nickname).thenReturn(null)
+        whenever(targetMember.user).thenReturn(targetUser)
+        whenever(targetUser.name).thenReturn("ReportedUser")
+        whenever(targetMessage.guildChannel).thenReturn(channel)
+        whenever(channel.asMention).thenReturn("<#123>")
+        whenever(targetMessage.jumpUrl).thenReturn("https://discord.com/channels/1/123/456")
+        whenever(targetMessage.contentRaw).thenReturn("This should be reviewed")
+        whenever(targetMessage.attachments).thenReturn(listOf(attachment))
+        whenever(attachment.url).thenReturn("https://example.invalid/image.png")
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -1,15 +1,21 @@
 package be.duncanc.discordmodbot.moderation
 
 import be.duncanc.discordmodbot.logging.GuildLogger
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.commands.Command
+import net.dv8tion.jda.api.requests.RestAction
+import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -20,11 +26,13 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.function.Consumer
 
 @ExtendWith(MockitoExtension::class)
 class ReportMessageContextMenuTest {
@@ -41,7 +49,13 @@ class ReportMessageContextMenuTest {
     private lateinit var reportRateLimitService: ReportRateLimitService
 
     @Mock
+    private lateinit var reportedMessageService: ReportedMessageService
+
+    @Mock
     private lateinit var event: MessageContextInteractionEvent
+
+    @Mock
+    private lateinit var buttonEvent: ButtonInteractionEvent
 
     @Mock
     private lateinit var guild: Guild
@@ -70,11 +84,29 @@ class ReportMessageContextMenuTest {
     @Mock
     private lateinit var replyAction: ReplyCallbackAction
 
+    @Mock
+    private lateinit var editAction: MessageEditCallbackAction
+
+    @Mock
+    private lateinit var jda: JDA
+
+    @Mock
+    private lateinit var messageChannel: MessageChannel
+
+    @Mock
+    private lateinit var retrieveMessageAction: RestAction<Message>
+
     private lateinit var command: ReportMessageContextMenu
 
     @BeforeEach
     fun setUp() {
-        command = ReportMessageContextMenu(guildLogger, muteService, reportSettingsService, reportRateLimitService)
+        command = ReportMessageContextMenu(
+            guildLogger,
+            muteService,
+            reportSettingsService,
+            reportRateLimitService,
+            reportedMessageService
+        )
     }
 
     @Test
@@ -117,6 +149,7 @@ class ReportMessageContextMenuTest {
         assertEquals("ReportedUser", embed.fields[1].value)
         assertTrue(embed.fields.any { it.name == "Message" && it.value == "This should be reviewed" })
         assertTrue(embed.fields.any { it.name == "Attachment(s)" && it.value == "https://example.invalid/image.png" })
+        verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = false)
         verify(event).reply("Your report has been sent to the moderation team.")
     }
 
@@ -136,6 +169,7 @@ class ReportMessageContextMenuTest {
             eq(GuildLogger.LogTypeAction.MODERATOR),
             eq("@everyone")
         )
+        verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = true)
         assertEquals("Urgent message report", embedCaptor.firstValue.build().title)
         verify(event).reply("Your report has been sent to the moderation team.")
     }
@@ -155,7 +189,98 @@ class ReportMessageContextMenuTest {
             eq(GuildLogger.LogTypeAction.MODERATOR),
             eq("<@&5>")
         )
+        verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = true)
         verify(event).reply("Your report has been sent to the moderation team.")
+    }
+
+    @Test
+    fun `non urgent duplicate report is blocked`() {
+        stubReporterAndTargetIds("Report Message")
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("This issue was already reported.")
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+    }
+
+    @Test
+    fun `urgent report over non urgent report asks for confirmation`() {
+        stubReporterAndTargetIds("Urgent Report Message")
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
+        whenever(replyAction.addComponents(any<ActionRow>())).thenReturn(replyAction)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("This message was already reported as non-urgent. Confirm if you want to report it as urgent.")
+        verify(replyAction).addComponents(any<ActionRow>())
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
+    }
+
+    @Test
+    fun `urgent duplicate report is blocked`() {
+        stubReporterAndTargetIds("Urgent Report Message")
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.URGENT)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("This issue was already reported.")
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+    }
+
+    @Test
+    fun `urgent confirmation by another user is rejected`() {
+        whenever(buttonEvent.componentId).thenReturn("report:urgent:1:123:456:99")
+        whenever(buttonEvent.user).thenReturn(reporterUser)
+        whenever(reporterUser.idLong).thenReturn(100L)
+        whenever(buttonEvent.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).reply("This confirmation is only for the user who requested it.")
+    }
+
+    @Test
+    fun `urgent confirmation logs urgent report and upgrades state`() {
+        stubUrgentConfirmation()
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
+        whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(true)
+        whenever(buttonEvent.jda).thenReturn(jda)
+        whenever(jda.getChannelById(MessageChannel::class.java, 123L)).thenReturn(messageChannel)
+        whenever(messageChannel.retrieveMessageById(456L)).thenReturn(retrieveMessageAction)
+        doRetrieveMessageSuccess()
+        whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("@everyone")
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(guildLogger).logWithContent(
+            any<EmbedBuilder>(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            eq("@everyone")
+        )
+        verify(reportedMessageService).markUrgent(1L, 123L, 456L)
+        verify(buttonEvent).editMessage("Your urgent report has been sent to the moderation team.")
+        verify(editAction).setComponents(emptyList<ActionRow>())
     }
 
     @Test
@@ -241,6 +366,7 @@ class ReportMessageContextMenuTest {
     private fun stubReport(commandName: String, timedOut: Boolean = false, muted: Boolean = false) {
         stubReporterContext(commandName, timedOut, muted)
         stubTargetMessage()
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
     }
 
     private fun stubBlockedReporterContext(
@@ -276,6 +402,8 @@ class ReportMessageContextMenuTest {
         whenever(reporter.isTimedOut).thenReturn(false)
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+        stubTargetMessageIds()
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
         whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(false)
         whenever(reportRateLimitService.rateLimitDescription()).thenReturn("5 minutes")
     }
@@ -301,18 +429,70 @@ class ReportMessageContextMenuTest {
         whenever(reporterUser.name).thenReturn("reporter-user")
     }
 
-    private fun stubTargetMessage() {
+    private fun stubReporterAndTargetIds(commandName: String) {
+        whenever(event.name).thenReturn(commandName)
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.member).thenReturn(reporter)
+        whenever(event.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reporter.idLong).thenReturn(99L)
+        whenever(reporter.isTimedOut).thenReturn(false)
+        whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
+        whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+        stubTargetMessageIds()
+    }
+
+    private fun stubTargetMessageIds() {
         whenever(event.target).thenReturn(targetMessage)
+        whenever(targetMessage.guildChannel).thenReturn(channel)
+        whenever(channel.idLong).thenReturn(123L)
+        whenever(targetMessage.idLong).thenReturn(456L)
+    }
+
+    private fun stubTargetMessage() {
+        stubTargetMessageIds()
+        stubTargetMessageDetails()
+    }
+
+    private fun stubTargetMessageDetails() {
         whenever(targetMessage.author).thenReturn(targetUser)
         whenever(targetMessage.member).thenReturn(targetMember)
         whenever(targetMember.nickname).thenReturn(null)
         whenever(targetMember.user).thenReturn(targetUser)
         whenever(targetUser.name).thenReturn("ReportedUser")
-        whenever(targetMessage.guildChannel).thenReturn(channel)
         whenever(channel.asMention).thenReturn("<#123>")
         whenever(targetMessage.jumpUrl).thenReturn("https://discord.com/channels/1/123/456")
         whenever(targetMessage.contentRaw).thenReturn("This should be reviewed")
         whenever(targetMessage.attachments).thenReturn(listOf(attachment))
         whenever(attachment.url).thenReturn("https://example.invalid/image.png")
+    }
+
+    private fun stubUrgentConfirmation() {
+        whenever(buttonEvent.componentId).thenReturn("report:urgent:1:123:456:99")
+        whenever(buttonEvent.user).thenReturn(reporterUser)
+        whenever(reporterUser.idLong).thenReturn(99L)
+        whenever(buttonEvent.guild).thenReturn(guild)
+        whenever(buttonEvent.member).thenReturn(reporter)
+        whenever(buttonEvent.editMessage(any<String>())).thenReturn(editAction)
+        whenever(editAction.setComponents(any<List<ActionRow>>())).thenReturn(editAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reporter.idLong).thenReturn(99L)
+        whenever(reporter.user).thenReturn(reporterUser)
+        whenever(reporter.nickname).thenReturn("Duncan")
+        whenever(reporterUser.name).thenReturn("reporter-user")
+        whenever(reporter.isTimedOut).thenReturn(false)
+        whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
+        whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+        whenever(targetMessage.guildChannel).thenReturn(channel)
+        stubTargetMessageDetails()
+    }
+
+    private fun doRetrieveMessageSuccess() {
+        doAnswer {
+            val success = it.arguments[0] as Consumer<Message>
+            success.accept(targetMessage)
+            null
+        }.whenever(retrieveMessageAction).queue(any<Consumer<Message>>(), any<Consumer<Throwable>>())
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -155,7 +155,7 @@ class ReportMessageContextMenuTest {
         val embed = embedCaptor.firstValue.build()
         assertEquals("Message report", embed.title)
         assertEquals("Reporter", embed.fields[0].name)
-        assertEquals("Duncan(reporter-user)", embed.fields[0].value)
+        assertEquals("Duncan(reporter-user) (99)", embed.fields[0].value)
         assertEquals("Reported user", embed.fields[1].name)
         assertEquals("ReportedUser", embed.fields[1].value)
         assertTrue(embed.fields.any { it.name == "Message" && it.value == "This should be reviewed" })
@@ -448,6 +448,91 @@ class ReportMessageContextMenuTest {
     }
 
     @Test
+    fun `cancel button clears confirmation message`() {
+        whenever(buttonEvent.componentId).thenReturn("report:cancel:1:123:456:99")
+        whenever(buttonEvent.user).thenReturn(reporterUser)
+        whenever(reporterUser.idLong).thenReturn(99L)
+        whenever(buttonEvent.editMessage("Urgent report cancelled.")).thenReturn(editAction)
+        whenever(editAction.setComponents(emptyList<ActionRow>())).thenReturn(editAction)
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).editMessage("Urgent report cancelled.")
+        verify(editAction).setComponents(emptyList<ActionRow>())
+    }
+
+    @Test
+    fun `report embed uses author name when reported member is null`() {
+        stubReportWithNullMember("Report Message")
+
+        command.onMessageContextInteraction(event)
+
+        val embedCaptor = argumentCaptor<EmbedBuilder>()
+        verify(guildLogger).logWithContent(
+            embedCaptor.capture(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            eq("@here")
+        )
+        val embed = embedCaptor.firstValue.build()
+        assertEquals("Reporter", embed.fields[0].name)
+        assertEquals("Duncan(reporter-user) (99)", embed.fields[0].value)
+        assertEquals("Reported user", embed.fields[1].name)
+        assertEquals("ReportedUser", embed.fields[1].value)
+    }
+
+    @Test
+    fun `report is rejected when no moderator log channel is configured`() {
+        stubReporterAndTargetIdsForModLogCheck("Report Message")
+        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(false)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply(
+            "Message reporting is not configured on this server. A moderator log channel is required."
+        )
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+        verify(reportedMessageService, never()).markReported(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `urgent confirmation succeeds when rate limit token is already active`() {
+        stubUrgentConfirmation()
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
+        whenever(reportRateLimitService.hasActiveToken(1L, 99L)).thenReturn(true)
+        whenever(buttonEvent.jda).thenReturn(jda)
+        whenever(jda.getChannelById(MessageChannel::class.java, 123L)).thenReturn(messageChannel)
+        whenever(messageChannel.retrieveMessageById(456L)).thenReturn(retrieveMessageAction)
+        doRetrieveMessageSuccess()
+        whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("@everyone")
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(guildLogger).logWithContent(
+            any<EmbedBuilder>(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            eq("@everyone")
+        )
+        verify(reportedMessageService).markUrgent(1L, 123L, 456L)
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
+        verify(buttonEvent).deferEdit()
+        verify(interactionHook).editOriginal("Your urgent report has been sent to the moderation team.")
+        verify(hookEditAction).setComponents(emptyList<ActionRow>())
+    }
+
+    @Test
     fun `command data includes urgent and non-urgent message context menus`() {
         val commands = command.getCommandsData()
 
@@ -459,6 +544,7 @@ class ReportMessageContextMenuTest {
     private fun stubReport(commandName: String, timedOut: Boolean = false, muted: Boolean = false) {
         stubReporterContext(commandName, timedOut, muted)
         stubTargetMessage()
+        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
     }
 
@@ -498,6 +584,7 @@ class ReportMessageContextMenuTest {
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
         whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
         stubTargetMessageIds()
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
         whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(false)
@@ -523,6 +610,7 @@ class ReportMessageContextMenuTest {
         }
         whenever(reporter.user).thenReturn(reporterUser)
         whenever(reporter.nickname).thenReturn("Duncan")
+        whenever(reporter.id).thenReturn("99")
         whenever(reporterUser.name).thenReturn("reporter-user")
     }
 
@@ -588,6 +676,7 @@ class ReportMessageContextMenuTest {
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
         whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
         if (includeRetrievedMessageDetails) {
             whenever(reporter.user).thenReturn(reporterUser)
             whenever(reporter.nickname).thenReturn("Duncan")
@@ -595,6 +684,46 @@ class ReportMessageContextMenuTest {
             whenever(targetMessage.guildChannel).thenReturn(channel)
             stubTargetMessageDetails()
         }
+    }
+
+    private fun stubReportWithNullMember(commandName: String) {
+        stubReporterContext(commandName)
+        whenever(event.target).thenReturn(targetMessage)
+        whenever(targetMessage.author).thenReturn(targetUser)
+        whenever(targetMessage.member).thenReturn(null)
+        whenever(targetMessage.guildChannel).thenReturn(channel)
+        whenever(channel.idLong).thenReturn(123L)
+        whenever(targetMessage.idLong).thenReturn(456L)
+        whenever(targetUser.idLong).thenReturn(2L)
+        whenever(targetUser.name).thenReturn("ReportedUser")
+        whenever(channel.asMention).thenReturn("<#123>")
+        whenever(targetMessage.jumpUrl).thenReturn("https://discord.com/channels/1/123/456")
+        whenever(targetMessage.contentRaw).thenReturn("This should be reviewed")
+        whenever(targetMessage.attachments).thenReturn(listOf(attachment))
+        whenever(attachment.url).thenReturn("https://example.invalid/image.png")
+        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
+    }
+
+    private fun stubReporterAndTargetIdsForModLogCheck(commandName: String) {
+        whenever(event.name).thenReturn(commandName)
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.member).thenReturn(reporter)
+        whenever(event.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reporter.idLong).thenReturn(99L)
+        whenever(reporter.isTimedOut).thenReturn(false)
+        whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
+        whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+        whenever(event.target).thenReturn(targetMessage)
+        whenever(targetMessage.author).thenReturn(targetUser)
+        whenever(targetMessage.guildChannel).thenReturn(channel)
+        whenever(channel.idLong).thenReturn(123L)
+        whenever(targetMessage.idLong).thenReturn(456L)
+        whenever(targetUser.idLong).thenReturn(2L)
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
     }
 
     private fun stubReportingDisabledContext(commandName: String) {

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -35,6 +35,9 @@ class ReportMessageContextMenuTest {
     private lateinit var muteService: MuteService
 
     @Mock
+    private lateinit var reportSettingsService: ReportSettingsService
+
+    @Mock
     private lateinit var event: MessageContextInteractionEvent
 
     @Mock
@@ -68,7 +71,7 @@ class ReportMessageContextMenuTest {
 
     @BeforeEach
     fun setUp() {
-        command = ReportMessageContextMenu(guildLogger, muteService)
+        command = ReportMessageContextMenu(guildLogger, muteService, reportSettingsService)
     }
 
     @Test
@@ -77,13 +80,12 @@ class ReportMessageContextMenuTest {
 
         command.onMessageContextInteraction(event)
 
-        verify(guildLogger, never()).log(
+        verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
             any<Guild>(),
             isNull<List<MessageEmbed>>(),
             any<GuildLogger.LogTypeAction>(),
-            isNull(),
             any<String>()
         )
         verify(event, never()).reply(any<String>())
@@ -96,13 +98,12 @@ class ReportMessageContextMenuTest {
         command.onMessageContextInteraction(event)
 
         val embedCaptor = argumentCaptor<EmbedBuilder>()
-        verify(guildLogger).log(
+        verify(guildLogger).logWithContent(
             embedCaptor.capture(),
             eq(targetUser),
             eq(guild),
             isNull<List<MessageEmbed>>(),
             eq(GuildLogger.LogTypeAction.MODERATOR),
-            isNull(),
             eq("@here")
         )
         val embed = embedCaptor.firstValue.build()
@@ -119,20 +120,38 @@ class ReportMessageContextMenuTest {
     @Test
     fun `urgent report logs to moderation channel with everyone ping`() {
         stubReport("Urgent Report Message")
+        whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("@everyone")
 
         command.onMessageContextInteraction(event)
 
         val embedCaptor = argumentCaptor<EmbedBuilder>()
-        verify(guildLogger).log(
+        verify(guildLogger).logWithContent(
             embedCaptor.capture(),
             eq(targetUser),
             eq(guild),
             isNull<List<MessageEmbed>>(),
             eq(GuildLogger.LogTypeAction.MODERATOR),
-            isNull(),
             eq("@everyone")
         )
         assertEquals("Urgent message report", embedCaptor.firstValue.build().title)
+        verify(event).reply("Your report has been sent to the moderation team.")
+    }
+
+    @Test
+    fun `urgent report logs to moderation channel with configured role ping`() {
+        stubReport("Urgent Report Message")
+        whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("<@&5>")
+
+        command.onMessageContextInteraction(event)
+
+        verify(guildLogger).logWithContent(
+            any<EmbedBuilder>(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            eq("<@&5>")
+        )
         verify(event).reply("Your report has been sent to the moderation team.")
     }
 
@@ -143,13 +162,12 @@ class ReportMessageContextMenuTest {
         command.onMessageContextInteraction(event)
 
         verify(event).reply("You cannot report messages while timed out or muted.")
-        verify(guildLogger, never()).log(
+        verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
             any<Guild>(),
             isNull<List<MessageEmbed>>(),
             any<GuildLogger.LogTypeAction>(),
-            isNull(),
             any<String>()
         )
     }
@@ -161,13 +179,29 @@ class ReportMessageContextMenuTest {
         command.onMessageContextInteraction(event)
 
         verify(event).reply("You cannot report messages while timed out or muted.")
-        verify(guildLogger, never()).log(
+        verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
             any<Guild>(),
             isNull<List<MessageEmbed>>(),
             any<GuildLogger.LogTypeAction>(),
-            isNull(),
+            any<String>()
+        )
+    }
+
+    @Test
+    fun `blocked member cannot report messages`() {
+        stubBlockedReporterContext("Report Message", blocked = true)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("You are not allowed to report messages in this server.")
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
             any<String>()
         )
     }
@@ -186,7 +220,12 @@ class ReportMessageContextMenuTest {
         stubTargetMessage()
     }
 
-    private fun stubBlockedReporterContext(commandName: String, timedOut: Boolean = false, muted: Boolean = false) {
+    private fun stubBlockedReporterContext(
+        commandName: String,
+        timedOut: Boolean = false,
+        muted: Boolean = false,
+        blocked: Boolean = false
+    ) {
         whenever(event.name).thenReturn(commandName)
         whenever(event.guild).thenReturn(guild)
         whenever(event.member).thenReturn(reporter)
@@ -197,6 +236,9 @@ class ReportMessageContextMenuTest {
             whenever(guild.idLong).thenReturn(1L)
             whenever(reporter.idLong).thenReturn(99L)
             whenever(muteService.isUserMuted(1L, 99L)).thenReturn(muted)
+            if (!muted) {
+                whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(blocked)
+            }
         }
     }
 
@@ -211,6 +253,9 @@ class ReportMessageContextMenuTest {
         whenever(reporter.isTimedOut).thenReturn(timedOut)
         if (!timedOut) {
             whenever(muteService.isUserMuted(1L, 99L)).thenReturn(muted)
+            if (!muted) {
+                whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+            }
         }
         whenever(reporter.user).thenReturn(reporterUser)
         whenever(reporter.nickname).thenReturn("Duncan")

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -13,8 +13,10 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.requests.RestAction
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -86,6 +88,15 @@ class ReportMessageContextMenuTest {
 
     @Mock
     private lateinit var editAction: MessageEditCallbackAction
+
+    @Mock
+    private lateinit var deferredEditAction: MessageEditCallbackAction
+
+    @Mock
+    private lateinit var interactionHook: InteractionHook
+
+    @Mock
+    private lateinit var hookEditAction: WebhookMessageEditAction<Message>
 
     @Mock
     private lateinit var jda: JDA
@@ -279,8 +290,35 @@ class ReportMessageContextMenuTest {
             eq("@everyone")
         )
         verify(reportedMessageService).markUrgent(1L, 123L, 456L)
-        verify(buttonEvent).editMessage("Your urgent report has been sent to the moderation team.")
-        verify(editAction).setComponents(emptyList<ActionRow>())
+        verify(buttonEvent).deferEdit()
+        verify(interactionHook).editOriginal("Your urgent report has been sent to the moderation team.")
+        verify(hookEditAction).setComponents(emptyList<ActionRow>())
+    }
+
+    @Test
+    fun `urgent confirmation updates deferred response when message retrieval fails`() {
+        stubUrgentConfirmation(includeRetrievedMessageDetails = false)
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
+        whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(true)
+        whenever(buttonEvent.jda).thenReturn(jda)
+        whenever(jda.getChannelById(MessageChannel::class.java, 123L)).thenReturn(messageChannel)
+        whenever(messageChannel.retrieveMessageById(456L)).thenReturn(retrieveMessageAction)
+        doRetrieveMessageFailure()
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).deferEdit()
+        verify(interactionHook).editOriginal("I could not find that message anymore.")
+        verify(hookEditAction).setComponents(emptyList<ActionRow>())
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+        verify(reportedMessageService, never()).markUrgent(any(), any(), any())
     }
 
     @Test
@@ -468,30 +506,46 @@ class ReportMessageContextMenuTest {
         whenever(attachment.url).thenReturn("https://example.invalid/image.png")
     }
 
-    private fun stubUrgentConfirmation() {
+    private fun stubUrgentConfirmation(includeRetrievedMessageDetails: Boolean = true) {
         whenever(buttonEvent.componentId).thenReturn("report:urgent:1:123:456:99")
         whenever(buttonEvent.user).thenReturn(reporterUser)
         whenever(reporterUser.idLong).thenReturn(99L)
         whenever(buttonEvent.guild).thenReturn(guild)
         whenever(buttonEvent.member).thenReturn(reporter)
-        whenever(buttonEvent.editMessage(any<String>())).thenReturn(editAction)
-        whenever(editAction.setComponents(any<List<ActionRow>>())).thenReturn(editAction)
+        whenever(buttonEvent.deferEdit()).thenReturn(deferredEditAction)
+        whenever(interactionHook.editOriginal(any<String>())).thenReturn(hookEditAction)
+        whenever(hookEditAction.setComponents(any<List<ActionRow>>())).thenReturn(hookEditAction)
+        doAnswer {
+            val success = it.arguments[0] as Consumer<InteractionHook>
+            success.accept(interactionHook)
+            null
+        }.whenever(deferredEditAction).queue(any<Consumer<InteractionHook>>())
         whenever(guild.idLong).thenReturn(1L)
         whenever(reporter.idLong).thenReturn(99L)
-        whenever(reporter.user).thenReturn(reporterUser)
-        whenever(reporter.nickname).thenReturn("Duncan")
-        whenever(reporterUser.name).thenReturn("reporter-user")
         whenever(reporter.isTimedOut).thenReturn(false)
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
-        whenever(targetMessage.guildChannel).thenReturn(channel)
-        stubTargetMessageDetails()
+        if (includeRetrievedMessageDetails) {
+            whenever(reporter.user).thenReturn(reporterUser)
+            whenever(reporter.nickname).thenReturn("Duncan")
+            whenever(reporterUser.name).thenReturn("reporter-user")
+            whenever(targetMessage.guildChannel).thenReturn(channel)
+            stubTargetMessageDetails()
+        }
     }
 
     private fun doRetrieveMessageSuccess() {
         doAnswer {
             val success = it.arguments[0] as Consumer<Message>
             success.accept(targetMessage)
+            null
+        }.whenever(retrieveMessageAction).queue(any<Consumer<Message>>(), any<Consumer<Throwable>>())
+    }
+
+    private fun doRetrieveMessageFailure() {
+        doAnswer {
+            val failure = it.arguments[1] as Consumer<Throwable>
+            failure.accept(RuntimeException("message not found"))
             null
         }.whenever(retrieveMessageAction).queue(any<Consumer<Message>>(), any<Consumer<Throwable>>())
     }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -522,12 +522,12 @@ class ReportMessageContextMenuTest {
     @Test
     fun `report is rejected when no moderator log channel is configured`() {
         stubReporterAndTargetIdsForModLogCheck("Report Message")
-        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(false)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(false)
 
         command.onMessageContextInteraction(event)
 
         verify(event).reply(
-            "Message reporting is not configured on this server. A moderator log channel is required."
+            "Message reporting is not configured on this server. The bot needs a moderator log channel with permission to send messages and embeds."
         )
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
@@ -552,7 +552,7 @@ class ReportMessageContextMenuTest {
     private fun stubReport(commandName: String, timedOut: Boolean = false, muted: Boolean = false) {
         stubReporterContext(commandName, timedOut, muted)
         stubTargetMessage()
-        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
     }
 
@@ -592,7 +592,7 @@ class ReportMessageContextMenuTest {
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
         whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
-        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
         stubTargetMessageIds()
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
         whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(false)
@@ -684,7 +684,7 @@ class ReportMessageContextMenuTest {
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
         whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
-        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
         if (includeRetrievedMessageDetails) {
             whenever(reporter.user).thenReturn(reporterUser)
             whenever(reporter.nickname).thenReturn("Duncan")
@@ -708,7 +708,7 @@ class ReportMessageContextMenuTest {
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
         whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
-        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
     }
 
     private fun stubReportWithNullMember(commandName: String) {
@@ -726,7 +726,7 @@ class ReportMessageContextMenuTest {
         whenever(targetMessage.contentRaw).thenReturn("This should be reviewed")
         whenever(targetMessage.attachments).thenReturn(listOf(attachment))
         whenever(attachment.url).thenReturn("https://example.invalid/image.png")
-        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
     }
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -38,6 +38,9 @@ class ReportMessageContextMenuTest {
     private lateinit var reportSettingsService: ReportSettingsService
 
     @Mock
+    private lateinit var reportRateLimitService: ReportRateLimitService
+
+    @Mock
     private lateinit var event: MessageContextInteractionEvent
 
     @Mock
@@ -71,7 +74,7 @@ class ReportMessageContextMenuTest {
 
     @BeforeEach
     fun setUp() {
-        command = ReportMessageContextMenu(guildLogger, muteService, reportSettingsService)
+        command = ReportMessageContextMenu(guildLogger, muteService, reportSettingsService, reportRateLimitService)
     }
 
     @Test
@@ -156,12 +159,30 @@ class ReportMessageContextMenuTest {
     }
 
     @Test
+    fun `rate limited member cannot report messages`() {
+        stubRateLimitedReporterContext("Report Message")
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("You can only report one message every 5 minutes.")
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+    }
+
+    @Test
     fun `timed out member cannot report messages`() {
         stubBlockedReporterContext("Report Message", timedOut = true)
 
         command.onMessageContextInteraction(event)
 
         verify(event).reply("You cannot report messages while timed out or muted.")
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
@@ -179,6 +200,7 @@ class ReportMessageContextMenuTest {
         command.onMessageContextInteraction(event)
 
         verify(event).reply("You cannot report messages while timed out or muted.")
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
@@ -196,6 +218,7 @@ class ReportMessageContextMenuTest {
         command.onMessageContextInteraction(event)
 
         verify(event).reply("You are not allowed to report messages in this server.")
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
@@ -242,6 +265,21 @@ class ReportMessageContextMenuTest {
         }
     }
 
+    private fun stubRateLimitedReporterContext(commandName: String) {
+        whenever(event.name).thenReturn(commandName)
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.member).thenReturn(reporter)
+        whenever(event.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reporter.idLong).thenReturn(99L)
+        whenever(reporter.isTimedOut).thenReturn(false)
+        whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
+        whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+        whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(false)
+        whenever(reportRateLimitService.rateLimitDescription()).thenReturn("5 minutes")
+    }
+
     private fun stubReporterContext(commandName: String, timedOut: Boolean = false, muted: Boolean = false) {
         whenever(event.name).thenReturn(commandName)
         whenever(event.guild).thenReturn(guild)
@@ -255,6 +293,7 @@ class ReportMessageContextMenuTest {
             whenever(muteService.isUserMuted(1L, 99L)).thenReturn(muted)
             if (!muted) {
                 whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+                whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(true)
             }
         }
         whenever(reporter.user).thenReturn(reporterUser)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -399,6 +399,8 @@ class ReportMessageContextMenuTest {
         whenever(event.member).thenReturn(reporter)
         whenever(event.reply(any<String>())).thenReturn(replyAction)
         whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(event.target).thenReturn(targetMessage)
         whenever(targetMessage.author).thenReturn(targetUser)
         whenever(targetUser.idLong).thenReturn(99L)
@@ -407,6 +409,42 @@ class ReportMessageContextMenuTest {
         command.onMessageContextInteraction(event)
 
         verify(event).reply("You cannot report your own messages.")
+    }
+
+    @Test
+    fun `reporting disabled member cannot report messages`() {
+        stubReportingDisabledContext("Report Message")
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("Message reporting is not enabled on this server.")
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+    }
+
+    @Test
+    fun `urgent confirmation rejects when reporting is disabled`() {
+        stubUrgentConfirmationDisabled()
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).editMessage("Message reporting is not enabled on this server.")
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+        verify(reportedMessageService, never()).markUrgent(any(), any(), any())
     }
 
     @Test
@@ -428,16 +466,18 @@ class ReportMessageContextMenuTest {
         commandName: String,
         timedOut: Boolean = false,
         muted: Boolean = false,
-        blocked: Boolean = false
+        blocked: Boolean = false,
+        enabled: Boolean = true
     ) {
         whenever(event.name).thenReturn(commandName)
         whenever(event.guild).thenReturn(guild)
         whenever(event.member).thenReturn(reporter)
         whenever(event.reply(any<String>())).thenReturn(replyAction)
         whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(enabled)
         whenever(reporter.isTimedOut).thenReturn(timedOut)
         if (!timedOut) {
-            whenever(guild.idLong).thenReturn(1L)
             whenever(reporter.idLong).thenReturn(99L)
             whenever(muteService.isUserMuted(1L, 99L)).thenReturn(muted)
             if (!muted) {
@@ -456,6 +496,7 @@ class ReportMessageContextMenuTest {
         whenever(reporter.idLong).thenReturn(99L)
         whenever(reporter.isTimedOut).thenReturn(false)
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
         stubTargetMessageIds()
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(null)
@@ -475,6 +516,7 @@ class ReportMessageContextMenuTest {
         if (!timedOut) {
             whenever(muteService.isUserMuted(1L, 99L)).thenReturn(muted)
             if (!muted) {
+                whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
                 whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
                 whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(true)
             }
@@ -494,6 +536,7 @@ class ReportMessageContextMenuTest {
         whenever(reporter.idLong).thenReturn(99L)
         whenever(reporter.isTimedOut).thenReturn(false)
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
         stubTargetMessageIds()
     }
@@ -543,6 +586,7 @@ class ReportMessageContextMenuTest {
         whenever(reporter.idLong).thenReturn(99L)
         whenever(reporter.isTimedOut).thenReturn(false)
         whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
         if (includeRetrievedMessageDetails) {
             whenever(reporter.user).thenReturn(reporterUser)
@@ -551,6 +595,28 @@ class ReportMessageContextMenuTest {
             whenever(targetMessage.guildChannel).thenReturn(channel)
             stubTargetMessageDetails()
         }
+    }
+
+    private fun stubReportingDisabledContext(commandName: String) {
+        whenever(event.name).thenReturn(commandName)
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.member).thenReturn(reporter)
+        whenever(event.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(false)
+    }
+
+    private fun stubUrgentConfirmationDisabled() {
+        whenever(buttonEvent.componentId).thenReturn("report:urgent:1:123:456:99")
+        whenever(buttonEvent.user).thenReturn(reporterUser)
+        whenever(reporterUser.idLong).thenReturn(99L)
+        whenever(buttonEvent.guild).thenReturn(guild)
+        whenever(buttonEvent.member).thenReturn(reporter)
+        whenever(buttonEvent.editMessage(any<String>())).thenReturn(editAction)
+        whenever(editAction.setComponents(any<List<ActionRow>>())).thenReturn(editAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(false)
     }
 
     private fun doRetrieveMessageSuccess() {

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -227,6 +227,7 @@ class ReportMessageContextMenuTest {
     fun `urgent report over non urgent report asks for confirmation`() {
         stubReporterAndTargetIds("Urgent Report Message")
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
+        whenever(reportRateLimitService.hasActiveToken(1L, 99L)).thenReturn(false)
         whenever(replyAction.addComponents(any<ActionRow>())).thenReturn(replyAction)
 
         command.onMessageContextInteraction(event)
@@ -234,6 +235,41 @@ class ReportMessageContextMenuTest {
         verify(event).reply("This message was already reported as non-urgent. Confirm if you want to report it as urgent.")
         verify(replyAction).addComponents(any<ActionRow>())
         verify(reportRateLimitService, never()).tryConsume(any(), any())
+    }
+
+    @Test
+    fun `urgent escalation prompt is not shown while rate limited`() {
+        stubReporterAndTargetIds("Urgent Report Message")
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
+        whenever(reportRateLimitService.hasActiveToken(1L, 99L)).thenReturn(true)
+        whenever(reportRateLimitService.rateLimitDescription()).thenReturn("5 minutes")
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("You can only report one message every 5 minutes.")
+        verify(replyAction, never()).addComponents(any<ActionRow>())
+        verify(reportRateLimitService, never()).tryConsume(any(), any())
+    }
+
+    @Test
+    fun `urgent confirmation is rejected while rate limited`() {
+        stubUrgentConfirmationRateLimited()
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
+        whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(false)
+        whenever(reportRateLimitService.rateLimitDescription()).thenReturn("5 minutes")
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).reply("You can only report one message every 5 minutes.")
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+        verify(reportedMessageService, never()).markUrgent(any(), any(), any())
     }
 
     @Test
@@ -505,34 +541,6 @@ class ReportMessageContextMenuTest {
     }
 
     @Test
-    fun `urgent confirmation succeeds when rate limit token is already active`() {
-        stubUrgentConfirmation()
-        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
-        whenever(reportRateLimitService.hasActiveToken(1L, 99L)).thenReturn(true)
-        whenever(buttonEvent.jda).thenReturn(jda)
-        whenever(jda.getChannelById(MessageChannel::class.java, 123L)).thenReturn(messageChannel)
-        whenever(messageChannel.retrieveMessageById(456L)).thenReturn(retrieveMessageAction)
-        doRetrieveMessageSuccess()
-        whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("@everyone")
-
-        command.onButtonInteraction(buttonEvent)
-
-        verify(guildLogger).logWithContent(
-            any<EmbedBuilder>(),
-            eq(targetUser),
-            eq(guild),
-            isNull<List<MessageEmbed>>(),
-            eq(GuildLogger.LogTypeAction.MODERATOR),
-            eq("@everyone")
-        )
-        verify(reportedMessageService).markUrgent(1L, 123L, 456L)
-        verify(reportRateLimitService, never()).tryConsume(any(), any())
-        verify(buttonEvent).deferEdit()
-        verify(interactionHook).editOriginal("Your urgent report has been sent to the moderation team.")
-        verify(hookEditAction).setComponents(emptyList<ActionRow>())
-    }
-
-    @Test
     fun `command data includes urgent and non-urgent message context menus`() {
         val commands = command.getCommandsData()
 
@@ -684,6 +692,23 @@ class ReportMessageContextMenuTest {
             whenever(targetMessage.guildChannel).thenReturn(channel)
             stubTargetMessageDetails()
         }
+    }
+
+    private fun stubUrgentConfirmationRateLimited() {
+        whenever(buttonEvent.componentId).thenReturn("report:urgent:1:123:456:99")
+        whenever(buttonEvent.user).thenReturn(reporterUser)
+        whenever(reporterUser.idLong).thenReturn(99L)
+        whenever(buttonEvent.guild).thenReturn(guild)
+        whenever(buttonEvent.member).thenReturn(reporter)
+        whenever(buttonEvent.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reporter.idLong).thenReturn(99L)
+        whenever(reporter.isTimedOut).thenReturn(false)
+        whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
+        whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+        whenever(guildLogger.hasModeratorLogChannel(guild)).thenReturn(true)
     }
 
     private fun stubReportWithNullMember(commandName: String) {

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -393,6 +393,23 @@ class ReportMessageContextMenuTest {
     }
 
     @Test
+    fun `member cannot report their own messages`() {
+        whenever(event.name).thenReturn("Report Message")
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.member).thenReturn(reporter)
+        whenever(event.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(event.target).thenReturn(targetMessage)
+        whenever(targetMessage.author).thenReturn(targetUser)
+        whenever(targetUser.idLong).thenReturn(99L)
+        whenever(reporter.idLong).thenReturn(99L)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("You cannot report your own messages.")
+    }
+
+    @Test
     fun `command data includes urgent and non-urgent message context menus`() {
         val commands = command.getCommandsData()
 
@@ -483,9 +500,11 @@ class ReportMessageContextMenuTest {
 
     private fun stubTargetMessageIds() {
         whenever(event.target).thenReturn(targetMessage)
+        whenever(targetMessage.author).thenReturn(targetUser)
         whenever(targetMessage.guildChannel).thenReturn(channel)
         whenever(channel.idLong).thenReturn(123L)
         whenever(targetMessage.idLong).thenReturn(456L)
+        whenever(targetUser.idLong).thenReturn(2L)
     }
 
     private fun stubTargetMessage() {

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -32,6 +32,9 @@ class ReportMessageContextMenuTest {
     private lateinit var guildLogger: GuildLogger
 
     @Mock
+    private lateinit var muteService: MuteService
+
+    @Mock
     private lateinit var event: MessageContextInteractionEvent
 
     @Mock
@@ -65,7 +68,7 @@ class ReportMessageContextMenuTest {
 
     @BeforeEach
     fun setUp() {
-        command = ReportMessageContextMenu(guildLogger)
+        command = ReportMessageContextMenu(guildLogger, muteService)
     }
 
     @Test
@@ -134,6 +137,42 @@ class ReportMessageContextMenuTest {
     }
 
     @Test
+    fun `timed out member cannot report messages`() {
+        stubBlockedReporterContext("Report Message", timedOut = true)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("You cannot report messages while timed out or muted.")
+        verify(guildLogger, never()).log(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            isNull(),
+            any<String>()
+        )
+    }
+
+    @Test
+    fun `muted member cannot report messages`() {
+        stubBlockedReporterContext("Urgent Report Message", muted = true)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply("You cannot report messages while timed out or muted.")
+        verify(guildLogger, never()).log(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            isNull(),
+            any<String>()
+        )
+    }
+
+    @Test
     fun `command data includes urgent and non-urgent message context menus`() {
         val commands = command.getCommandsData()
 
@@ -142,16 +181,44 @@ class ReportMessageContextMenuTest {
         assertEquals(listOf("Report Message", "Urgent Report Message"), commands.map { it.name })
     }
 
-    private fun stubReport(commandName: String) {
+    private fun stubReport(commandName: String, timedOut: Boolean = false, muted: Boolean = false) {
+        stubReporterContext(commandName, timedOut, muted)
+        stubTargetMessage()
+    }
+
+    private fun stubBlockedReporterContext(commandName: String, timedOut: Boolean = false, muted: Boolean = false) {
         whenever(event.name).thenReturn(commandName)
         whenever(event.guild).thenReturn(guild)
         whenever(event.member).thenReturn(reporter)
-        whenever(event.target).thenReturn(targetMessage)
         whenever(event.reply(any<String>())).thenReturn(replyAction)
         whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(reporter.isTimedOut).thenReturn(timedOut)
+        if (!timedOut) {
+            whenever(guild.idLong).thenReturn(1L)
+            whenever(reporter.idLong).thenReturn(99L)
+            whenever(muteService.isUserMuted(1L, 99L)).thenReturn(muted)
+        }
+    }
+
+    private fun stubReporterContext(commandName: String, timedOut: Boolean = false, muted: Boolean = false) {
+        whenever(event.name).thenReturn(commandName)
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.member).thenReturn(reporter)
+        whenever(event.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reporter.idLong).thenReturn(99L)
+        whenever(reporter.isTimedOut).thenReturn(timedOut)
+        if (!timedOut) {
+            whenever(muteService.isUserMuted(1L, 99L)).thenReturn(muted)
+        }
         whenever(reporter.user).thenReturn(reporterUser)
         whenever(reporter.nickname).thenReturn("Duncan")
         whenever(reporterUser.name).thenReturn("reporter-user")
+    }
+
+    private fun stubTargetMessage() {
+        whenever(event.target).thenReturn(targetMessage)
         whenever(targetMessage.author).thenReturn(targetUser)
         whenever(targetMessage.member).thenReturn(targetMember)
         whenever(targetMember.nickname).thenReturn(null)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportPropertiesTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportPropertiesTest.kt
@@ -1,0 +1,41 @@
+package be.duncanc.discordmodbot.moderation
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+class ReportPropertiesTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        .withUserConfiguration(ReportPropertiesConfiguration::class.java)
+
+    @Test
+    fun `default values are bound when no properties are set`() {
+        contextRunner.run { context ->
+            val properties = context.getBean(ReportProperties::class.java)
+            assertEquals(Duration.ofMinutes(5), properties.reportRateLimit)
+            assertEquals(Duration.ofHours(1), properties.reportedMessageRetention)
+        }
+    }
+
+    @Test
+    fun `custom values are bound from properties`() {
+        contextRunner
+            .withPropertyValues(
+                "discord-mod-bot.reporting.report-rate-limit=10m",
+                "discord-mod-bot.reporting.reported-message-retention=2h"
+            )
+            .run { context ->
+                val properties = context.getBean(ReportProperties::class.java)
+                assertEquals(Duration.ofMinutes(10), properties.reportRateLimit)
+                assertEquals(Duration.ofHours(2), properties.reportedMessageRetention)
+            }
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(ReportProperties::class)
+    class ReportPropertiesConfiguration
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitServiceTest.kt
@@ -82,6 +82,20 @@ class ReportRateLimitServiceTest {
     }
 
     @Test
+    fun `description formats mixed hours and minutes`() {
+        val service = service(Duration.ofMinutes(90))
+
+        assertEquals("1 hour 30 minutes", service.rateLimitDescription())
+    }
+
+    @Test
+    fun `description formats mixed days hours minutes and seconds`() {
+        val service = service(Duration.ofSeconds(90061))
+
+        assertEquals("1 day 1 hour 1 minute 1 second", service.rateLimitDescription())
+    }
+
+    @Test
     fun `key uses guild and user id`() {
         val service = service(Duration.ofMinutes(5))
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitServiceTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitServiceTest.kt
@@ -103,6 +103,36 @@ class ReportRateLimitServiceTest {
         assertEquals("report:rate-limit:2:99", service.createKey(2L, 99L))
     }
 
+    @Test
+    fun `hasActiveToken returns true when key exists`() {
+        val service = service(Duration.ofMinutes(5))
+        whenever(redisTemplate.hasKey("report:rate-limit:1:99")).thenReturn(true)
+
+        val active = service.hasActiveToken(1L, 99L)
+
+        assertTrue(active)
+    }
+
+    @Test
+    fun `hasActiveToken returns false when key does not exist`() {
+        val service = service(Duration.ofMinutes(5))
+        whenever(redisTemplate.hasKey("report:rate-limit:1:99")).thenReturn(false)
+
+        val active = service.hasActiveToken(1L, 99L)
+
+        assertFalse(active)
+    }
+
+    @Test
+    fun `hasActiveToken returns false when rate limiting is disabled`() {
+        val service = service(Duration.ZERO)
+
+        val active = service.hasActiveToken(1L, 99L)
+
+        assertFalse(active)
+        verify(redisTemplate, never()).hasKey(any<String>())
+    }
+
     private fun service(rateLimit: Duration): ReportRateLimitService {
         return ReportRateLimitService(redisTemplate, ReportProperties(reportRateLimit = rateLimit))
     }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportRateLimitServiceTest.kt
@@ -1,0 +1,95 @@
+package be.duncanc.discordmodbot.moderation
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.time.Duration
+
+@ExtendWith(MockitoExtension::class)
+class ReportRateLimitServiceTest {
+    @Mock
+    private lateinit var redisTemplate: StringRedisTemplate
+
+    @Mock
+    private lateinit var valueOperations: ValueOperations<String, String>
+
+    @Test
+    fun `first report is allowed and stores per guild user key`() {
+        val service = service(Duration.ofMinutes(5))
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+        whenever(valueOperations.setIfAbsent("report:rate-limit:1:99", "1", Duration.ofMinutes(5))).thenReturn(true)
+
+        val allowed = service.tryConsume(1L, 99L)
+
+        assertTrue(allowed)
+        verify(valueOperations).setIfAbsent("report:rate-limit:1:99", "1", Duration.ofMinutes(5))
+    }
+
+    @Test
+    fun `second report while key exists is rejected`() {
+        val service = service(Duration.ofMinutes(5))
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+        whenever(valueOperations.setIfAbsent("report:rate-limit:1:99", "1", Duration.ofMinutes(5))).thenReturn(false)
+
+        val allowed = service.tryConsume(1L, 99L)
+
+        assertFalse(allowed)
+    }
+
+    @Test
+    fun `zero duration disables rate limiting`() {
+        val service = service(Duration.ZERO)
+
+        val allowed = service.tryConsume(1L, 99L)
+
+        assertTrue(allowed)
+        verify(redisTemplate, never()).opsForValue()
+    }
+
+    @Test
+    fun `negative duration disables rate limiting`() {
+        val service = service(Duration.ofSeconds(-1))
+
+        val allowed = service.tryConsume(1L, 99L)
+
+        assertTrue(allowed)
+        verify(redisTemplate, never()).opsForValue()
+    }
+
+    @Test
+    fun `description formats default minutes`() {
+        val service = service(Duration.ofMinutes(5))
+
+        assertEquals("5 minutes", service.rateLimitDescription())
+    }
+
+    @Test
+    fun `description formats seconds`() {
+        val service = service(Duration.ofSeconds(30))
+
+        assertEquals("30 seconds", service.rateLimitDescription())
+    }
+
+    @Test
+    fun `key uses guild and user id`() {
+        val service = service(Duration.ofMinutes(5))
+
+        assertEquals("report:rate-limit:1:99", service.createKey(1L, 99L))
+        assertEquals("report:rate-limit:2:99", service.createKey(2L, 99L))
+    }
+
+    private fun service(rateLimit: Duration): ReportRateLimitService {
+        return ReportRateLimitService(redisTemplate, ReportProperties(reportRateLimit = rateLimit))
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
@@ -132,11 +132,11 @@ class ReportSettingsCommandTest {
     }
 
     @Test
-    fun `show displays urgent role and blocked users`() {
+    fun `show displays reporting status, urgent role and blocked users`() {
         stubAuthorizedCommand("show")
         whenever(guild.name).thenReturn("Test Guild")
         whenever(reportSettingsService.getSettings(1L)).thenReturn(
-            ReportSettings(1L, urgentRoleId = 5L, blockedUserIds = mutableSetOf(99L))
+            ReportSettings(1L, urgentRoleId = 5L, enabled = true, blockedUserIds = mutableSetOf(99L))
         )
         whenever(guild.getRoleById(5L)).thenReturn(role)
         whenever(role.asMention).thenReturn("<@&5>")
@@ -146,8 +146,29 @@ class ReportSettingsCommandTest {
         val replyCaptor = argumentCaptor<String>()
         verify(event).reply(replyCaptor.capture())
         assertTrue(replyCaptor.firstValue.contains("Report settings for Test Guild"))
+        assertTrue(replyCaptor.firstValue.contains("- Reporting: enabled"))
         assertTrue(replyCaptor.firstValue.contains("- Urgent mention: <@&5>"))
         assertTrue(replyCaptor.firstValue.contains("- Blocked users: <@99>"))
+    }
+
+    @Test
+    fun `toggle enables reporting`() {
+        stubAuthorizedCommand("toggle")
+        whenever(reportSettingsService.toggleReporting(1L)).thenReturn(true)
+
+        command.onSlashCommandInteraction(event)
+
+        verify(event).reply("Message reporting is now enabled.")
+    }
+
+    @Test
+    fun `toggle disables reporting`() {
+        stubAuthorizedCommand("toggle")
+        whenever(reportSettingsService.toggleReporting(1L)).thenReturn(false)
+
+        command.onSlashCommandInteraction(event)
+
+        verify(event).reply("Message reporting is now disabled.")
     }
 
     @Test
@@ -157,7 +178,7 @@ class ReportSettingsCommandTest {
         assertEquals("reportsettings", commandData.name)
         assertEquals(setOf(InteractionContextType.GUILD), commandData.contexts)
         assertEquals(
-            listOf("show", "block-user", "allow-user", "set-urgent-role", "clear-urgent-role"),
+            listOf("show", "block-user", "allow-user", "set-urgent-role", "clear-urgent-role", "toggle"),
             commandData.subcommands.map(SubcommandData::getName)
         )
     }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
@@ -138,8 +138,7 @@ class ReportSettingsCommandTest {
         whenever(reportSettingsService.getSettings(1L)).thenReturn(
             ReportSettings(1L, urgentRoleId = 5L, enabled = true, blockedUserIds = mutableSetOf(99L))
         )
-        whenever(guild.getRoleById(5L)).thenReturn(role)
-        whenever(role.asMention).thenReturn("<@&5>")
+        whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("<@&5>")
 
         command.onSlashCommandInteraction(event)
 

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
@@ -1,0 +1,187 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.moderation.persistence.ReportSettings
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionContextType
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class ReportSettingsCommandTest {
+    @Mock
+    private lateinit var reportSettingsService: ReportSettingsService
+
+    @Mock
+    private lateinit var event: SlashCommandInteractionEvent
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var member: Member
+
+    @Mock
+    private lateinit var user: User
+
+    @Mock
+    private lateinit var role: Role
+
+    @Mock
+    private lateinit var userOption: OptionMapping
+
+    @Mock
+    private lateinit var roleOption: OptionMapping
+
+    @Mock
+    private lateinit var replyAction: ReplyCallbackAction
+
+    private lateinit var command: ReportSettingsCommand
+
+    @BeforeEach
+    fun setUp() {
+        command = ReportSettingsCommand(reportSettingsService)
+    }
+
+    @Test
+    fun `non-matching command name returns early`() {
+        whenever(event.name).thenReturn("other")
+
+        command.onSlashCommandInteraction(event)
+
+        verify(event, never()).reply(any<String>())
+    }
+
+    @Test
+    fun `missing manage roles permission returns error`() {
+        stubGuildCommandWithoutSubcommand()
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(false)
+
+        command.onSlashCommandInteraction(event)
+
+        verify(event).reply("You need manage roles permission to use this command.")
+    }
+
+    @Test
+    fun `block user stores blocked user`() {
+        stubAuthorizedCommand("block-user")
+        whenever(event.getOption("user")).thenReturn(userOption)
+        whenever(userOption.asUser).thenReturn(user)
+        whenever(user.idLong).thenReturn(99L)
+        whenever(user.asMention).thenReturn("<@99>")
+
+        command.onSlashCommandInteraction(event)
+
+        verify(reportSettingsService).blockUser(1L, 99L)
+        verify(event).reply("<@99> can no longer report messages in this server.")
+    }
+
+    @Test
+    fun `allow user removes blocked user`() {
+        stubAuthorizedCommand("allow-user")
+        whenever(event.getOption("user")).thenReturn(userOption)
+        whenever(userOption.asUser).thenReturn(user)
+        whenever(user.idLong).thenReturn(99L)
+        whenever(user.asMention).thenReturn("<@99>")
+
+        command.onSlashCommandInteraction(event)
+
+        verify(reportSettingsService).allowUser(1L, 99L)
+        verify(event).reply("<@99> can report messages in this server again.")
+    }
+
+    @Test
+    fun `set urgent role stores role`() {
+        stubAuthorizedCommand("set-urgent-role")
+        whenever(event.getOption("role")).thenReturn(roleOption)
+        whenever(roleOption.asRole).thenReturn(role)
+        whenever(role.idLong).thenReturn(5L)
+        whenever(role.asMention).thenReturn("<@&5>")
+
+        command.onSlashCommandInteraction(event)
+
+        verify(reportSettingsService).setUrgentRole(1L, 5L)
+        verify(event).reply("Urgent reports will now mention <@&5>.")
+    }
+
+    @Test
+    fun `clear urgent role removes role`() {
+        stubAuthorizedCommand("clear-urgent-role")
+
+        command.onSlashCommandInteraction(event)
+
+        verify(reportSettingsService).clearUrgentRole(1L)
+        verify(event).reply("Urgent report role cleared. Urgent reports will mention @everyone.")
+    }
+
+    @Test
+    fun `show displays urgent role and blocked users`() {
+        stubAuthorizedCommand("show")
+        whenever(guild.name).thenReturn("Test Guild")
+        whenever(reportSettingsService.getSettings(1L)).thenReturn(
+            ReportSettings(1L, urgentRoleId = 5L, blockedUserIds = mutableSetOf(99L))
+        )
+        whenever(guild.getRoleById(5L)).thenReturn(role)
+        whenever(role.asMention).thenReturn("<@&5>")
+
+        command.onSlashCommandInteraction(event)
+
+        val replyCaptor = argumentCaptor<String>()
+        verify(event).reply(replyCaptor.capture())
+        assertTrue(replyCaptor.firstValue.contains("Report settings for Test Guild"))
+        assertTrue(replyCaptor.firstValue.contains("- Urgent mention: <@&5>"))
+        assertTrue(replyCaptor.firstValue.contains("- Blocked users: <@99>"))
+    }
+
+    @Test
+    fun `command data exposes expected subcommands and metadata`() {
+        val commandData = command.getCommandsData().single()
+
+        assertEquals("reportsettings", commandData.name)
+        assertEquals(setOf(InteractionContextType.GUILD), commandData.contexts)
+        assertEquals(
+            listOf("show", "block-user", "allow-user", "set-urgent-role", "clear-urgent-role"),
+            commandData.subcommands.map(SubcommandData::getName)
+        )
+    }
+
+    private fun stubAuthorizedCommand(subcommandName: String) {
+        stubGuildCommand(subcommandName)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(guild.idLong).thenReturn(1L)
+    }
+
+    private fun stubGuildCommand(subcommandName: String) {
+        whenever(event.name).thenReturn("reportsettings")
+        whenever(event.subcommandName).thenReturn(subcommandName)
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.member).thenReturn(member)
+        whenever(event.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+    }
+
+    private fun stubGuildCommandWithoutSubcommand() {
+        whenever(event.name).thenReturn("reportsettings")
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.member).thenReturn(member)
+        whenever(event.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsServiceTest.kt
@@ -1,0 +1,76 @@
+package be.duncanc.discordmodbot.moderation
+
+import be.duncanc.discordmodbot.moderation.persistence.ReportSettings
+import be.duncanc.discordmodbot.moderation.persistence.ReportSettingsRepository
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Role
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class ReportSettingsServiceTest {
+    @Mock
+    private lateinit var reportSettingsRepository: ReportSettingsRepository
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var role: Role
+
+    @Test
+    fun `urgent mention falls back to everyone when role is not configured`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+
+        val mention = service.getUrgentMention(guild)
+
+        assertEquals("@everyone", mention)
+    }
+
+    @Test
+    fun `urgent mention uses configured role when role still exists`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guild.getRoleById(5L)).thenReturn(role)
+        whenever(role.asMention).thenReturn("<@&5>")
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.of(ReportSettings(1L, urgentRoleId = 5L)))
+
+        val mention = service.getUrgentMention(guild)
+
+        assertEquals("<@&5>", mention)
+    }
+
+    @Test
+    fun `urgent mention falls back to everyone when configured role is missing`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guild.getRoleById(5L)).thenReturn(null)
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.of(ReportSettings(1L, urgentRoleId = 5L)))
+
+        val mention = service.getUrgentMention(guild)
+
+        assertEquals("@everyone", mention)
+    }
+
+    @Test
+    fun `blocking a user creates settings and stores user id`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+
+        service.blockUser(1L, 99L)
+
+        val settingsCaptor = argumentCaptor<ReportSettings>()
+        verify(reportSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(1L, settingsCaptor.firstValue.guildId)
+        assertEquals(setOf(99L), settingsCaptor.firstValue.blockedUserIds)
+    }
+}

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsServiceTest.kt
@@ -5,6 +5,8 @@ import be.duncanc.discordmodbot.moderation.persistence.ReportSettingsRepository
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Role
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
@@ -94,5 +96,54 @@ class ReportSettingsServiceTest {
         service.clearUrgentRole(1L)
 
         verify(reportSettingsRepository, never()).save(any<ReportSettings>())
+    }
+
+    @Test
+    fun `isReportingEnabled returns false when no settings exist`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+
+        val enabled = service.isReportingEnabled(1L)
+
+        assertFalse(enabled)
+    }
+
+    @Test
+    fun `isReportingEnabled returns stored value`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(reportSettingsRepository.findById(1L))
+            .thenReturn(Optional.of(ReportSettings(1L, enabled = true)))
+
+        val enabled = service.isReportingEnabled(1L)
+
+        assertTrue(enabled)
+    }
+
+    @Test
+    fun `toggleReporting creates settings when absent and enables reporting`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+
+        val enabled = service.toggleReporting(1L)
+
+        val settingsCaptor = argumentCaptor<ReportSettings>()
+        verify(reportSettingsRepository).save(settingsCaptor.capture())
+        assertTrue(enabled)
+        assertTrue(settingsCaptor.firstValue.enabled)
+        assertEquals(1L, settingsCaptor.firstValue.guildId)
+    }
+
+    @Test
+    fun `toggleReporting flips existing enabled state`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(reportSettingsRepository.findById(1L))
+            .thenReturn(Optional.of(ReportSettings(1L, enabled = true)))
+
+        val enabled = service.toggleReporting(1L)
+
+        val settingsCaptor = argumentCaptor<ReportSettings>()
+        verify(reportSettingsRepository).save(settingsCaptor.capture())
+        assertFalse(enabled)
+        assertFalse(settingsCaptor.firstValue.enabled)
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsServiceTest.kt
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Optional
@@ -72,5 +74,25 @@ class ReportSettingsServiceTest {
         verify(reportSettingsRepository).save(settingsCaptor.capture())
         assertEquals(1L, settingsCaptor.firstValue.guildId)
         assertEquals(setOf(99L), settingsCaptor.firstValue.blockedUserIds)
+    }
+
+    @Test
+    fun `allowing a user without existing settings does not create a row`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+
+        service.allowUser(1L, 99L)
+
+        verify(reportSettingsRepository, never()).save(any<ReportSettings>())
+    }
+
+    @Test
+    fun `clearing urgent role without existing settings does not create a row`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+
+        service.clearUrgentRole(1L)
+
+        verify(reportSettingsRepository, never()).save(any<ReportSettings>())
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportedMessageServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportedMessageServiceTest.kt
@@ -1,0 +1,97 @@
+package be.duncanc.discordmodbot.moderation
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.time.Duration
+
+@ExtendWith(MockitoExtension::class)
+class ReportedMessageServiceTest {
+    @Mock
+    private lateinit var redisTemplate: StringRedisTemplate
+
+    @Mock
+    private lateinit var valueOperations: ValueOperations<String, String>
+
+    @Test
+    fun `missing state returns null`() {
+        val service = service(Duration.ofHours(1))
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+        whenever(valueOperations.get("report:message:1:2:3")).thenReturn(null)
+
+        val state = service.getState(1L, 2L, 3L)
+
+        assertNull(state)
+    }
+
+    @Test
+    fun `stored non urgent state is returned`() {
+        val service = service(Duration.ofHours(1))
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+        whenever(valueOperations.get("report:message:1:2:3")).thenReturn("NON_URGENT")
+
+        val state = service.getState(1L, 2L, 3L)
+
+        assertEquals(ReportedMessageState.NON_URGENT, state)
+    }
+
+    @Test
+    fun `invalid state returns null`() {
+        val service = service(Duration.ofHours(1))
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+        whenever(valueOperations.get("report:message:1:2:3")).thenReturn("UNKNOWN")
+
+        val state = service.getState(1L, 2L, 3L)
+
+        assertNull(state)
+    }
+
+    @Test
+    fun `mark reported stores non urgent state with retention`() {
+        val service = service(Duration.ofHours(1))
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+
+        service.markReported(1L, 2L, 3L, urgent = false)
+
+        verify(valueOperations).set("report:message:1:2:3", "NON_URGENT", Duration.ofHours(1))
+    }
+
+    @Test
+    fun `mark urgent stores urgent state with retention`() {
+        val service = service(Duration.ofHours(1))
+        whenever(redisTemplate.opsForValue()).thenReturn(valueOperations)
+
+        service.markUrgent(1L, 2L, 3L)
+
+        verify(valueOperations).set("report:message:1:2:3", "URGENT", Duration.ofHours(1))
+    }
+
+    @Test
+    fun `non-positive retention disables tracking writes`() {
+        val service = service(Duration.ZERO)
+
+        service.markReported(1L, 2L, 3L, urgent = false)
+
+        verify(redisTemplate, never()).opsForValue()
+    }
+
+    @Test
+    fun `key includes guild channel and message id`() {
+        val service = service(Duration.ofHours(1))
+
+        assertEquals("report:message:1:2:3", service.createKey(1L, 2L, 3L))
+        assertEquals("report:message:1:4:3", service.createKey(1L, 4L, 3L))
+    }
+
+    private fun service(retention: Duration): ReportedMessageService {
+        return ReportedMessageService(redisTemplate, ReportProperties(reportedMessageRetention = retention))
+    }
+}


### PR DESCRIPTION
## Summary
- add non-urgent and urgent message context-menu reporting
- add report settings for blocked users and urgent moderator mentions
- add Redis-backed rate limiting and duplicate reported-message tracking

## Verification
- ./gradlew.bat check