### PR TITLE
fix(moderation): set audit reasons for mod actions

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsByIdCommand.kt
@@ -299,7 +299,7 @@ class AddWarnPointsByIdCommand(
                     return
                 }
 
-                guild.addRoleToMember(targetMember, muteRole).reason(reason).queue(
+                guild.addRoleToMember(targetMember, muteRole).reason(reason.toAuditReason()).queue(
                     {
                         try {
                             muteService.muteUserById(guild.idLong, targetUserId)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AddWarnPointsCommand.kt
@@ -292,7 +292,7 @@ class AddWarnPointsCommand(
                     return
                 }
 
-                guild.addRoleToMember(targetMember, muteRole).reason(reason).queue(
+                guild.addRoleToMember(targetMember, muteRole).reason(reason.toAuditReason()).queue(
                     {
                         muteService.muteUserById(guild.idLong, targetUserId)
                         try {
@@ -381,7 +381,7 @@ class AddWarnPointsCommand(
                     )
                     return
                 }
-                guild.kick(targetMember).reason(reason).queue()
+                guild.kick(targetMember).reason(reason.toAuditReason()).queue()
             }
         }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/AuditReasons.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/AuditReasons.kt
@@ -1,0 +1,5 @@
+package be.duncanc.discordmodbot.moderation
+
+private const val MAX_AUDIT_REASON_LENGTH = 512
+
+internal fun String.toAuditReason(): String = take(MAX_AUDIT_REASON_LENGTH)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanCommand.kt
@@ -113,7 +113,7 @@ class BanCommand : ListenerAdapter(), SlashCommand {
     private fun processBan(event: ModalInteractionEvent, member: Member, targetMember: Member, reason: String) {
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
-            val banRestAction = guild.ban(targetMember, 7, TimeUnit.DAYS)
+            val banRestAction = guild.ban(targetMember, 7, TimeUnit.DAYS).reason(reason.toAuditReason())
             val description = StringBuilder("Reason: $reason")
             if (guild.idLong == 175856762677624832L) {
                 description.append("\n\n")
@@ -147,7 +147,7 @@ class BanCommand : ListenerAdapter(), SlashCommand {
     private fun processBanById(event: ModalInteractionEvent, member: Member, targetUserId: Long, reason: String) {
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
-            val banRestAction = guild.ban(User.fromId(targetUserId), 7, TimeUnit.DAYS)
+            val banRestAction = guild.ban(User.fromId(targetUserId), 7, TimeUnit.DAYS).reason(reason.toAuditReason())
 
             event.jda.retrieveUserById(targetUserId).queue(
                 { targetUser ->

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanUserByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/BanUserByIdCommand.kt
@@ -119,7 +119,7 @@ class BanUserByIdCommand : ListenerAdapter(), SlashCommand {
                     User.fromId(userId),
                     1,
                     TimeUnit.DAYS
-                ).queue({
+                ).reason(reason.toAuditReason()).queue({
                     val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
                     if (guildLogger != null) {
                         val logEmbed = EmbedBuilder()

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/KickCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/KickCommand.kt
@@ -112,7 +112,7 @@ class KickCommand : ListenerAdapter(), SlashCommand {
     private fun processKick(event: ModalInteractionEvent, member: Member, targetMember: Member, reason: String) {
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
-            val kickRestAction = guild.kick(targetMember)
+            val kickRestAction = guild.kick(targetMember).reason(reason.toAuditReason())
 
             val userKickNotification = EmbedBuilder()
                 .setColor(Color.RED)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteByIdCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteByIdCommand.kt
@@ -118,7 +118,7 @@ class MuteByIdCommand(
 
             val targetMember = guild.getMemberById(userId)
             targetMember?.let {
-                guild.addRoleToMember(it, muteRole).reason(reason).queue()
+                guild.addRoleToMember(it, muteRole).reason(reason.toAuditReason()).queue()
             }
 
             val logEmbed = EmbedBuilder()

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteCommand.kt
@@ -146,7 +146,7 @@ class MuteCommand(
                 return@queue
             }
 
-            guild.addRoleToMember(targetMember, muteRole).queue({
+            guild.addRoleToMember(targetMember, muteRole).reason(reason.toAuditReason()).queue({
                 muteService.muteUserById(guild.idLong, targetUserId)
                 val guildLogger = event.jda.registeredListeners.firstOrNull { it is GuildLogger } as GuildLogger?
                 if (guildLogger != null) {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteRoleCommandAndEventsListener.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/MuteRoleCommandAndEventsListener.kt
@@ -32,6 +32,7 @@ class MuteRoleCommandAndEventsListener(
         private const val COMMAND = "muterole"
         private const val DESCRIPTION = "Set or remove the mute role for this server."
         private const val OPTION_ROLE = "role"
+        private const val RESTORE_MUTE_REASON = "Restoring mute role because user was previously muted before leaving"
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
@@ -98,7 +99,9 @@ class MuteRoleCommandAndEventsListener(
     override fun onGuildMemberJoin(event: GuildMemberJoinEvent) {
         val muteRoleId = muteService.getMuteRoleId(event.guild.idLong) ?: return
         if (muteService.isUserMuted(event.guild.idLong, event.user.idLong)) {
-            event.guild.addRoleToMember(event.member, event.guild.getRoleById(muteRoleId)!!).queue()
+            event.guild.addRoleToMember(event.member, event.guild.getRoleById(muteRoleId)!!)
+                .reason(RESTORE_MUTE_REASON)
+                .queue()
             val logEmbed = EmbedBuilder()
                 .setColor(Color.YELLOW)
                 .setTitle("User automatically muted")

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/MuteCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/MuteCommandTest.kt
@@ -1,0 +1,89 @@
+package be.duncanc.discordmodbot.moderation
+
+import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.modals.ModalMapping
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.function.Consumer
+
+@ExtendWith(MockitoExtension::class)
+class MuteCommandTest {
+    @Mock
+    private lateinit var muteRoleCommandAndEventsListener: MuteRoleCommandAndEventsListener
+
+    @Mock
+    private lateinit var muteService: MuteService
+
+    @Mock
+    private lateinit var modalEvent: ModalInteractionEvent
+
+    @Mock
+    private lateinit var moderator: Member
+
+    @Mock
+    private lateinit var targetMember: Member
+
+    @Mock
+    private lateinit var guild: Guild
+
+    @Mock
+    private lateinit var muteRole: Role
+
+    @Mock
+    private lateinit var reasonValue: ModalMapping
+
+    @Mock
+    private lateinit var replyAction: ReplyCallbackAction
+
+    @Mock
+    private lateinit var hook: InteractionHook
+
+    @Mock
+    private lateinit var addRoleAction: AuditableRestAction<Void>
+
+    private lateinit var command: MuteCommand
+
+
+    @BeforeEach
+    fun setUp() {
+        command = MuteCommand(muteRoleCommandAndEventsListener, muteService)
+    }
+
+    @Test
+    fun `modal submission applies the mute reason to the audit log`() {
+        whenever(modalEvent.modalId).thenReturn("mute_reason:99")
+        whenever(modalEvent.member).thenReturn(moderator)
+        whenever(modalEvent.guild).thenReturn(guild)
+        whenever(moderator.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
+        whenever(moderator.canInteract(targetMember)).thenReturn(true)
+        whenever(guild.getMemberById(99L)).thenReturn(targetMember)
+        whenever(modalEvent.getValue("reason")).thenReturn(reasonValue)
+        whenever(reasonValue.asString).thenReturn("Spamming")
+        whenever(modalEvent.deferReply(true)).thenReturn(replyAction)
+        doAnswer { (consumer: Consumer<InteractionHook>) ->
+            consumer.accept(hook)
+            null
+        }.whenever(replyAction).queue(any())
+        whenever(muteRoleCommandAndEventsListener.getMuteRole(guild)).thenReturn(muteRole)
+        whenever(guild.addRoleToMember(targetMember, muteRole)).thenReturn(addRoleAction)
+        whenever(addRoleAction.reason("Spamming")).thenReturn(addRoleAction)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(addRoleAction).reason("Spamming")
+    }
+}


### PR DESCRIPTION
## Summary
- Set Discord audit-log reasons for kick, ban, mute, and warn-point punishment role actions
- Truncate user-provided audit reasons to Discord's 512-character audit reason limit while preserving full modal/log/DM text
- Add an audit reason when restoring a mute role after rejoin

## Testing
- ./gradlew.bat test