### PR TITLE
fix(moderation): improve trap channel warning and handling

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelService.kt
@@ -23,6 +23,7 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.awt.Color
+import java.time.Duration
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.concurrent.ConcurrentHashMap
@@ -94,6 +95,10 @@ class TrapChannelService(
             return
         }
 
+        member.timeoutFor(Duration.ofHours(1))
+            .reason(TRAP_BAN_REASON)
+            .queue()
+
         val actionKey = guild.id + ":" + member.id
         if (!pendingTrapActions.add(actionKey)) {
             return
@@ -101,7 +106,7 @@ class TrapChannelService(
 
         val scheduledUnbanAt = OffsetDateTime.now().plusHours(AUTO_UNBAN_DELAY_HOURS)
 
-        guild.ban(member, 10, TimeUnit.MINUTES)
+        member.ban(10, TimeUnit.MINUTES)
             .reason(TRAP_BAN_REASON)
             .queue(
                 {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelService.kt
@@ -197,8 +197,6 @@ class TrapChannelService(
             .setAuthor(member.nicknameAndUsername, null, member.user.effectiveAvatarUrl)
             .setTitle("Spambot trap triggered")
             .setDescription("This user was automatically banned for posting in the trap channel. Do not post here.")
-            .addField("User", member.nicknameAndUsername, true)
-            .addField("Reason", TRAP_BAN_REASON, false)
             .setTimestamp(Instant.now())
             .setFooter(member.id, member.user.effectiveAvatarUrl)
             .build()

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelService.kt
@@ -197,13 +197,15 @@ class TrapChannelService(
     }
 
     private fun postTrapWarning(channel: MessageChannelUnion, member: Member) {
+        val user = member.user
+
         val embed = EmbedBuilder()
             .setColor(Color.RED)
-            .setAuthor(member.nicknameAndUsername, null, member.user.effectiveAvatarUrl)
+            .setAuthor(user.name, null, user.effectiveAvatarUrl)
             .setTitle("Spambot trap triggered")
             .setDescription("This user was automatically banned for posting in the trap channel. Do not post here.")
             .setTimestamp(Instant.now())
-            .setFooter(member.id, member.user.effectiveAvatarUrl)
+            .setFooter(user.id, user.effectiveAvatarUrl)
             .build()
 
         channel.sendMessageEmbeds(embed).queue()

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelServiceTest.kt
@@ -108,6 +108,7 @@ class TrapChannelServiceTest {
         val embed = embedCaptor.firstValue
         kotlin.test.assertEquals(Color.RED, embed.color)
         kotlin.test.assertEquals("Spambot trap triggered", embed.title)
+        kotlin.test.assertEquals("spammer#0001", embed.author!!.name)
         kotlin.test.assertTrue(embed.description!!.contains("automatically banned"))
         kotlin.test.assertEquals("5", embed.footer!!.text)
         kotlin.test.assertNotNull(embed.timestamp)
@@ -187,7 +188,9 @@ class TrapChannelServiceTest {
         whenever(member.idLong).thenReturn(5L)
         whenever(member.user).thenReturn(user)
         whenever(member.nickname).thenReturn("spammer")
+        whenever(user.id).thenReturn("5")
         whenever(user.name).thenReturn("spammer#0001")
+        whenever(user.effectiveAvatarUrl).thenReturn("https://cdn.discordapp.com/avatars/5/avatar.png")
         whenever(event.channel).thenReturn(channelUnion)
         whenever(channelUnion.idLong).thenReturn(99L)
         whenever(channelUnion.asMention).thenReturn("<#99>")

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/TrapChannelServiceTest.kt
@@ -19,6 +19,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
 import java.awt.Color
+import java.time.Duration
 import java.time.OffsetDateTime
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -57,6 +58,9 @@ class TrapChannelServiceTest {
     private lateinit var channelUnion: MessageChannelUnion
 
     @Mock
+    private lateinit var timeoutAction: AuditableRestAction<Void>
+
+    @Mock
     private lateinit var banAction: AuditableRestAction<Void>
 
     @Mock
@@ -80,14 +84,18 @@ class TrapChannelServiceTest {
     @Test
     fun `message in configured trap channel bans user and schedules unban`() {
         stubTrapEvent()
-        whenever(guild.ban(member, 10, TimeUnit.MINUTES)).thenReturn(banAction)
+        whenever(member.timeoutFor(Duration.ofHours(1))).thenReturn(timeoutAction)
+        whenever(timeoutAction.reason(any())).thenReturn(timeoutAction)
+        whenever(member.ban(10, TimeUnit.MINUTES)).thenReturn(banAction)
         whenever(banAction.reason(any())).thenReturn(banAction)
         whenever(channelUnion.sendMessageEmbeds(any<MessageEmbed>())).thenReturn(messageCreateAction)
         doSuccess(banAction)
 
         service.handleTrapMessage(event)
 
-        verify(guild).ban(member, 10, TimeUnit.MINUTES)
+        verify(member).timeoutFor(Duration.ofHours(1))
+        verify(timeoutAction).reason("Triggered the spam trap channel")
+        verify(member).ban(10, TimeUnit.MINUTES)
         verify(banAction).reason("Triggered the spam trap channel")
 
         val unbanCaptor = argumentCaptor<TrapChannelUnban>()


### PR DESCRIPTION
The author and description already convey the user and reason, so the explicit User and Reason fields are redundant.