### PR TITLE
fix(member-gate): confirm review session interruptions

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
@@ -306,8 +306,8 @@ class ReviewCommand(
         }
 
         val currentOtherSessions = reviewSessionRegistry.getOtherSessions(guild.idLong, event.user.idLong)
-        val currentTargetReviewerIds = currentOtherSessions.map { it.reviewerId }.toSet()
-        if (currentTargetReviewerIds != confirmation.targetReviewerIds) {
+        val currentTargetSessionIds = currentOtherSessions.associate { it.reviewerId to it.sessionId }
+        if (currentTargetSessionIds != confirmation.targetSessionIds) {
             reviewInterruptConfirmationRepository.deleteById(buttonAction.token)
             event.editMessage("The active review sessions changed. Run `/review` again to confirm the current sessions.")
                 .setComponents(emptyList())
@@ -329,7 +329,7 @@ class ReviewCommand(
         }
 
         reviewInterruptConfirmationRepository.deleteById(buttonAction.token)
-        reviewSessionRegistry.forgetSessions(guild.idLong, confirmation.targetReviewerIds)
+        reviewSessionRegistry.forgetSessions(guild.idLong, confirmation.targetSessionIds.keys)
             .forEach { logReviewInterrupted(guild, it) }
         reviewSessionRegistry.remember(guild.idLong, event.user.idLong, session)
         logReviewStarted(guild, event.member!!, session)
@@ -363,7 +363,7 @@ class ReviewCommand(
                 id = token,
                 guildId = guildId,
                 reviewerId = reviewerId,
-                targetReviewerIds = sessions.map { it.reviewerId }.toSet()
+                targetSessionIds = sessions.associate { it.reviewerId to it.sessionId }
             )
         )
         return token

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
@@ -49,7 +49,8 @@ class ReviewCommand(
 
         private data class InterruptButtonAction(
             val action: String,
-            val reviewerId: Long
+            val reviewerId: Long,
+            val targetReviewerIds: Set<Long>
         )
     }
 
@@ -94,7 +95,7 @@ class ReviewCommand(
         if (otherSessions.isNotEmpty()) {
             event.reply(buildInterruptPrompt(guild, otherSessions))
                 .setEphemeral(true)
-                .addComponents(ActionRow.of(buildInterruptButtons(event.user.idLong)))
+                .addComponents(ActionRow.of(buildInterruptButtons(event.user.idLong, otherSessions)))
                 .queue()
             return
         }
@@ -293,6 +294,15 @@ class ReviewCommand(
             return
         }
 
+        val currentOtherSessions = reviewSessionRegistry.getOtherSessions(guild.idLong, event.user.idLong)
+        val currentTargetReviewerIds = currentOtherSessions.map { it.reviewerId }.toSet()
+        if (currentTargetReviewerIds != buttonAction.targetReviewerIds) {
+            event.editMessage("The active review sessions changed. Run `/review` again to confirm the current sessions.")
+                .setComponents(emptyList())
+                .queue()
+            return
+        }
+
         val session = reviewManager.createSession(guild.idLong)
         if (session == null) {
             event.editMessage("Nobody is currently waiting for approval.").setComponents(emptyList()).queue()
@@ -306,7 +316,7 @@ class ReviewCommand(
             return
         }
 
-        reviewSessionRegistry.forgetOtherSessions(guild.idLong, event.user.idLong)
+        reviewSessionRegistry.forgetSessions(guild.idLong, buttonAction.targetReviewerIds)
             .forEach { logReviewInterrupted(guild, it) }
         reviewSessionRegistry.remember(guild.idLong, event.user.idLong, session)
         logReviewStarted(guild, event.member!!, session)
@@ -321,13 +331,18 @@ class ReviewCommand(
             return null
         }
 
-        val segments = componentId.removePrefix(INTERRUPT_CONFIRM_PREFIX).split(":", limit = 2)
-        if (segments.size != 2) {
+        val segments = componentId.removePrefix(INTERRUPT_CONFIRM_PREFIX).split(":", limit = 3)
+        if (segments.size != 3) {
             return null
         }
 
         val reviewerId = segments[1].toLongOrNull() ?: return null
-        return InterruptButtonAction(segments[0], reviewerId)
+        val targetReviewerIds = segments[2]
+            .split(",")
+            .filter { it.isNotBlank() }
+            .map { it.toLongOrNull() ?: return null }
+            .toSet()
+        return InterruptButtonAction(segments[0], reviewerId, targetReviewerIds)
     }
 
     private fun resolveCurrentQuestion(guild: Guild, jda: JDA, session: ReviewSession): MemberGateQuestion? {
@@ -445,8 +460,20 @@ class ReviewCommand(
         Button.primary("$BUTTON_PREFIX$MANUAL_ACTION:${question.userId}:${question.queuedAt}", "Manual Action")
     )
 
-    private fun buildInterruptButtons(reviewerId: Long) = listOf(
-        Button.danger("$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CONFIRM_ACTION:$reviewerId", "Interrupt review"),
-        Button.secondary("$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CANCEL_ACTION:$reviewerId", "Cancel")
-    )
+    private fun buildInterruptButtons(
+        reviewerId: Long,
+        sessions: List<ReviewSessionRegistry.StoredReviewSession>
+    ): List<Button> {
+        val targetReviewerIds = sessions.joinToString(",") { it.reviewerId.toString() }
+        return listOf(
+            Button.danger(
+                "$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CONFIRM_ACTION:$reviewerId:$targetReviewerIds",
+                "Interrupt review"
+            ),
+            Button.secondary(
+                "$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CANCEL_ACTION:$reviewerId:$targetReviewerIds",
+                "Cancel"
+            )
+        )
+    }
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
@@ -4,6 +4,8 @@ import be.duncanc.discordmodbot.discord.SlashCommand
 import be.duncanc.discordmodbot.discord.nicknameAndUsername
 import be.duncanc.discordmodbot.logging.GuildLogger
 import be.duncanc.discordmodbot.member.gate.persistence.MemberGateQuestion
+import be.duncanc.discordmodbot.member.gate.persistence.ReviewInterruptConfirmation
+import be.duncanc.discordmodbot.member.gate.persistence.ReviewInterruptConfirmationRepository
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
@@ -24,11 +26,13 @@ import net.dv8tion.jda.api.utils.TimeFormat
 import org.springframework.stereotype.Component
 import java.awt.Color
 import java.time.Instant
+import java.util.UUID
 
 @Component
 class ReviewCommand(
     private val reviewManager: ReviewManager,
     private val reviewSessionRegistry: ReviewSessionRegistry,
+    private val reviewInterruptConfirmationRepository: ReviewInterruptConfirmationRepository,
     private val guildLogger: GuildLogger
 ) : ListenerAdapter(), SlashCommand {
     companion object {
@@ -49,8 +53,7 @@ class ReviewCommand(
 
         private data class InterruptButtonAction(
             val action: String,
-            val reviewerId: Long,
-            val targetReviewerIds: Set<Long>
+            val token: String
         )
     }
 
@@ -93,9 +96,10 @@ class ReviewCommand(
 
         val otherSessions = reviewSessionRegistry.getOtherSessions(guild.idLong, event.user.idLong)
         if (otherSessions.isNotEmpty()) {
+            val token = rememberInterruptConfirmation(guild.idLong, event.user.idLong, otherSessions)
             event.reply(buildInterruptPrompt(guild, otherSessions))
                 .setEphemeral(true)
-                .addComponents(ActionRow.of(buildInterruptButtons(event.user.idLong, otherSessions)))
+                .addComponents(ActionRow.of(buildInterruptButtons(token)))
                 .queue()
             return
         }
@@ -275,12 +279,19 @@ class ReviewCommand(
             return
         }
 
-        if (buttonAction.reviewerId != event.user.idLong) {
+        val confirmation = reviewInterruptConfirmationRepository.findById(buttonAction.token).orElse(null)
+        if (confirmation == null) {
+            event.reply("This confirmation prompt expired. Run `/review` again.").setEphemeral(true).queue()
+            return
+        }
+
+        if (confirmation.guildId != guild.idLong || confirmation.reviewerId != event.user.idLong) {
             event.reply("This confirmation prompt belongs to another moderator.").setEphemeral(true).queue()
             return
         }
 
         if (buttonAction.action == INTERRUPT_CANCEL_ACTION) {
+            reviewInterruptConfirmationRepository.deleteById(buttonAction.token)
             event.editMessage("Review start cancelled. The other moderator's review session was not interrupted.")
                 .setComponents(emptyList())
                 .queue()
@@ -296,7 +307,8 @@ class ReviewCommand(
 
         val currentOtherSessions = reviewSessionRegistry.getOtherSessions(guild.idLong, event.user.idLong)
         val currentTargetReviewerIds = currentOtherSessions.map { it.reviewerId }.toSet()
-        if (currentTargetReviewerIds != buttonAction.targetReviewerIds) {
+        if (currentTargetReviewerIds != confirmation.targetReviewerIds) {
+            reviewInterruptConfirmationRepository.deleteById(buttonAction.token)
             event.editMessage("The active review sessions changed. Run `/review` again to confirm the current sessions.")
                 .setComponents(emptyList())
                 .queue()
@@ -316,7 +328,8 @@ class ReviewCommand(
             return
         }
 
-        reviewSessionRegistry.forgetSessions(guild.idLong, buttonAction.targetReviewerIds)
+        reviewInterruptConfirmationRepository.deleteById(buttonAction.token)
+        reviewSessionRegistry.forgetSessions(guild.idLong, confirmation.targetReviewerIds)
             .forEach { logReviewInterrupted(guild, it) }
         reviewSessionRegistry.remember(guild.idLong, event.user.idLong, session)
         logReviewStarted(guild, event.member!!, session)
@@ -331,18 +344,29 @@ class ReviewCommand(
             return null
         }
 
-        val segments = componentId.removePrefix(INTERRUPT_CONFIRM_PREFIX).split(":", limit = 3)
-        if (segments.size != 3) {
+        val segments = componentId.removePrefix(INTERRUPT_CONFIRM_PREFIX).split(":", limit = 2)
+        if (segments.size != 2) {
             return null
         }
 
-        val reviewerId = segments[1].toLongOrNull() ?: return null
-        val targetReviewerIds = segments[2]
-            .split(",")
-            .filter { it.isNotBlank() }
-            .map { it.toLongOrNull() ?: return null }
-            .toSet()
-        return InterruptButtonAction(segments[0], reviewerId, targetReviewerIds)
+        return InterruptButtonAction(segments[0], segments[1])
+    }
+
+    private fun rememberInterruptConfirmation(
+        guildId: Long,
+        reviewerId: Long,
+        sessions: List<ReviewSessionRegistry.StoredReviewSession>
+    ): String {
+        val token = UUID.randomUUID().toString().replace("-", "").take(12)
+        reviewInterruptConfirmationRepository.save(
+            ReviewInterruptConfirmation(
+                id = token,
+                guildId = guildId,
+                reviewerId = reviewerId,
+                targetReviewerIds = sessions.map { it.reviewerId }.toSet()
+            )
+        )
+        return token
     }
 
     private fun resolveCurrentQuestion(guild: Guild, jda: JDA, session: ReviewSession): MemberGateQuestion? {
@@ -460,18 +484,14 @@ class ReviewCommand(
         Button.primary("$BUTTON_PREFIX$MANUAL_ACTION:${question.userId}:${question.queuedAt}", "Manual Action")
     )
 
-    private fun buildInterruptButtons(
-        reviewerId: Long,
-        sessions: List<ReviewSessionRegistry.StoredReviewSession>
-    ): List<Button> {
-        val targetReviewerIds = sessions.joinToString(",") { it.reviewerId.toString() }
+    private fun buildInterruptButtons(token: String): List<Button> {
         return listOf(
             Button.danger(
-                "$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CONFIRM_ACTION:$reviewerId:$targetReviewerIds",
+                "$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CONFIRM_ACTION:$token",
                 "Interrupt review"
             ),
             Button.secondary(
-                "$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CANCEL_ACTION:$reviewerId:$targetReviewerIds",
+                "$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CANCEL_ACTION:$token",
                 "Cancel"
             )
         )

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
@@ -20,8 +20,10 @@ import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import net.dv8tion.jda.api.utils.MarkdownUtil
+import net.dv8tion.jda.api.utils.TimeFormat
 import org.springframework.stereotype.Component
 import java.awt.Color
+import java.time.Instant
 
 @Component
 class ReviewCommand(
@@ -32,14 +34,22 @@ class ReviewCommand(
     companion object {
         private const val COMMAND = "review"
         private const val BUTTON_PREFIX = "member-gate-review:"
+        private const val INTERRUPT_CONFIRM_PREFIX = "member-gate-review-interrupt:"
         private const val APPROVE_ACTION = "approve"
         private const val REJECT_ACTION = "reject"
         private const val MANUAL_ACTION = "manual"
+        private const val INTERRUPT_CONFIRM_ACTION = "confirm"
+        private const val INTERRUPT_CANCEL_ACTION = "cancel"
 
         private data class ReviewButtonAction(
             val action: String,
             val expectedUserId: Long,
             val expectedQueuedAt: Long
+        )
+
+        private data class InterruptButtonAction(
+            val action: String,
+            val reviewerId: Long
         )
     }
 
@@ -80,8 +90,24 @@ class ReviewCommand(
             return
         }
 
-        reviewSessionRegistry.forgetOtherSessions(guild.idLong, event.user.idLong)
-            .forEach { logReviewInterrupted(guild, it) }
+        val otherSessions = reviewSessionRegistry.getOtherSessions(guild.idLong, event.user.idLong)
+        if (otherSessions.isNotEmpty()) {
+            event.reply(buildInterruptPrompt(guild, otherSessions))
+                .setEphemeral(true)
+                .addComponents(ActionRow.of(buildInterruptButtons(event.user.idLong)))
+                .queue()
+            return
+        }
+
+        replyWithNewReviewSession(event, guild, session, pendingQuestion)
+    }
+
+    private fun replyWithNewReviewSession(
+        event: SlashCommandInteractionEvent,
+        guild: Guild,
+        session: ReviewSession,
+        pendingQuestion: MemberGateQuestion
+    ) {
         reviewSessionRegistry.remember(guild.idLong, event.user.idLong, session)
         logReviewStarted(guild, event.member!!, session)
 
@@ -107,6 +133,12 @@ class ReviewCommand(
     }
 
     override fun onButtonInteraction(event: ButtonInteractionEvent) {
+        val interruptAction = parseInterruptButtonAction(event.componentId)
+        if (interruptAction != null) {
+            handleInterruptButton(event, interruptAction)
+            return
+        }
+
         if (!event.componentId.startsWith(BUTTON_PREFIX)) {
             return
         }
@@ -235,6 +267,69 @@ class ReviewCommand(
         return ReviewButtonAction(segments[0], expectedUserId, expectedQueuedAt)
     }
 
+    private fun handleInterruptButton(event: ButtonInteractionEvent, buttonAction: InterruptButtonAction) {
+        val guild = event.guild
+        if (guild == null || event.member?.hasPermission(Permission.MANAGE_ROLES) != true) {
+            event.reply("You need the manage roles permission to use this command.").setEphemeral(true).queue()
+            return
+        }
+
+        if (buttonAction.reviewerId != event.user.idLong) {
+            event.reply("This confirmation prompt belongs to another moderator.").setEphemeral(true).queue()
+            return
+        }
+
+        if (buttonAction.action == INTERRUPT_CANCEL_ACTION) {
+            event.editMessage("Review start cancelled. The other moderator's review session was not interrupted.")
+                .setComponents(emptyList())
+                .queue()
+            return
+        }
+
+        if (buttonAction.action != INTERRUPT_CONFIRM_ACTION) {
+            event.reply("This review action is no longer available. Run `/review` again.")
+                .setEphemeral(true)
+                .queue()
+            return
+        }
+
+        val session = reviewManager.createSession(guild.idLong)
+        if (session == null) {
+            event.editMessage("Nobody is currently waiting for approval.").setComponents(emptyList()).queue()
+            return
+        }
+
+        val pendingQuestion = resolveCurrentQuestion(guild, event.jda, session)
+        if (pendingQuestion == null) {
+            reviewSessionRegistry.forget(guild.idLong, event.user.idLong)
+            event.editMessage("Nobody is currently waiting for approval.").setComponents(emptyList()).queue()
+            return
+        }
+
+        reviewSessionRegistry.forgetOtherSessions(guild.idLong, event.user.idLong)
+            .forEach { logReviewInterrupted(guild, it) }
+        reviewSessionRegistry.remember(guild.idLong, event.user.idLong, session)
+        logReviewStarted(guild, event.member!!, session)
+
+        event.editMessage(buildReviewMessage(guild, session, pendingQuestion))
+            .setComponents(ActionRow.of(buildButtons(pendingQuestion)))
+            .queue()
+    }
+
+    private fun parseInterruptButtonAction(componentId: String): InterruptButtonAction? {
+        if (!componentId.startsWith(INTERRUPT_CONFIRM_PREFIX)) {
+            return null
+        }
+
+        val segments = componentId.removePrefix(INTERRUPT_CONFIRM_PREFIX).split(":", limit = 2)
+        if (segments.size != 2) {
+            return null
+        }
+
+        val reviewerId = segments[1].toLongOrNull() ?: return null
+        return InterruptButtonAction(segments[0], reviewerId)
+    }
+
     private fun resolveCurrentQuestion(guild: Guild, jda: JDA, session: ReviewSession): MemberGateQuestion? {
         while (true) {
             val currentUserId = session.getCurrentUserId() ?: return null
@@ -275,6 +370,30 @@ class ReviewCommand(
 
     private fun buildCompletionMessage(feedback: String): String {
         return "$feedback\n\nThere are no more pending applicants in the queue."
+    }
+
+    private fun buildInterruptPrompt(
+        guild: Guild,
+        sessions: List<ReviewSessionRegistry.StoredReviewSession>
+    ): String {
+        val sessionLines = sessions.joinToString("\n") { storedSession ->
+            val reviewer = guild.getMemberById(storedSession.reviewerId)
+            val reviewerName = reviewer?.user?.asMention ?: "<@${storedSession.reviewerId}>"
+            val pendingCount = storedSession.session.toPendingUserIds().size
+            "- $reviewerName has $pendingCount pending applicant(s), last updated ${formatUpdatedAt(storedSession.updatedAt)}."
+        }
+
+        return "Another moderator is already reviewing members:\n" +
+                sessionLines +
+                "\n\nDo you want to interrupt their session and start yours?"
+    }
+
+    private fun formatUpdatedAt(updatedAt: Instant): String {
+        return if (updatedAt == Instant.EPOCH) {
+            "at an unknown time"
+        } else {
+            TimeFormat.RELATIVE.atInstant(updatedAt).toString()
+        }
     }
 
     private fun logReviewStarted(guild: Guild, moderator: Member, session: ReviewSession) {
@@ -324,5 +443,10 @@ class ReviewCommand(
         Button.success("$BUTTON_PREFIX$APPROVE_ACTION:${question.userId}:${question.queuedAt}", "Approve"),
         Button.danger("$BUTTON_PREFIX$REJECT_ACTION:${question.userId}:${question.queuedAt}", "Reject"),
         Button.primary("$BUTTON_PREFIX$MANUAL_ACTION:${question.userId}:${question.queuedAt}", "Manual Action")
+    )
+
+    private fun buildInterruptButtons(reviewerId: Long) = listOf(
+        Button.danger("$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CONFIRM_ACTION:$reviewerId", "Interrupt review"),
+        Button.secondary("$INTERRUPT_CONFIRM_PREFIX$INTERRUPT_CANCEL_ACTION:$reviewerId", "Cancel")
     )
 }

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSession.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSession.kt
@@ -1,7 +1,10 @@
 package be.duncanc.discordmodbot.member.gate
 
+import java.util.UUID
+
 class ReviewSession(
     pendingUserIds: List<Long>,
+    val sessionId: String = UUID.randomUUID().toString(),
     val oldestPendingUserId: Long = pendingUserIds.firstOrNull()
         ?: throw IllegalArgumentException("A review session requires at least one pending user."),
     var approvedCount: Int = 0,

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistry.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistry.kt
@@ -3,6 +3,7 @@ package be.duncanc.discordmodbot.member.gate
 import be.duncanc.discordmodbot.member.gate.persistence.ReviewSessionState
 import be.duncanc.discordmodbot.member.gate.persistence.ReviewSessionStateRepository
 import org.springframework.stereotype.Component
+import java.time.Instant
 
 @Component
 class ReviewSessionRegistry(
@@ -10,7 +11,8 @@ class ReviewSessionRegistry(
 ) {
     data class StoredReviewSession(
         val reviewerId: Long,
-        val session: ReviewSession
+        val session: ReviewSession,
+        val updatedAt: Instant
     )
 
     fun remember(guildId: Long, reviewerId: Long, session: ReviewSession) {
@@ -29,7 +31,8 @@ class ReviewSessionRegistry(
                 pendingUserIds = pendingUserIds,
                 approvedCount = session.approvedCount,
                 rejectedCount = session.rejectedCount,
-                manualActionCount = session.manualActionCount
+                manualActionCount = session.manualActionCount,
+                updatedAt = Instant.now()
             )
         )
     }
@@ -50,13 +53,18 @@ class ReviewSessionRegistry(
     }
 
     fun forgetOtherSessions(guildId: Long, reviewerId: Long): List<StoredReviewSession> {
+        return getOtherSessions(guildId, reviewerId)
+            .mapNotNull { state ->
+                reviewSessionStateRepository.deleteById(createId(guildId, state.reviewerId))
+                state
+            }
+    }
+
+    fun getOtherSessions(guildId: Long, reviewerId: Long): List<StoredReviewSession> {
         return reviewSessionStateRepository.findAll()
             .filterNotNull()
             .filter { it.guildId == guildId && it.reviewerId != reviewerId }
-            .mapNotNull { state ->
-                reviewSessionStateRepository.deleteById(state.id)
-                state.toStoredSession()
-            }
+            .mapNotNull { it.toStoredSession() }
     }
 
     private fun createId(guildId: Long, reviewerId: Long): String = "$guildId:$reviewerId"
@@ -66,7 +74,7 @@ class ReviewSessionRegistry(
             return null
         }
 
-        return StoredReviewSession(reviewerId, toSession())
+        return StoredReviewSession(reviewerId, toSession(), updatedAt)
     }
 
     private fun ReviewSessionState.toSession(): ReviewSession {

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistry.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistry.kt
@@ -12,6 +12,7 @@ class ReviewSessionRegistry(
     data class StoredReviewSession(
         val reviewerId: Long,
         val session: ReviewSession,
+        val sessionId: String,
         val updatedAt: Instant
     )
 
@@ -27,6 +28,7 @@ class ReviewSessionRegistry(
                 id = createId(guildId, reviewerId),
                 guildId = guildId,
                 reviewerId = reviewerId,
+                sessionId = session.sessionId,
                 oldestPendingUserId = session.oldestPendingUserId,
                 pendingUserIds = pendingUserIds,
                 approvedCount = session.approvedCount,
@@ -88,12 +90,14 @@ class ReviewSessionRegistry(
             return null
         }
 
-        return StoredReviewSession(reviewerId, toSession(), updatedAt)
+        val session = toSession()
+        return StoredReviewSession(reviewerId, session, session.sessionId, updatedAt)
     }
 
     private fun ReviewSessionState.toSession(): ReviewSession {
         return ReviewSession(
             pendingUserIds = pendingUserIds,
+            sessionId = sessionId.ifBlank { "$guildId:$reviewerId:$updatedAt" },
             oldestPendingUserId = oldestPendingUserId,
             approvedCount = approvedCount,
             rejectedCount = rejectedCount,

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistry.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistry.kt
@@ -60,6 +60,20 @@ class ReviewSessionRegistry(
             }
     }
 
+    fun forgetSessions(guildId: Long, reviewerIds: Set<Long>): List<StoredReviewSession> {
+        if (reviewerIds.isEmpty()) {
+            return emptyList()
+        }
+
+        return reviewSessionStateRepository.findAll()
+            .filterNotNull()
+            .filter { it.guildId == guildId && it.reviewerId in reviewerIds }
+            .mapNotNull { state ->
+                reviewSessionStateRepository.deleteById(state.id)
+                state.toStoredSession()
+            }
+    }
+
     fun getOtherSessions(guildId: Long, reviewerId: Long): List<StoredReviewSession> {
         return reviewSessionStateRepository.findAll()
             .filterNotNull()

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewInterruptConfirmation.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewInterruptConfirmation.kt
@@ -1,0 +1,13 @@
+package be.duncanc.discordmodbot.member.gate.persistence
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+
+@RedisHash("memberGateReviewInterruptConfirmation", timeToLive = 600)
+data class ReviewInterruptConfirmation(
+    @Id
+    val id: String,
+    val guildId: Long,
+    val reviewerId: Long,
+    val targetReviewerIds: Set<Long>
+)

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewInterruptConfirmation.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewInterruptConfirmation.kt
@@ -9,5 +9,5 @@ data class ReviewInterruptConfirmation(
     val id: String,
     val guildId: Long,
     val reviewerId: Long,
-    val targetReviewerIds: Set<Long>
+    val targetSessionIds: Map<Long, String>
 )

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewInterruptConfirmationRepository.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewInterruptConfirmationRepository.kt
@@ -1,0 +1,7 @@
+package be.duncanc.discordmodbot.member.gate.persistence
+
+import org.springframework.data.keyvalue.repository.KeyValueRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ReviewInterruptConfirmationRepository : KeyValueRepository<ReviewInterruptConfirmation, String>

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewSessionState.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewSessionState.kt
@@ -10,6 +10,7 @@ data class ReviewSessionState(
     val id: String,
     val guildId: Long,
     val reviewerId: Long,
+    val sessionId: String = "",
     val oldestPendingUserId: Long,
     val pendingUserIds: List<Long>,
     val approvedCount: Int = 0,

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewSessionState.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewSessionState.kt
@@ -2,6 +2,7 @@ package be.duncanc.discordmodbot.member.gate.persistence
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
+import java.time.Instant
 
 @RedisHash("memberGateReviewSession", timeToLive = 43200)
 data class ReviewSessionState(
@@ -13,5 +14,6 @@ data class ReviewSessionState(
     val pendingUserIds: List<Long>,
     val approvedCount: Int = 0,
     val rejectedCount: Int = 0,
-    val manualActionCount: Int = 0
+    val manualActionCount: Int = 0,
+    val updatedAt: Instant = Instant.EPOCH
 )

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
@@ -2,10 +2,13 @@ package be.duncanc.discordmodbot.member.gate
 
 import be.duncanc.discordmodbot.logging.GuildLogger
 import be.duncanc.discordmodbot.member.gate.persistence.MemberGateQuestion
+import be.duncanc.discordmodbot.member.gate.persistence.ReviewInterruptConfirmation
+import be.duncanc.discordmodbot.member.gate.persistence.ReviewInterruptConfirmationRepository
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.components.actionrow.ActionRow
+import net.dv8tion.jda.api.components.buttons.Button
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.MessageEmbed
@@ -14,6 +17,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -22,6 +26,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
 import java.time.Instant
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class ReviewCommandTest {
@@ -30,6 +35,9 @@ class ReviewCommandTest {
 
     @Mock
     private lateinit var reviewSessionRegistry: ReviewSessionRegistry
+
+    @Mock
+    private lateinit var reviewInterruptConfirmationRepository: ReviewInterruptConfirmationRepository
 
     @Mock
     private lateinit var guildLogger: GuildLogger
@@ -62,7 +70,7 @@ class ReviewCommandTest {
 
     @BeforeEach
     fun setUp() {
-        command = ReviewCommand(reviewManager, reviewSessionRegistry, guildLogger)
+        command = ReviewCommand(reviewManager, reviewSessionRegistry, reviewInterruptConfirmationRepository, guildLogger)
     }
 
     private fun pendingQuestion(guildId: Long, userId: Long, question: String, answer: String, queuedAt: Long): MemberGateQuestion {
@@ -139,13 +147,26 @@ class ReviewCommandTest {
         whenever(buttonEvent.user).thenReturn(user)
     }
 
-    private fun stubInterruptButtonInteraction(action: String = "confirm", targetReviewerIds: String = "42") {
+    private fun stubInterruptButtonInteraction(componentId: String) {
         stubCommonIdentity()
-        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:$action:99:$targetReviewerIds")
+        whenever(buttonEvent.componentId).thenReturn(componentId)
         whenever(buttonEvent.guild).thenReturn(guild)
         whenever(buttonEvent.member).thenReturn(member)
         whenever(buttonEvent.user).thenReturn(user)
         whenever(buttonEvent.jda).thenReturn(jda)
+    }
+
+    private fun captureInterruptButtonId(index: Int): String {
+        val actionRowCaptor = argumentCaptor<ActionRow>()
+        verify(replyAction).addComponents(actionRowCaptor.capture())
+        val button = actionRowCaptor.firstValue.components[index] as Button
+        return requireNotNull(button.customId)
+    }
+
+    private fun captureSavedInterruptConfirmation(): ReviewInterruptConfirmation {
+        val captor = argumentCaptor<ReviewInterruptConfirmation>()
+        verify(reviewInterruptConfirmationRepository).save(captor.capture())
+        return captor.firstValue
     }
 
     private fun stubButtonReply() {
@@ -333,13 +354,19 @@ class ReviewCommandTest {
         verify(slashEvent).reply(messageCaptor.capture())
         assertTrue(messageCaptor.firstValue.contains("Another moderator is already reviewing members:"))
         assertTrue(messageCaptor.firstValue.contains("<@42> has 1 pending applicant(s), last updated <t:1782648000:R>."))
+        val confirmation = captureSavedInterruptConfirmation()
+        assertEquals(1L, confirmation.guildId)
+        assertEquals(99L, confirmation.reviewerId)
+        assertEquals(setOf(42L), confirmation.targetReviewerIds)
+        assertTrue(captureInterruptButtonId(0).length <= Button.ID_MAX_LENGTH)
+        assertTrue(captureInterruptButtonId(1).length <= Button.ID_MAX_LENGTH)
         verify(reviewSessionRegistry, never()).forgetOtherSessions(any(), any())
         verify(reviewSessionRegistry, never()).remember(eq(1L), eq(99L), same(session))
     }
 
     @Test
     fun `confirming interruption logs and removes another moderator's unfinished session`() {
-        stubInterruptButtonInteraction()
+        stubInterruptButtonInteraction("member-gate-review-interrupt:confirm:token")
         stubModeratorName()
         stubButtonEditWithActionRow()
 
@@ -353,6 +380,16 @@ class ReviewCommandTest {
             reviewerId = 42L,
             session = interruptedSession,
             updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+        )
+        whenever(reviewInterruptConfirmationRepository.findById("token")).thenReturn(
+            Optional.of(
+                ReviewInterruptConfirmation(
+                    id = "token",
+                    guildId = 1L,
+                    reviewerId = 99L,
+                    targetReviewerIds = setOf(42L)
+                )
+            )
         )
         whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(listOf(storedSession))
         whenever(reviewSessionRegistry.forgetSessions(1L, setOf(42L))).thenReturn(listOf(storedSession))
@@ -370,6 +407,7 @@ class ReviewCommandTest {
         verifyReviewLog("Member gate review interrupted", "Approved", "2")
         verifyReviewLog("Member gate review interrupted", "Rejected", "1")
         verifyReviewLog("Member gate review interrupted", "Manual action", "3")
+        verify(reviewInterruptConfirmationRepository).deleteById("token")
         verify(reviewSessionRegistry).remember(eq(1L), eq(99L), same(session))
         val messageCaptor = argumentCaptor<String>()
         verify(buttonEvent).editMessage(messageCaptor.capture())
@@ -381,11 +419,21 @@ class ReviewCommandTest {
         whenever(guild.idLong).thenReturn(1L)
         whenever(user.idLong).thenReturn(99L)
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
-        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:confirm:99:42")
+        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:confirm:token")
         whenever(buttonEvent.guild).thenReturn(guild)
         whenever(buttonEvent.member).thenReturn(member)
         whenever(buttonEvent.user).thenReturn(user)
         stubButtonEditWithList()
+        whenever(reviewInterruptConfirmationRepository.findById("token")).thenReturn(
+            Optional.of(
+                ReviewInterruptConfirmation(
+                    id = "token",
+                    guildId = 1L,
+                    reviewerId = 99L,
+                    targetReviewerIds = setOf(42L)
+                )
+            )
+        )
 
         whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(
             listOf(
@@ -400,13 +448,14 @@ class ReviewCommandTest {
         command.onButtonInteraction(buttonEvent)
 
         verify(buttonEvent).editMessage("The active review sessions changed. Run `/review` again to confirm the current sessions.")
+        verify(reviewInterruptConfirmationRepository).deleteById("token")
         verify(reviewSessionRegistry, never()).forgetSessions(any(), any())
         verify(reviewManager, never()).createSession(any())
     }
 
     @Test
     fun `confirming interruption deletes only sessions shown in prompt`() {
-        stubInterruptButtonInteraction(targetReviewerIds = "42,43")
+        stubInterruptButtonInteraction("member-gate-review-interrupt:confirm:token")
         stubModeratorName()
         stubButtonEditWithActionRow()
 
@@ -420,6 +469,16 @@ class ReviewCommandTest {
                 reviewerId = 43L,
                 session = ReviewSession(listOf(60L)),
                 updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+            )
+        )
+        whenever(reviewInterruptConfirmationRepository.findById("token")).thenReturn(
+            Optional.of(
+                ReviewInterruptConfirmation(
+                    id = "token",
+                    guildId = 1L,
+                    reviewerId = 99L,
+                    targetReviewerIds = setOf(42L, 43L)
+                )
             )
         )
         whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(storedSessions)
@@ -441,17 +500,29 @@ class ReviewCommandTest {
 
     @Test
     fun `cancelling interruption keeps another moderator's unfinished session`() {
+        whenever(guild.idLong).thenReturn(1L)
         whenever(user.idLong).thenReturn(99L)
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
-        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:cancel:99:42")
+        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:cancel:token")
         whenever(buttonEvent.guild).thenReturn(guild)
         whenever(buttonEvent.member).thenReturn(member)
         whenever(buttonEvent.user).thenReturn(user)
         stubButtonEditWithList()
+        whenever(reviewInterruptConfirmationRepository.findById("token")).thenReturn(
+            Optional.of(
+                ReviewInterruptConfirmation(
+                    id = "token",
+                    guildId = 1L,
+                    reviewerId = 99L,
+                    targetReviewerIds = setOf(42L)
+                )
+            )
+        )
 
         command.onButtonInteraction(buttonEvent)
 
         verify(buttonEvent).editMessage("Review start cancelled. The other moderator's review session was not interrupted.")
+        verify(reviewInterruptConfirmationRepository).deleteById("token")
         verify(reviewSessionRegistry, never()).forgetOtherSessions(any(), any())
         verify(reviewManager, never()).createSession(any())
     }

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
@@ -328,6 +328,7 @@ class ReviewCommandTest {
 
         val interruptedSession = ReviewSession(
             pendingUserIds = listOf(50L),
+            sessionId = "session-42",
             approvedCount = 2,
             rejectedCount = 1,
             manualActionCount = 3
@@ -337,6 +338,7 @@ class ReviewCommandTest {
                 ReviewSessionRegistry.StoredReviewSession(
                     reviewerId = 42L,
                     session = interruptedSession,
+                    sessionId = "session-42",
                     updatedAt = Instant.parse("2026-06-28T12:00:00Z")
                 )
             )
@@ -357,7 +359,7 @@ class ReviewCommandTest {
         val confirmation = captureSavedInterruptConfirmation()
         assertEquals(1L, confirmation.guildId)
         assertEquals(99L, confirmation.reviewerId)
-        assertEquals(setOf(42L), confirmation.targetReviewerIds)
+        assertEquals(mapOf(42L to "session-42"), confirmation.targetSessionIds)
         assertTrue(captureInterruptButtonId(0).length <= Button.ID_MAX_LENGTH)
         assertTrue(captureInterruptButtonId(1).length <= Button.ID_MAX_LENGTH)
         verify(reviewSessionRegistry, never()).forgetOtherSessions(any(), any())
@@ -372,6 +374,7 @@ class ReviewCommandTest {
 
         val interruptedSession = ReviewSession(
             pendingUserIds = listOf(50L),
+            sessionId = "session-42",
             approvedCount = 2,
             rejectedCount = 1,
             manualActionCount = 3
@@ -379,6 +382,7 @@ class ReviewCommandTest {
         val storedSession = ReviewSessionRegistry.StoredReviewSession(
             reviewerId = 42L,
             session = interruptedSession,
+            sessionId = "session-42",
             updatedAt = Instant.parse("2026-06-28T12:00:00Z")
         )
         whenever(reviewInterruptConfirmationRepository.findById("token")).thenReturn(
@@ -387,7 +391,7 @@ class ReviewCommandTest {
                     id = "token",
                     guildId = 1L,
                     reviewerId = 99L,
-                    targetReviewerIds = setOf(42L)
+                    targetSessionIds = mapOf(42L to "session-42")
                 )
             )
         )
@@ -430,7 +434,7 @@ class ReviewCommandTest {
                     id = "token",
                     guildId = 1L,
                     reviewerId = 99L,
-                    targetReviewerIds = setOf(42L)
+                    targetSessionIds = mapOf(42L to "session-42")
                 )
             )
         )
@@ -439,7 +443,48 @@ class ReviewCommandTest {
             listOf(
                 ReviewSessionRegistry.StoredReviewSession(
                     reviewerId = 43L,
-                    session = ReviewSession(listOf(50L)),
+                    session = ReviewSession(listOf(50L), sessionId = "session-43"),
+                    sessionId = "session-43",
+                    updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+                )
+            )
+        )
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).editMessage("The active review sessions changed. Run `/review` again to confirm the current sessions.")
+        verify(reviewInterruptConfirmationRepository).deleteById("token")
+        verify(reviewSessionRegistry, never()).forgetSessions(any(), any())
+        verify(reviewManager, never()).createSession(any())
+    }
+
+    @Test
+    fun `confirming stale interruption rejects changed session from same moderator`() {
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(user.idLong).thenReturn(99L)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:confirm:token")
+        whenever(buttonEvent.guild).thenReturn(guild)
+        whenever(buttonEvent.member).thenReturn(member)
+        whenever(buttonEvent.user).thenReturn(user)
+        stubButtonEditWithList()
+        whenever(reviewInterruptConfirmationRepository.findById("token")).thenReturn(
+            Optional.of(
+                ReviewInterruptConfirmation(
+                    id = "token",
+                    guildId = 1L,
+                    reviewerId = 99L,
+                    targetSessionIds = mapOf(42L to "old-session-42")
+                )
+            )
+        )
+
+        whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(
+            listOf(
+                ReviewSessionRegistry.StoredReviewSession(
+                    reviewerId = 42L,
+                    session = ReviewSession(listOf(50L), sessionId = "new-session-42"),
+                    sessionId = "new-session-42",
                     updatedAt = Instant.parse("2026-06-28T12:00:00Z")
                 )
             )
@@ -462,12 +507,14 @@ class ReviewCommandTest {
         val storedSessions = listOf(
             ReviewSessionRegistry.StoredReviewSession(
                 reviewerId = 42L,
-                session = ReviewSession(listOf(50L)),
+                session = ReviewSession(listOf(50L), sessionId = "session-42"),
+                sessionId = "session-42",
                 updatedAt = Instant.parse("2026-06-28T12:00:00Z")
             ),
             ReviewSessionRegistry.StoredReviewSession(
                 reviewerId = 43L,
-                session = ReviewSession(listOf(60L)),
+                session = ReviewSession(listOf(60L), sessionId = "session-43"),
+                sessionId = "session-43",
                 updatedAt = Instant.parse("2026-06-28T12:00:00Z")
             )
         )
@@ -477,7 +524,7 @@ class ReviewCommandTest {
                     id = "token",
                     guildId = 1L,
                     reviewerId = 99L,
-                    targetReviewerIds = setOf(42L, 43L)
+                    targetSessionIds = mapOf(42L to "session-42", 43L to "session-43")
                 )
             )
         )
@@ -514,7 +561,7 @@ class ReviewCommandTest {
                     id = "token",
                     guildId = 1L,
                     reviewerId = 99L,
-                    targetReviewerIds = setOf(42L)
+                    targetSessionIds = mapOf(42L to "session-42")
                 )
             )
         )

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
+import java.time.Instant
 
 @ExtendWith(MockitoExtension::class)
 class ReviewCommandTest {
@@ -98,7 +99,7 @@ class ReviewCommandTest {
     private fun stubSlashReviewStart() {
         stubSlashReviewCommand()
         whenever(reviewSessionRegistry.get(1L, 99L)).thenReturn(null)
-        whenever(reviewSessionRegistry.forgetOtherSessions(1L, 99L)).thenReturn(emptyList())
+        whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(emptyList())
     }
 
     private fun stubSlashReviewCommand() {
@@ -136,6 +137,15 @@ class ReviewCommandTest {
         whenever(buttonEvent.guild).thenReturn(guild)
         whenever(buttonEvent.member).thenReturn(member)
         whenever(buttonEvent.user).thenReturn(user)
+    }
+
+    private fun stubInterruptButtonInteraction(action: String = "confirm") {
+        stubCommonIdentity()
+        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:$action:99")
+        whenever(buttonEvent.guild).thenReturn(guild)
+        whenever(buttonEvent.member).thenReturn(member)
+        whenever(buttonEvent.user).thenReturn(user)
+        whenever(buttonEvent.jda).thenReturn(jda)
     }
 
     private fun stubButtonReply() {
@@ -273,7 +283,7 @@ class ReviewCommandTest {
         val storedSession = ReviewSession(listOf(20L))
         val newSession = ReviewSession(listOf(30L))
         whenever(reviewSessionRegistry.get(1L, 99L)).thenReturn(storedSession)
-        whenever(reviewSessionRegistry.forgetOtherSessions(1L, 99L)).thenReturn(emptyList())
+        whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(emptyList())
         whenever(reviewManager.createSession(1L)).thenReturn(newSession)
         whenever(reviewManager.getPendingQuestion(1L, 20L)).thenReturn(null)
         whenever(reviewManager.getPendingQuestion(1L, 30L)).thenReturn(
@@ -292,9 +302,46 @@ class ReviewCommandTest {
     }
 
     @Test
-    fun `starting review logs and removes another moderator's unfinished session`() {
+    fun `starting review prompts before interrupting another moderator's unfinished session`() {
         stubSlashReviewStart()
+
+        val interruptedSession = ReviewSession(
+            pendingUserIds = listOf(50L),
+            approvedCount = 2,
+            rejectedCount = 1,
+            manualActionCount = 3
+        )
+        whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(
+            listOf(
+                ReviewSessionRegistry.StoredReviewSession(
+                    reviewerId = 42L,
+                    session = interruptedSession,
+                    updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+                )
+            )
+        )
+        val session = ReviewSession(listOf(10L))
+        whenever(reviewManager.createSession(1L)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        whenever(guild.getMemberById(10L)).thenReturn(mock())
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        val messageCaptor = argumentCaptor<String>()
+        verify(slashEvent).reply(messageCaptor.capture())
+        assertTrue(messageCaptor.firstValue.contains("Another moderator is already reviewing members:"))
+        assertTrue(messageCaptor.firstValue.contains("<@42> has 1 pending applicant(s), last updated <t:1782648000:R>."))
+        verify(reviewSessionRegistry, never()).forgetOtherSessions(any(), any())
+        verify(reviewSessionRegistry, never()).remember(eq(1L), eq(99L), same(session))
+    }
+
+    @Test
+    fun `confirming interruption logs and removes another moderator's unfinished session`() {
+        stubInterruptButtonInteraction()
         stubModeratorName()
+        stubButtonEditWithActionRow()
 
         val interruptedSession = ReviewSession(
             pendingUserIds = listOf(50L),
@@ -303,7 +350,13 @@ class ReviewCommandTest {
             manualActionCount = 3
         )
         whenever(reviewSessionRegistry.forgetOtherSessions(1L, 99L)).thenReturn(
-            listOf(ReviewSessionRegistry.StoredReviewSession(42L, interruptedSession))
+            listOf(
+                ReviewSessionRegistry.StoredReviewSession(
+                    reviewerId = 42L,
+                    session = interruptedSession,
+                    updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+                )
+            )
         )
         val session = ReviewSession(listOf(10L))
         whenever(reviewManager.createSession(1L)).thenReturn(session)
@@ -313,11 +366,32 @@ class ReviewCommandTest {
         whenever(guild.getMemberById(42L)).thenReturn(null)
         stubApplicantPresent(10L, "<@10>")
 
-        command.onSlashCommandInteraction(slashEvent)
+        command.onButtonInteraction(buttonEvent)
 
         verifyReviewLog("Member gate review interrupted", "Approved", "2")
         verifyReviewLog("Member gate review interrupted", "Rejected", "1")
         verifyReviewLog("Member gate review interrupted", "Manual action", "3")
+        verify(reviewSessionRegistry).remember(eq(1L), eq(99L), same(session))
+        val messageCaptor = argumentCaptor<String>()
+        verify(buttonEvent).editMessage(messageCaptor.capture())
+        assertTrue(messageCaptor.firstValue.contains("Applicant: <@10> (`10`)"))
+    }
+
+    @Test
+    fun `cancelling interruption keeps another moderator's unfinished session`() {
+        whenever(user.idLong).thenReturn(99L)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:cancel:99")
+        whenever(buttonEvent.guild).thenReturn(guild)
+        whenever(buttonEvent.member).thenReturn(member)
+        whenever(buttonEvent.user).thenReturn(user)
+        stubButtonEditWithList()
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).editMessage("Review start cancelled. The other moderator's review session was not interrupted.")
+        verify(reviewSessionRegistry, never()).forgetOtherSessions(any(), any())
+        verify(reviewManager, never()).createSession(any())
     }
 
     @Test

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
@@ -139,9 +139,9 @@ class ReviewCommandTest {
         whenever(buttonEvent.user).thenReturn(user)
     }
 
-    private fun stubInterruptButtonInteraction(action: String = "confirm") {
+    private fun stubInterruptButtonInteraction(action: String = "confirm", targetReviewerIds: String = "42") {
         stubCommonIdentity()
-        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:$action:99")
+        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:$action:99:$targetReviewerIds")
         whenever(buttonEvent.guild).thenReturn(guild)
         whenever(buttonEvent.member).thenReturn(member)
         whenever(buttonEvent.user).thenReturn(user)
@@ -349,15 +349,14 @@ class ReviewCommandTest {
             rejectedCount = 1,
             manualActionCount = 3
         )
-        whenever(reviewSessionRegistry.forgetOtherSessions(1L, 99L)).thenReturn(
-            listOf(
-                ReviewSessionRegistry.StoredReviewSession(
-                    reviewerId = 42L,
-                    session = interruptedSession,
-                    updatedAt = Instant.parse("2026-06-28T12:00:00Z")
-                )
-            )
+        val storedSession = ReviewSessionRegistry.StoredReviewSession(
+            reviewerId = 42L,
+            session = interruptedSession,
+            updatedAt = Instant.parse("2026-06-28T12:00:00Z")
         )
+        whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(listOf(storedSession))
+        whenever(reviewSessionRegistry.forgetSessions(1L, setOf(42L))).thenReturn(listOf(storedSession))
+
         val session = ReviewSession(listOf(10L))
         whenever(reviewManager.createSession(1L)).thenReturn(session)
         whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
@@ -378,10 +377,73 @@ class ReviewCommandTest {
     }
 
     @Test
+    fun `confirming stale interruption asks moderator to review current sessions`() {
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(user.idLong).thenReturn(99L)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:confirm:99:42")
+        whenever(buttonEvent.guild).thenReturn(guild)
+        whenever(buttonEvent.member).thenReturn(member)
+        whenever(buttonEvent.user).thenReturn(user)
+        stubButtonEditWithList()
+
+        whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(
+            listOf(
+                ReviewSessionRegistry.StoredReviewSession(
+                    reviewerId = 43L,
+                    session = ReviewSession(listOf(50L)),
+                    updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+                )
+            )
+        )
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).editMessage("The active review sessions changed. Run `/review` again to confirm the current sessions.")
+        verify(reviewSessionRegistry, never()).forgetSessions(any(), any())
+        verify(reviewManager, never()).createSession(any())
+    }
+
+    @Test
+    fun `confirming interruption deletes only sessions shown in prompt`() {
+        stubInterruptButtonInteraction(targetReviewerIds = "42,43")
+        stubModeratorName()
+        stubButtonEditWithActionRow()
+
+        val storedSessions = listOf(
+            ReviewSessionRegistry.StoredReviewSession(
+                reviewerId = 42L,
+                session = ReviewSession(listOf(50L)),
+                updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+            ),
+            ReviewSessionRegistry.StoredReviewSession(
+                reviewerId = 43L,
+                session = ReviewSession(listOf(60L)),
+                updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+            )
+        )
+        whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(storedSessions)
+        whenever(reviewSessionRegistry.forgetSessions(1L, setOf(42L, 43L))).thenReturn(storedSessions)
+        val session = ReviewSession(listOf(10L))
+        whenever(reviewManager.createSession(1L)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        whenever(guild.getMemberById(42L)).thenReturn(null)
+        whenever(guild.getMemberById(43L)).thenReturn(null)
+        stubApplicantPresent(10L, "<@10>")
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(reviewSessionRegistry).forgetSessions(1L, setOf(42L, 43L))
+        verify(reviewSessionRegistry, never()).forgetOtherSessions(any(), any())
+    }
+
+    @Test
     fun `cancelling interruption keeps another moderator's unfinished session`() {
         whenever(user.idLong).thenReturn(99L)
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
-        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:cancel:99")
+        whenever(buttonEvent.componentId).thenReturn("member-gate-review-interrupt:cancel:99:42")
         whenever(buttonEvent.guild).thenReturn(guild)
         whenever(buttonEvent.member).thenReturn(member)
         whenever(buttonEvent.user).thenReturn(user)

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistryTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistryTest.kt
@@ -171,4 +171,39 @@ class ReviewSessionRegistryTest {
         assertEquals(42L, sessions.first().reviewerId)
         assertEquals(updatedAt, sessions.first().updatedAt)
     }
+
+    @Test
+    fun `forget sessions deletes only requested reviewers in guild`() {
+        whenever(reviewSessionStateRepository.findAll()).thenReturn(
+            listOf(
+                ReviewSessionState(
+                    id = "1:42",
+                    guildId = 1L,
+                    reviewerId = 42L,
+                    oldestPendingUserId = 10L,
+                    pendingUserIds = listOf(10L)
+                ),
+                ReviewSessionState(
+                    id = "1:43",
+                    guildId = 1L,
+                    reviewerId = 43L,
+                    oldestPendingUserId = 20L,
+                    pendingUserIds = listOf(20L)
+                ),
+                ReviewSessionState(
+                    id = "2:42",
+                    guildId = 2L,
+                    reviewerId = 42L,
+                    oldestPendingUserId = 30L,
+                    pendingUserIds = listOf(30L)
+                )
+            )
+        )
+
+        val sessions = reviewSessionRegistry.forgetSessions(1L, setOf(42L))
+
+        assertEquals(1, sessions.size)
+        assertEquals(42L, sessions.first().reviewerId)
+        verify(reviewSessionStateRepository).deleteById("1:42")
+    }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistryTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistryTest.kt
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Instant
 import java.util.*
 
 @ExtendWith(MockitoExtension::class)
@@ -28,6 +29,7 @@ class ReviewSessionRegistryTest {
 
     @Test
     fun `remember stores session state in redis repository`() {
+        val before = Instant.now()
         val session = ReviewSession(
             pendingUserIds = listOf(20L, 10L),
             oldestPendingUserId = 10L,
@@ -47,6 +49,8 @@ class ReviewSessionRegistryTest {
         assertEquals(1, state.approvedCount)
         assertEquals(2, state.rejectedCount)
         assertEquals(3, state.manualActionCount)
+        assertEquals(false, state.updatedAt.isBefore(before))
+        assertEquals(false, state.updatedAt.isAfter(Instant.now()))
     }
 
     @Test
@@ -95,6 +99,7 @@ class ReviewSessionRegistryTest {
 
     @Test
     fun `forget other sessions returns and deletes sessions from other reviewers in guild`() {
+        val updatedAt = Instant.parse("2026-06-28T12:00:00Z")
         whenever(reviewSessionStateRepository.findAll()).thenReturn(
             listOf(
                 ReviewSessionState(
@@ -105,7 +110,8 @@ class ReviewSessionRegistryTest {
                     pendingUserIds = listOf(10L),
                     approvedCount = 1,
                     rejectedCount = 2,
-                    manualActionCount = 3
+                    manualActionCount = 3,
+                    updatedAt = updatedAt
                 ),
                 ReviewSessionState(
                     id = "1:99",
@@ -132,6 +138,37 @@ class ReviewSessionRegistryTest {
         assertEquals(1, sessions.first().session.approvedCount)
         assertEquals(2, sessions.first().session.rejectedCount)
         assertEquals(3, sessions.first().session.manualActionCount)
+        assertEquals(updatedAt, sessions.first().updatedAt)
         verify(reviewSessionStateRepository).deleteById("1:42")
+    }
+
+    @Test
+    fun `get other sessions returns sessions without deleting them`() {
+        val updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+        whenever(reviewSessionStateRepository.findAll()).thenReturn(
+            listOf(
+                ReviewSessionState(
+                    id = "1:42",
+                    guildId = 1L,
+                    reviewerId = 42L,
+                    oldestPendingUserId = 10L,
+                    pendingUserIds = listOf(10L),
+                    updatedAt = updatedAt
+                ),
+                ReviewSessionState(
+                    id = "1:99",
+                    guildId = 1L,
+                    reviewerId = 99L,
+                    oldestPendingUserId = 20L,
+                    pendingUserIds = listOf(20L)
+                )
+            )
+        )
+
+        val sessions = reviewSessionRegistry.getOtherSessions(1L, 99L)
+
+        assertEquals(1, sessions.size)
+        assertEquals(42L, sessions.first().reviewerId)
+        assertEquals(updatedAt, sessions.first().updatedAt)
     }
 }

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistryTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewSessionRegistryTest.kt
@@ -32,6 +32,7 @@ class ReviewSessionRegistryTest {
         val before = Instant.now()
         val session = ReviewSession(
             pendingUserIds = listOf(20L, 10L),
+            sessionId = "session-99",
             oldestPendingUserId = 10L,
             approvedCount = 1,
             rejectedCount = 2,
@@ -44,6 +45,7 @@ class ReviewSessionRegistryTest {
         verify(reviewSessionStateRepository).save(captor.capture())
         val state = captor.firstValue
         assertEquals("1:99", state.id)
+        assertEquals("session-99", state.sessionId)
         assertEquals(10L, state.oldestPendingUserId)
         assertEquals(listOf(20L, 10L), state.pendingUserIds)
         assertEquals(1, state.approvedCount)
@@ -61,6 +63,7 @@ class ReviewSessionRegistryTest {
                     id = "1:99",
                     guildId = 1L,
                     reviewerId = 99L,
+                    sessionId = "session-99",
                     oldestPendingUserId = 10L,
                     pendingUserIds = listOf(20L, 10L),
                     approvedCount = 1,
@@ -75,6 +78,7 @@ class ReviewSessionRegistryTest {
         assertEquals(20L, session?.getCurrentUserId())
         assertEquals(false, session?.isCurrentOldest())
         assertEquals(listOf(20L, 10L), session?.toPendingUserIds())
+        assertEquals("session-99", session?.sessionId)
         assertEquals(1, session?.approvedCount)
         assertEquals(2, session?.rejectedCount)
         assertEquals(3, session?.manualActionCount)
@@ -106,6 +110,7 @@ class ReviewSessionRegistryTest {
                     id = "1:42",
                     guildId = 1L,
                     reviewerId = 42L,
+                    sessionId = "session-42",
                     oldestPendingUserId = 10L,
                     pendingUserIds = listOf(10L),
                     approvedCount = 1,
@@ -134,6 +139,7 @@ class ReviewSessionRegistryTest {
 
         assertEquals(1, sessions.size)
         assertEquals(42L, sessions.first().reviewerId)
+        assertEquals("session-42", sessions.first().sessionId)
         assertEquals(10L, sessions.first().session.getCurrentUserId())
         assertEquals(1, sessions.first().session.approvedCount)
         assertEquals(2, sessions.first().session.rejectedCount)
@@ -151,6 +157,7 @@ class ReviewSessionRegistryTest {
                     id = "1:42",
                     guildId = 1L,
                     reviewerId = 42L,
+                    sessionId = "session-42",
                     oldestPendingUserId = 10L,
                     pendingUserIds = listOf(10L),
                     updatedAt = updatedAt
@@ -169,6 +176,7 @@ class ReviewSessionRegistryTest {
 
         assertEquals(1, sessions.size)
         assertEquals(42L, sessions.first().reviewerId)
+        assertEquals("session-42", sessions.first().sessionId)
         assertEquals(updatedAt, sessions.first().updatedAt)
     }
 
@@ -180,6 +188,7 @@ class ReviewSessionRegistryTest {
                     id = "1:42",
                     guildId = 1L,
                     reviewerId = 42L,
+                    sessionId = "session-42",
                     oldestPendingUserId = 10L,
                     pendingUserIds = listOf(10L)
                 ),
@@ -204,6 +213,7 @@ class ReviewSessionRegistryTest {
 
         assertEquals(1, sessions.size)
         assertEquals(42L, sessions.first().reviewerId)
+        assertEquals("session-42", sessions.first().sessionId)
         verify(reviewSessionStateRepository).deleteById("1:42")
     }
 }


### PR DESCRIPTION
## Summary
- prompt moderators before interrupting another active member-gate review session
- track review session update times with Instant.now() and display them with JDA TimeFormat
- add focused tests for prompt, confirm, cancel, and session lookup behavior

## Tests
- ./gradlew.bat test --tests "be.duncanc.discordmodbot.member.gate.ReviewCommandTest" --tests "be.duncanc.discordmodbot.member.gate.ReviewSessionRegistryTest"