### PR TITLE
fix(moderation): require reasons for message reports

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -153,6 +153,11 @@ class ReportMessageContextMenu(
         }
 
         if (!action.confirm) {
+            val existingState = reportedMessageService.getState(action.guildId, action.channelId, action.messageId)
+            if (existingState == ReportedMessageState.URGENT) {
+                event.editMessage(ALREADY_REPORTED_MESSAGE).setComponents(emptyList()).queue()
+                return
+            }
             event.editMessage("Urgent report cancelled.").setComponents(emptyList()).queue()
             return
         }

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -6,10 +6,14 @@ import be.duncanc.discordmodbot.logging.GuildLogger
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.components.actionrow.ActionRow
 import net.dv8tion.jda.api.components.buttons.Button
+import net.dv8tion.jda.api.components.label.Label
+import net.dv8tion.jda.api.components.textinput.TextInput
+import net.dv8tion.jda.api.components.textinput.TextInputStyle
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
@@ -17,6 +21,7 @@ import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.build.CommandData
 import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.modals.Modal
 import org.springframework.stereotype.Component
 import java.awt.Color
 
@@ -34,6 +39,9 @@ class ReportMessageContextMenu(
         private const val MAX_FIELD_LENGTH = 1024
         private const val BUTTON_CONFIRM_PREFIX = "report:urgent:"
         private const val BUTTON_CANCEL_PREFIX = "report:cancel:"
+        private const val MODAL_ID_PREFIX = "report:reason:"
+        private const val REASON_INPUT_ID = "reason"
+        private const val MIN_REASON_LENGTH = 5
         private const val ALREADY_REPORTED_MESSAGE = "This issue was already reported."
         private const val HERE_MENTION = "@here"
         private const val NO_MOD_LOG_CHANNEL_MESSAGE =
@@ -46,6 +54,14 @@ class ReportMessageContextMenu(
         val channelId: Long,
         val messageId: Long,
         val reporterId: Long
+    )
+
+    private data class ReportReasonAction(
+        val guildId: Long,
+        val channelId: Long,
+        val messageId: Long,
+        val reporterId: Long,
+        val urgent: Boolean
     )
 
     override fun onMessageContextInteraction(event: MessageContextInteractionEvent) {
@@ -122,14 +138,10 @@ class ReportMessageContextMenu(
             return
         }
 
-        logReport(guild, reporter, target, urgent)
-
-        if (!tryConsumeRateLimit(event, guild, reporter)) {
-            return
-        }
-
-        reportedMessageService.markReported(guild.idLong, target.guildChannel.idLong, target.idLong, urgent)
-        event.reply("Your report has been sent to the moderation team.").setEphemeral(true).queue()
+        event.replyModal(
+            createReasonModal(guild.idLong, target.guildChannel.idLong, target.idLong, reporter.idLong, urgent)
+        )
+            .queue()
     }
 
     override fun onButtonInteraction(event: ButtonInteractionEvent) {
@@ -196,26 +208,109 @@ class ReportMessageContextMenu(
             return
         }
 
-        val channel = event.jda.getChannelById(MessageChannel::class.java, action.channelId)
-        if (channel == null) {
-            event.editMessage("I could not find that message anymore.").setComponents(emptyList()).queue()
+        event.replyModal(
+            createReasonModal(action.guildId, action.channelId, action.messageId, reporter.idLong, urgent = true)
+        )
+            .queue()
+    }
+
+    override fun onModalInteraction(event: ModalInteractionEvent) {
+        val action = parseReportReasonAction(event.modalId) ?: return
+        val reason = event.getValue(REASON_INPUT_ID)?.asString?.trim().orEmpty()
+
+        if (reason.length < MIN_REASON_LENGTH) {
+            event.reply("Reason must be at least $MIN_REASON_LENGTH characters.").setEphemeral(true).queue()
             return
         }
 
-        event.deferEdit().queue { hook ->
+        if (reason.length > MAX_FIELD_LENGTH) {
+            event.reply("Reason must be $MAX_FIELD_LENGTH characters or less.").setEphemeral(true).queue()
+            return
+        }
+
+        val guild = event.guild
+        val reporter = event.member
+        if (guild == null || reporter == null || guild.idLong != action.guildId || reporter.idLong != action.reporterId) {
+            event.reply("This report form is no longer valid.").setEphemeral(true).queue()
+            return
+        }
+
+        if (!reportSettingsService.isReportingEnabled(guild.idLong)) {
+            event.reply("Message reporting is not enabled on this server.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reporter.isTimedOut || muteService.isUserMuted(guild.idLong, reporter.idLong)) {
+            event.reply("You cannot report messages while timed out or muted.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reportSettingsService.isUserBlocked(guild.idLong, reporter.idLong)) {
+            event.reply("You are not allowed to report messages in this server.").setEphemeral(true).queue()
+            return
+        }
+
+        val existingState = reportedMessageService.getState(guild.idLong, action.channelId, action.messageId)
+        if (
+            existingState == ReportedMessageState.URGENT ||
+            (existingState == ReportedMessageState.NON_URGENT && !action.urgent)
+        ) {
+            event.reply(ALREADY_REPORTED_MESSAGE).setEphemeral(true).queue()
+            return
+        }
+
+        if (action.urgent && existingState != null && existingState != ReportedMessageState.NON_URGENT) {
+            event.reply("This report form expired. Report the message again.").setEphemeral(true).queue()
+            return
+        }
+
+        if (reportRateLimitService.hasActiveToken(guild.idLong, reporter.idLong)) {
+            event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
+                .setEphemeral(true)
+                .queue()
+            return
+        }
+
+        if (!guildLogger.canSendModeratorLog(guild)) {
+            event.reply(NO_MOD_LOG_CHANNEL_MESSAGE).setEphemeral(true).queue()
+            return
+        }
+
+        val channel = event.jda.getChannelById(MessageChannel::class.java, action.channelId)
+        if (channel == null) {
+            event.reply("I could not find that message anymore.").setEphemeral(true).queue()
+            return
+        }
+
+        event.deferReply(true).queue { hook ->
             channel.retrieveMessageById(action.messageId).queue(
                 { message ->
-                    logReport(guild, reporter, message, urgent = true)
+                    if (reporter.idLong == message.author.idLong) {
+                        hook.editOriginal("You cannot report your own messages.").queue()
+                        return@queue
+                    }
                     if (!tryConsumeRateLimit(hook, guild, reporter)) {
                         return@queue
                     }
-                    reportedMessageService.markUrgent(guild.idLong, action.channelId, action.messageId)
-                    hook.editOriginal("Your urgent report has been sent to the moderation team.")
-                        .setComponents(emptyList())
-                        .queue()
+                    logReport(guild, reporter, message, action.urgent, reason)
+                    if (action.urgent) {
+                        if (existingState == ReportedMessageState.NON_URGENT) {
+                            reportedMessageService.markUrgent(guild.idLong, action.channelId, action.messageId)
+                        } else {
+                            reportedMessageService.markReported(guild.idLong, action.channelId, action.messageId, urgent = true)
+                        }
+                    } else {
+                        reportedMessageService.markReported(guild.idLong, action.channelId, action.messageId, urgent = false)
+                    }
+                    val response = if (action.urgent && existingState == ReportedMessageState.NON_URGENT) {
+                        "Your urgent report has been sent to the moderation team."
+                    } else {
+                        "Your report has been sent to the moderation team."
+                    }
+                    hook.editOriginal(response).queue()
                 },
                 {
-                    hook.editOriginal("I could not find that message anymore.").setComponents(emptyList()).queue()
+                    hook.editOriginal("I could not find that message anymore.").queue()
                 }
             )
         }
@@ -230,37 +325,15 @@ class ReportMessageContextMenu(
         )
     }
 
-    private fun logReport(guild: Guild, reporter: Member, target: Message, urgent: Boolean) {
+    private fun logReport(guild: Guild, reporter: Member, target: Message, urgent: Boolean, reason: String) {
         val ping = if (urgent) reportSettingsService.getUrgentMention(guild) else HERE_MENTION
         guildLogger.logWithContent(
-            logEmbed = createReportEmbed(target, reporter, urgent),
+            logEmbed = createReportEmbed(target, reporter, urgent, reason),
             associatedUser = target.author,
             guild = guild,
             actionType = GuildLogger.LogTypeAction.MODERATOR,
             content = ping
         )
-    }
-
-    private fun tryConsumeRateLimit(event: MessageContextInteractionEvent, guild: Guild, reporter: Member): Boolean {
-        if (reportRateLimitService.tryConsume(guild.idLong, reporter.idLong)) {
-            return true
-        }
-
-        event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
-            .setEphemeral(true)
-            .queue()
-        return false
-    }
-
-    private fun tryConsumeRateLimit(event: ButtonInteractionEvent, guild: Guild, reporter: Member): Boolean {
-        if (reportRateLimitService.tryConsume(guild.idLong, reporter.idLong)) {
-            return true
-        }
-
-        event.reply("You can only report one message every ${reportRateLimitService.rateLimitDescription()}.")
-            .setEphemeral(true)
-            .queue()
-        return false
     }
 
     private fun tryConsumeRateLimit(hook: InteractionHook, guild: Guild, reporter: Member): Boolean {
@@ -303,7 +376,45 @@ class ReportMessageContextMenu(
         )
     }
 
-    private fun createReportEmbed(target: Message, reporter: Member, urgent: Boolean): EmbedBuilder {
+    private fun createReasonModal(
+        guildId: Long,
+        channelId: Long,
+        messageId: Long,
+        reporterId: Long,
+        urgent: Boolean
+    ): Modal {
+        val modalId = "$MODAL_ID_PREFIX$guildId:$channelId:$messageId:$reporterId:$urgent"
+        val reasonInput = TextInput.create(REASON_INPUT_ID, TextInputStyle.PARAGRAPH)
+            .setPlaceholder("Explain why this message should be reviewed...")
+            .setMinLength(MIN_REASON_LENGTH)
+            .setMaxLength(MAX_FIELD_LENGTH)
+            .build()
+
+        return Modal.create(modalId, "Report Reason")
+            .addComponents(Label.of("Reason", reasonInput))
+            .build()
+    }
+
+    private fun parseReportReasonAction(modalId: String): ReportReasonAction? {
+        if (!modalId.startsWith(MODAL_ID_PREFIX)) {
+            return null
+        }
+
+        val tokens = modalId.removePrefix(MODAL_ID_PREFIX).split(':')
+        if (tokens.size != 5) {
+            return null
+        }
+
+        return ReportReasonAction(
+            guildId = tokens[0].toLongOrNull() ?: return null,
+            channelId = tokens[1].toLongOrNull() ?: return null,
+            messageId = tokens[2].toLongOrNull() ?: return null,
+            reporterId = tokens[3].toLongOrNull() ?: return null,
+            urgent = tokens[4].toBooleanStrictOrNull() ?: return null
+        )
+    }
+
+    private fun createReportEmbed(target: Message, reporter: Member, urgent: Boolean, reason: String): EmbedBuilder {
         val authorName = target.member?.nicknameAndUsername ?: target.author.name
         val embed = EmbedBuilder()
             .setColor(if (urgent) Color.RED else Color.YELLOW)
@@ -312,6 +423,7 @@ class ReportMessageContextMenu(
             .addField("Reported user", authorName, true)
             .addField("Channel", target.guildChannel.asMention, true)
             .addField("Message URL", "[Link](${target.jumpUrl})", false)
+            .addField("Reason", reason, false)
 
         if (target.contentRaw.isNotBlank()) {
             embed.addField("Message", target.contentRaw.abbreviateField(), false)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -567,6 +567,22 @@ class ReportMessageContextMenuTest {
     }
 
     @Test
+    fun `stale cancel button clears confirmation after urgent report was sent`() {
+        whenever(buttonEvent.componentId).thenReturn("report:cancel:1:123:456:99")
+        whenever(buttonEvent.user).thenReturn(reporterUser)
+        whenever(reporterUser.idLong).thenReturn(99L)
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.URGENT)
+        whenever(buttonEvent.editMessage("This issue was already reported.")).thenReturn(editAction)
+        whenever(editAction.setComponents(emptyList<ActionRow>())).thenReturn(editAction)
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).editMessage("This issue was already reported.")
+        verify(editAction).setComponents(emptyList<ActionRow>())
+        verify(editAction).queue()
+    }
+
+    @Test
     fun `report embed uses author name when reported member is null`() {
         stubReportWithNullMember("Report Message")
         whenever(event.replyModal(any())).thenReturn(modalAction)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -11,13 +11,16 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.Command
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
 import net.dv8tion.jda.api.requests.RestAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
+import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -27,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
@@ -60,6 +64,9 @@ class ReportMessageContextMenuTest {
     private lateinit var buttonEvent: ButtonInteractionEvent
 
     @Mock
+    private lateinit var modalEvent: ModalInteractionEvent
+
+    @Mock
     private lateinit var guild: Guild
 
     @Mock
@@ -87,6 +94,9 @@ class ReportMessageContextMenuTest {
     private lateinit var replyAction: ReplyCallbackAction
 
     @Mock
+    private lateinit var modalAction: ModalCallbackAction
+
+    @Mock
     private lateinit var editAction: MessageEditCallbackAction
 
     @Mock
@@ -106,6 +116,9 @@ class ReportMessageContextMenuTest {
 
     @Mock
     private lateinit var retrieveMessageAction: RestAction<Message>
+
+    @Mock
+    private lateinit var reasonValue: ModalMapping
 
     private lateinit var command: ReportMessageContextMenu
 
@@ -140,8 +153,15 @@ class ReportMessageContextMenuTest {
     @Test
     fun `non-urgent report logs to moderation channel with here ping`() {
         stubReport("Report Message")
+        whenever(event.replyModal(any())).thenReturn(modalAction)
 
         command.onMessageContextInteraction(event)
+
+        verify(event).replyModal(argThat { id == "report:reason:1:123:456:99:false" })
+
+        stubReportReasonModal(urgent = false)
+
+        command.onModalInteraction(modalEvent)
 
         val embedCaptor = argumentCaptor<EmbedBuilder>()
         verify(guildLogger).logWithContent(
@@ -158,19 +178,27 @@ class ReportMessageContextMenuTest {
         assertEquals("Duncan(reporter-user) (99)", embed.fields[0].value)
         assertEquals("Reported user", embed.fields[1].name)
         assertEquals("ReportedUser", embed.fields[1].value)
+        assertTrue(embed.fields.any { it.name == "Reason" && it.value == "Breaking the server rules" })
         assertTrue(embed.fields.any { it.name == "Message" && it.value == "This should be reviewed" })
         assertTrue(embed.fields.any { it.name == "Attachment(s)" && it.value == "https://example.invalid/image.png" })
         verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = false)
-        verify(event).reply("Your report has been sent to the moderation team.")
-        verify(replyAction).queue()
+        verify(interactionHook).editOriginal("Your report has been sent to the moderation team.")
+        verify(hookEditAction).queue()
     }
 
     @Test
     fun `urgent report logs to moderation channel with everyone ping`() {
         stubReport("Urgent Report Message")
+        whenever(event.replyModal(any())).thenReturn(modalAction)
         whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("@everyone")
 
         command.onMessageContextInteraction(event)
+
+        verify(event).replyModal(argThat { id == "report:reason:1:123:456:99:true" })
+
+        stubReportReasonModal(urgent = true)
+
+        command.onModalInteraction(modalEvent)
 
         val embedCaptor = argumentCaptor<EmbedBuilder>()
         verify(guildLogger).logWithContent(
@@ -183,16 +211,23 @@ class ReportMessageContextMenuTest {
         )
         verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = true)
         assertEquals("Urgent message report", embedCaptor.firstValue.build().title)
-        verify(event).reply("Your report has been sent to the moderation team.")
-        verify(replyAction).queue()
+        assertTrue(
+            embedCaptor.firstValue.build().fields.any { it.name == "Reason" && it.value == "Breaking the server rules" }
+        )
+        verify(interactionHook).editOriginal("Your report has been sent to the moderation team.")
     }
 
     @Test
     fun `urgent report logs to moderation channel with configured role ping`() {
         stubReport("Urgent Report Message")
+        whenever(event.replyModal(any())).thenReturn(modalAction)
         whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("<@&5>")
 
         command.onMessageContextInteraction(event)
+
+        stubReportReasonModal(urgent = true)
+
+        command.onModalInteraction(modalEvent)
 
         verify(guildLogger).logWithContent(
             any<EmbedBuilder>(),
@@ -203,8 +238,7 @@ class ReportMessageContextMenuTest {
             eq("<@&5>")
         )
         verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = true)
-        verify(event).reply("Your report has been sent to the moderation team.")
-        verify(replyAction).queue()
+        verify(interactionHook).editOriginal("Your report has been sent to the moderation team.")
     }
 
     @Test
@@ -216,6 +250,27 @@ class ReportMessageContextMenuTest {
 
         verify(event).reply("This issue was already reported.")
         verify(reportRateLimitService, never()).tryConsume(any(), any())
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+    }
+
+    @Test
+    fun `report reason must have at least five characters`() {
+        whenever(modalEvent.modalId).thenReturn("report:reason:1:123:456:99:false")
+        whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
+        whenever(reasonValue.asString).thenReturn("no")
+        whenever(modalEvent.reply(any<String>())).thenReturn(replyAction)
+        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(modalEvent).reply("Reason must be at least 5 characters.")
         verify(guildLogger, never()).logWithContent(
             any<EmbedBuilder>(),
             any<User>(),
@@ -313,14 +368,16 @@ class ReportMessageContextMenuTest {
     fun `urgent confirmation logs urgent report and upgrades state`() {
         stubUrgentConfirmation()
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
-        whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(true)
-        whenever(buttonEvent.jda).thenReturn(jda)
-        whenever(jda.getChannelById(MessageChannel::class.java, 123L)).thenReturn(messageChannel)
-        whenever(messageChannel.retrieveMessageById(456L)).thenReturn(retrieveMessageAction)
-        doRetrieveMessageSuccess()
+        whenever(buttonEvent.replyModal(any())).thenReturn(modalAction)
         whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("@everyone")
 
         command.onButtonInteraction(buttonEvent)
+
+        verify(buttonEvent).replyModal(argThat { id == "report:reason:1:123:456:99:true" })
+
+        stubReportReasonModal(urgent = true, existingState = ReportedMessageState.NON_URGENT)
+
+        command.onModalInteraction(modalEvent)
 
         verify(guildLogger).logWithContent(
             any<EmbedBuilder>(),
@@ -331,10 +388,7 @@ class ReportMessageContextMenuTest {
             eq("@everyone")
         )
         verify(reportedMessageService).markUrgent(1L, 123L, 456L)
-        verify(buttonEvent).deferEdit()
-        verify(deferredEditAction).queue(any<Consumer<InteractionHook>>())
         verify(interactionHook).editOriginal("Your urgent report has been sent to the moderation team.")
-        verify(hookEditAction).setComponents(emptyList<ActionRow>())
         verify(hookEditAction).queue()
     }
 
@@ -342,17 +396,19 @@ class ReportMessageContextMenuTest {
     fun `urgent confirmation updates deferred response when message retrieval fails`() {
         stubUrgentConfirmation(includeRetrievedMessageDetails = false)
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(ReportedMessageState.NON_URGENT)
-        whenever(buttonEvent.jda).thenReturn(jda)
+        whenever(buttonEvent.replyModal(any())).thenReturn(modalAction)
+
+        command.onButtonInteraction(buttonEvent)
+
+        stubReportReasonModal(urgent = true, existingState = ReportedMessageState.NON_URGENT, retrieveMessage = false)
         whenever(jda.getChannelById(MessageChannel::class.java, 123L)).thenReturn(messageChannel)
         whenever(messageChannel.retrieveMessageById(456L)).thenReturn(retrieveMessageAction)
         doRetrieveMessageFailure()
 
-        command.onButtonInteraction(buttonEvent)
+        command.onModalInteraction(modalEvent)
 
-        verify(buttonEvent).deferEdit()
-        verify(deferredEditAction).queue(any<Consumer<InteractionHook>>())
+        verify(modalEvent).deferReply(true)
         verify(interactionHook).editOriginal("I could not find that message anymore.")
-        verify(hookEditAction).setComponents(emptyList<ActionRow>())
         verify(hookEditAction).queue()
         verify(reportRateLimitService, never()).tryConsume(any(), any())
         verify(guildLogger, never()).logWithContent(
@@ -513,8 +569,13 @@ class ReportMessageContextMenuTest {
     @Test
     fun `report embed uses author name when reported member is null`() {
         stubReportWithNullMember("Report Message")
+        whenever(event.replyModal(any())).thenReturn(modalAction)
 
         command.onMessageContextInteraction(event)
+
+        stubReportReasonModal(urgent = false)
+
+        command.onModalInteraction(modalEvent)
 
         val embedCaptor = argumentCaptor<EmbedBuilder>()
         verify(guildLogger).logWithContent(
@@ -561,6 +622,41 @@ class ReportMessageContextMenuTest {
         assertEquals(2, commands.size)
         assertEquals(listOf(Command.Type.MESSAGE, Command.Type.MESSAGE), commands.map { it.type })
         assertEquals(listOf("Report Message", "Urgent Report Message"), commands.map { it.name })
+    }
+
+    private fun stubReportReasonModal(
+        urgent: Boolean,
+        reason: String = "Breaking the server rules",
+        existingState: ReportedMessageState? = null,
+        retrieveMessage: Boolean = true
+    ) {
+        whenever(modalEvent.modalId).thenReturn("report:reason:1:123:456:99:$urgent")
+        whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
+        whenever(reasonValue.asString).thenReturn(reason)
+        whenever(modalEvent.guild).thenReturn(guild)
+        whenever(modalEvent.member).thenReturn(reporter)
+        whenever(modalEvent.jda).thenReturn(jda)
+        whenever(modalEvent.deferReply(true)).thenReturn(replyAction)
+        whenever(interactionHook.editOriginal(any<String>())).thenReturn(hookEditAction)
+        doAnswer { invocation ->
+            invocation.component1<Consumer<InteractionHook>>().accept(interactionHook)
+            null
+        }.whenever(replyAction).queue(any<Consumer<InteractionHook>>())
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(reporter.idLong).thenReturn(99L)
+        whenever(reporter.isTimedOut).thenReturn(false)
+        whenever(muteService.isUserMuted(1L, 99L)).thenReturn(false)
+        whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
+        whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
+        whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(existingState)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
+        whenever(reportRateLimitService.hasActiveToken(1L, 99L)).thenReturn(false)
+        if (retrieveMessage) {
+            whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(true)
+            whenever(jda.getChannelById(MessageChannel::class.java, 123L)).thenReturn(messageChannel)
+            whenever(messageChannel.retrieveMessageById(456L)).thenReturn(retrieveMessageAction)
+            doRetrieveMessageSuccess()
+        }
     }
 
     private fun stubReport(commandName: String, timedOut: Boolean = false, muted: Boolean = false) {
@@ -616,8 +712,6 @@ class ReportMessageContextMenuTest {
         whenever(event.name).thenReturn(commandName)
         whenever(event.guild).thenReturn(guild)
         whenever(event.member).thenReturn(reporter)
-        whenever(event.reply(any<String>())).thenReturn(replyAction)
-        whenever(replyAction.setEphemeral(true)).thenReturn(replyAction)
         whenever(guild.idLong).thenReturn(1L)
         whenever(reporter.idLong).thenReturn(99L)
         whenever(reporter.isTimedOut).thenReturn(timedOut)
@@ -626,7 +720,6 @@ class ReportMessageContextMenuTest {
             if (!muted) {
                 whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
                 whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
-                whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(true)
             }
         }
         whenever(reporter.user).thenReturn(reporterUser)
@@ -683,13 +776,6 @@ class ReportMessageContextMenuTest {
         whenever(reporterUser.idLong).thenReturn(99L)
         whenever(buttonEvent.guild).thenReturn(guild)
         whenever(buttonEvent.member).thenReturn(reporter)
-        whenever(buttonEvent.deferEdit()).thenReturn(deferredEditAction)
-        whenever(interactionHook.editOriginal(any<String>())).thenReturn(hookEditAction)
-        whenever(hookEditAction.setComponents(any<List<ActionRow>>())).thenReturn(hookEditAction)
-        doAnswer { (success: Consumer<InteractionHook>) ->
-            success.accept(interactionHook)
-            null
-        }.whenever(deferredEditAction).queue(any())
         whenever(guild.idLong).thenReturn(1L)
         whenever(reporter.idLong).thenReturn(99L)
         whenever(reporter.isTimedOut).thenReturn(false)


### PR DESCRIPTION
## Summary
- add a required reason modal before message reports are logged
- include the submitted reason in moderator report embeds
- handle stale urgent escalation cancel buttons after an urgent report is sent

## Testing
- ./gradlew.bat test --tests be.duncanc.discordmodbot.moderation.ReportMessageContextMenuTest