### PR TITLE
fix: configure report channel

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -338,7 +338,7 @@ class ReportMessageContextMenu(
     private fun logReport(guild: Guild, reporter: Member, target: Message, urgent: Boolean, reason: String) {
         val ping = if (urgent) reportSettingsService.getUrgentMention(guild) else HERE_MENTION
         val reportChannel = reportSettingsService.getReportChannel(guild)
-        if (reportChannel != null) {
+        if (reportChannel != null && reportSettingsService.canSendReportToConfiguredChannel(guild)) {
             try {
                 val embed = createReportEmbed(target, reporter, urgent, reason)
                     .setTimestamp(Instant.now())
@@ -374,8 +374,8 @@ class ReportMessageContextMenu(
     }
 
     private fun canSendReport(guild: Guild): Boolean {
-        if (reportSettingsService.getReportChannel(guild) != null) {
-            return reportSettingsService.canSendReportToConfiguredChannel(guild)
+        if (reportSettingsService.canSendReportToConfiguredChannel(guild)) {
+            return true
         }
 
         return guildLogger.canSendModeratorLog(guild)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.build.CommandData
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.modals.Modal
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
 import org.springframework.stereotype.Component
 import java.awt.Color
 
@@ -45,7 +46,7 @@ class ReportMessageContextMenu(
         private const val ALREADY_REPORTED_MESSAGE = "This issue was already reported."
         private const val HERE_MENTION = "@here"
         private const val NO_MOD_LOG_CHANNEL_MESSAGE =
-            "Message reporting is not configured on this server. The bot needs a moderator log channel with permission to send messages and embeds."
+            "Message reporting is not configured on this server. The bot needs a report channel or moderator log channel with permission to send messages and embeds."
     }
 
     private data class UrgentConfirmationAction(
@@ -115,7 +116,7 @@ class ReportMessageContextMenu(
                     .queue()
                 return
             }
-            if (!guildLogger.canSendModeratorLog(guild)) {
+            if (!canSendReport(guild)) {
                 event.reply(NO_MOD_LOG_CHANNEL_MESSAGE).setEphemeral(true).queue()
                 return
             }
@@ -133,7 +134,7 @@ class ReportMessageContextMenu(
             return
         }
 
-        if (!guildLogger.canSendModeratorLog(guild)) {
+        if (!canSendReport(guild)) {
             event.reply(NO_MOD_LOG_CHANNEL_MESSAGE).setEphemeral(true).queue()
             return
         }
@@ -208,7 +209,7 @@ class ReportMessageContextMenu(
             return
         }
 
-        if (!guildLogger.canSendModeratorLog(guild)) {
+        if (!canSendReport(guild)) {
             event.editMessage(NO_MOD_LOG_CHANNEL_MESSAGE).setComponents(emptyList()).queue()
             return
         }
@@ -276,7 +277,7 @@ class ReportMessageContextMenu(
             return
         }
 
-        if (!guildLogger.canSendModeratorLog(guild)) {
+        if (!canSendReport(guild)) {
             event.reply(NO_MOD_LOG_CHANNEL_MESSAGE).setEphemeral(true).queue()
             return
         }
@@ -332,6 +333,20 @@ class ReportMessageContextMenu(
 
     private fun logReport(guild: Guild, reporter: Member, target: Message, urgent: Boolean, reason: String) {
         val ping = if (urgent) reportSettingsService.getUrgentMention(guild) else HERE_MENTION
+        val reportChannel = reportSettingsService.getReportChannel(guild)
+        if (reportChannel != null) {
+            reportChannel.sendMessage(
+                MessageCreateBuilder()
+                    .setEmbeds(createReportEmbed(target, reporter, urgent, reason).build())
+                    .addContent(ping)
+                    .setAllowedMentions(
+                        setOf(Message.MentionType.EVERYONE, Message.MentionType.HERE, Message.MentionType.ROLE)
+                    )
+                    .build()
+            ).queue()
+            return
+        }
+
         guildLogger.logWithContent(
             logEmbed = createReportEmbed(target, reporter, urgent, reason),
             associatedUser = target.author,
@@ -339,6 +354,14 @@ class ReportMessageContextMenu(
             actionType = GuildLogger.LogTypeAction.MODERATOR,
             content = ping
         )
+    }
+
+    private fun canSendReport(guild: Guild): Boolean {
+        if (reportSettingsService.getReportChannel(guild) != null) {
+            return reportSettingsService.canSendReportToConfiguredChannel(guild)
+        }
+
+        return guildLogger.canSendModeratorLog(guild)
     }
 
     private fun tryConsumeRateLimit(hook: InteractionHook, guild: Guild, reporter: Member): Boolean {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenu.kt
@@ -16,6 +16,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.exceptions.PermissionException
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.InteractionHook
@@ -23,8 +24,10 @@ import net.dv8tion.jda.api.interactions.commands.build.CommandData
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.modals.Modal
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.awt.Color
+import java.time.Instant
 
 @Component
 class ReportMessageContextMenu(
@@ -47,6 +50,7 @@ class ReportMessageContextMenu(
         private const val HERE_MENTION = "@here"
         private const val NO_MOD_LOG_CHANNEL_MESSAGE =
             "Message reporting is not configured on this server. The bot needs a report channel or moderator log channel with permission to send messages and embeds."
+        private val LOG = LoggerFactory.getLogger(ReportMessageContextMenu::class.java)
     }
 
     private data class UrgentConfirmationAction(
@@ -335,15 +339,28 @@ class ReportMessageContextMenu(
         val ping = if (urgent) reportSettingsService.getUrgentMention(guild) else HERE_MENTION
         val reportChannel = reportSettingsService.getReportChannel(guild)
         if (reportChannel != null) {
-            reportChannel.sendMessage(
-                MessageCreateBuilder()
-                    .setEmbeds(createReportEmbed(target, reporter, urgent, reason).build())
-                    .addContent(ping)
-                    .setAllowedMentions(
-                        setOf(Message.MentionType.EVERYONE, Message.MentionType.HERE, Message.MentionType.ROLE)
-                    )
+            try {
+                val embed = createReportEmbed(target, reporter, urgent, reason)
+                    .setTimestamp(Instant.now())
+                    .setFooter(target.author.id, target.author.effectiveAvatarUrl)
                     .build()
-            ).queue()
+                reportChannel.sendMessage(
+                    MessageCreateBuilder()
+                        .setEmbeds(embed)
+                        .addContent(ping)
+                        .setAllowedMentions(
+                            setOf(Message.MentionType.EVERYONE, Message.MentionType.HERE, Message.MentionType.ROLE)
+                        )
+                        .build()
+                ).queue()
+            } catch (e: PermissionException) {
+                LOG.warn(
+                    "{}: {}\nGuild: {}",
+                    e.javaClass.simpleName,
+                    e.message,
+                    guild
+                )
+            }
             return
         }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
@@ -58,7 +58,11 @@ class ReportSettingsCommand(
             SUBCOMMAND_BLOCK_USER -> blockUser(event, guild.idLong)
             SUBCOMMAND_ALLOW_USER -> allowUser(event, guild.idLong)
             SUBCOMMAND_SET_URGENT_ROLE -> setUrgentRole(event, guild.idLong)
-            SUBCOMMAND_SET_CHANNEL -> setReportChannel(event, guild.idLong)
+            SUBCOMMAND_SET_CHANNEL -> {
+                if (!hasManageChannelPermission(event)) return
+                setReportChannel(event, guild.idLong)
+            }
+
             SUBCOMMAND_CLEAR_URGENT_ROLE -> {
                 reportSettingsService.clearUrgentRole(guild.idLong)
                 event.reply("Urgent report role cleared. Urgent reports will mention @everyone.")
@@ -67,6 +71,7 @@ class ReportSettingsCommand(
             }
 
             SUBCOMMAND_CLEAR_CHANNEL -> {
+                if (!hasManageChannelPermission(event)) return
                 reportSettingsService.clearReportChannel(guild.idLong)
                 event.reply("Report channel cleared. Reports will use the moderator log channel.")
                     .setEphemeral(true)
@@ -136,6 +141,16 @@ class ReportSettingsCommand(
 
         reportSettingsService.setUrgentRole(guildId, role.idLong)
         event.reply("Urgent reports will now mention ${role.asMention}.").setEphemeral(true).queue()
+    }
+
+    private fun hasManageChannelPermission(event: SlashCommandInteractionEvent): Boolean {
+        val member = event.member ?: return false
+        if (!member.hasPermission(Permission.MANAGE_CHANNEL)) {
+            event.reply("You need manage channel permission to use this command.").setEphemeral(true).queue()
+            return false
+        }
+
+        return true
     }
 
     private fun setReportChannel(event: SlashCommandInteractionEvent, guildId: Long) {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommand.kt
@@ -4,12 +4,15 @@ import be.duncanc.discordmodbot.discord.SlashCommand
 import be.duncanc.discordmodbot.moderation.persistence.ReportSettings
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData
 import org.springframework.stereotype.Component
@@ -26,9 +29,12 @@ class ReportSettingsCommand(
         private const val SUBCOMMAND_ALLOW_USER = "allow-user"
         private const val SUBCOMMAND_SET_URGENT_ROLE = "set-urgent-role"
         private const val SUBCOMMAND_CLEAR_URGENT_ROLE = "clear-urgent-role"
+        private const val SUBCOMMAND_SET_CHANNEL = "set-channel"
+        private const val SUBCOMMAND_CLEAR_CHANNEL = "clear-channel"
         private const val SUBCOMMAND_TOGGLE = "toggle"
         private const val OPTION_USER = "user"
         private const val OPTION_ROLE = "role"
+        private const val OPTION_CHANNEL = "channel"
         private const val BLOCKED_USER_DISPLAY_LIMIT = 20
     }
 
@@ -52,9 +58,17 @@ class ReportSettingsCommand(
             SUBCOMMAND_BLOCK_USER -> blockUser(event, guild.idLong)
             SUBCOMMAND_ALLOW_USER -> allowUser(event, guild.idLong)
             SUBCOMMAND_SET_URGENT_ROLE -> setUrgentRole(event, guild.idLong)
+            SUBCOMMAND_SET_CHANNEL -> setReportChannel(event, guild.idLong)
             SUBCOMMAND_CLEAR_URGENT_ROLE -> {
                 reportSettingsService.clearUrgentRole(guild.idLong)
                 event.reply("Urgent report role cleared. Urgent reports will mention @everyone.")
+                    .setEphemeral(true)
+                    .queue()
+            }
+
+            SUBCOMMAND_CLEAR_CHANNEL -> {
+                reportSettingsService.clearReportChannel(guild.idLong)
+                event.reply("Report channel cleared. Reports will use the moderator log channel.")
                     .setEphemeral(true)
                     .queue()
             }
@@ -83,6 +97,9 @@ class ReportSettingsCommand(
                     SubcommandData(SUBCOMMAND_SET_URGENT_ROLE, "Set the role mentioned by urgent reports")
                         .addOption(OptionType.ROLE, OPTION_ROLE, "The role to mention", true),
                     SubcommandData(SUBCOMMAND_CLEAR_URGENT_ROLE, "Clear the urgent report role"),
+                    SubcommandData(SUBCOMMAND_SET_CHANNEL, "Set the channel used for message reports")
+                        .addOptions(textChannelOption("The channel used for message reports")),
+                    SubcommandData(SUBCOMMAND_CLEAR_CHANNEL, "Use the moderator log channel for message reports"),
                     SubcommandData(SUBCOMMAND_TOGGLE, "Enable or disable message reporting")
                 )
         )
@@ -121,17 +138,48 @@ class ReportSettingsCommand(
         event.reply("Urgent reports will now mention ${role.asMention}.").setEphemeral(true).queue()
     }
 
+    private fun setReportChannel(event: SlashCommandInteractionEvent, guildId: Long) {
+        val channel = getRequiredTextChannel(event) ?: return
+
+        reportSettingsService.setReportChannel(guildId, channel.idLong)
+        event.reply("Message reports will now be sent to ${channel.asMention}.").setEphemeral(true).queue()
+    }
+
     private fun showCurrentSettings(event: SlashCommandInteractionEvent, guild: Guild) {
         val settings = reportSettingsService.getSettings(guild.idLong)
         val message = buildString {
             appendLine("Report settings for ${guild.name}")
             appendLine()
             appendLine("- Reporting: ${if (settings.enabled) "enabled" else "disabled"}")
+            appendLine("- Report channel: ${formatChannel(guild, settings.reportChannelId)}")
             appendLine("- Urgent mention: ${reportSettingsService.getUrgentMention(guild)}")
             appendLine("- Blocked users: ${formatBlockedUsers(settings)}")
         }
 
         event.reply(message).setEphemeral(true).queue()
+    }
+
+    private fun getRequiredTextChannel(event: SlashCommandInteractionEvent): TextChannel? {
+        val channel = event.getOption(OPTION_CHANNEL)?.asChannel?.asTextChannel()
+        if (channel == null) {
+            event.reply("Please choose a text channel.").setEphemeral(true).queue()
+            return null
+        }
+
+        return channel
+    }
+
+    private fun formatChannel(guild: Guild, channelId: Long?): String {
+        if (channelId == null) {
+            return "Using moderator log channel"
+        }
+
+        return guild.getTextChannelById(channelId)?.asMention ?: "Channel not found (ID: $channelId)"
+    }
+
+    private fun textChannelOption(description: String): OptionData {
+        return OptionData(OptionType.CHANNEL, OPTION_CHANNEL, description, true)
+            .setChannelTypes(ChannelType.TEXT)
     }
 
     private fun formatBlockedUsers(settings: ReportSettings): String {

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsService.kt
@@ -2,7 +2,9 @@ package be.duncanc.discordmodbot.moderation
 
 import be.duncanc.discordmodbot.moderation.persistence.ReportSettings
 import be.duncanc.discordmodbot.moderation.persistence.ReportSettingsRepository
+import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -28,6 +30,21 @@ class ReportSettingsService(
         return guild.getRoleById(roleId)?.asMention ?: EVERYONE_MENTION
     }
 
+    fun getReportChannel(guild: Guild): TextChannel? {
+        val channelId = getSettings(guild.idLong).reportChannelId ?: return null
+        return guild.getTextChannelById(channelId)
+    }
+
+    fun canSendReportToConfiguredChannel(guild: Guild): Boolean {
+        val channel = getReportChannel(guild) ?: return false
+        return guild.selfMember.hasPermission(
+            channel,
+            Permission.VIEW_CHANNEL,
+            Permission.MESSAGE_SEND,
+            Permission.MESSAGE_EMBED_LINKS
+        )
+    }
+
     @Transactional
     fun blockUser(guildId: Long, userId: Long) {
         val settings = getSettings(guildId)
@@ -50,9 +67,23 @@ class ReportSettingsService(
     }
 
     @Transactional
+    fun setReportChannel(guildId: Long, channelId: Long) {
+        val settings = getSettings(guildId)
+        settings.reportChannelId = channelId
+        reportSettingsRepository.save(settings)
+    }
+
+    @Transactional
     fun clearUrgentRole(guildId: Long) {
         val settings = reportSettingsRepository.findById(guildId).orElse(null) ?: return
         settings.urgentRoleId = null
+        reportSettingsRepository.save(settings)
+    }
+
+    @Transactional
+    fun clearReportChannel(guildId: Long) {
+        val settings = reportSettingsRepository.findById(guildId).orElse(null) ?: return
+        settings.reportChannelId = null
         reportSettingsRepository.save(settings)
     }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/ReportSettings.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/persistence/ReportSettings.kt
@@ -20,6 +20,9 @@ data class ReportSettings(
     @Column(name = "urgent_role_id")
     var urgentRoleId: Long? = null,
 
+    @Column(name = "report_channel_id")
+    var reportChannelId: Long? = null,
+
     @Column(name = "enabled")
     var enabled: Boolean = false,
 
@@ -41,5 +44,6 @@ data class ReportSettings(
 
     override fun hashCode(): Int = Hibernate.getClass(this).hashCode()
 
-    override fun toString(): String = "ReportSettings(guildId=$guildId, urgentRoleId=$urgentRoleId, enabled=$enabled)"
+    override fun toString(): String =
+        "ReportSettings(guildId=$guildId, urgentRoleId=$urgentRoleId, reportChannelId=$reportChannelId, enabled=$enabled)"
 }

--- a/src/main/resources/db/migration/V17__add_report_channel.sql
+++ b/src/main/resources/db/migration/V17__add_report_channel.sql
@@ -1,0 +1,2 @@
+alter table `report_settings`
+    add column `report_channel_id` bigint null;

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -234,6 +234,55 @@ class ReportMessageContextMenuTest {
     }
 
     @Test
+    fun `non-urgent report falls back to moderator log when configured report channel is unusable`() {
+        stubReport("Report Message")
+        whenever(event.replyModal(any())).thenReturn(modalAction)
+        whenever(reportSettingsService.getReportChannel(guild)).thenReturn(reportChannel)
+        whenever(reportSettingsService.canSendReportToConfiguredChannel(guild)).thenReturn(false)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).replyModal(argThat { id == "report:reason:1:123:456:99:false" })
+
+        stubReportReasonModal(urgent = false)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(guildLogger).logWithContent(
+            any<EmbedBuilder>(),
+            eq(targetUser),
+            eq(guild),
+            isNull<List<MessageEmbed>>(),
+            eq(GuildLogger.LogTypeAction.MODERATOR),
+            eq("@here")
+        )
+        verify(reportChannel, never()).sendMessage(any<MessageCreateData>())
+    }
+
+    @Test
+    fun `non-urgent report is rejected when configured report channel and moderator log are unusable`() {
+        stubReporterAndTargetIdsForModLogCheck("Report Message")
+        whenever(reportSettingsService.canSendReportToConfiguredChannel(guild)).thenReturn(false)
+        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(false)
+
+        command.onMessageContextInteraction(event)
+
+        verify(event).reply(
+            "Message reporting is not configured on this server. The bot needs a report channel or moderator log channel with permission to send messages and embeds."
+        )
+        verify(replyAction).queue()
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
+    }
+
+    @Test
     fun `urgent report logs to moderation channel with everyone ping`() {
         stubReport("Urgent Report Message")
         whenever(event.replyModal(any())).thenReturn(modalAction)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -204,6 +204,8 @@ class ReportMessageContextMenuTest {
         whenever(reportSettingsService.canSendReportToConfiguredChannel(guild)).thenReturn(true)
         whenever(reportChannel.sendMessage(any<MessageCreateData>()))
             .thenReturn(sendReportAction)
+        whenever(targetUser.id).thenReturn("2")
+        whenever(targetUser.effectiveAvatarUrl).thenReturn("https://example.invalid/avatar.png")
 
         command.onMessageContextInteraction(event)
 
@@ -213,7 +215,11 @@ class ReportMessageContextMenuTest {
 
         verify(reportChannel).sendMessage(
             argThat<MessageCreateData> {
-                content == "@here" && embeds.single().title == "Message report"
+                content == "@here" &&
+                    embeds.single().title == "Message report" &&
+                    embeds.single().timestamp != null &&
+                    embeds.single().footer?.text == "2" &&
+                    embeds.single().footer?.iconUrl == "https://example.invalid/avatar.png"
             }
         )
         verify(sendReportAction).queue()

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportMessageContextMenuTest.kt
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
@@ -18,16 +19,19 @@ import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.commands.Command
 import net.dv8tion.jda.api.interactions.modals.ModalMapping
 import net.dv8tion.jda.api.requests.RestAction
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageEditAction
 import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ModalCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
@@ -115,6 +119,12 @@ class ReportMessageContextMenuTest {
     private lateinit var messageChannel: MessageChannel
 
     @Mock
+    private lateinit var reportChannel: TextChannel
+
+    @Mock
+    private lateinit var sendReportAction: MessageCreateAction
+
+    @Mock
     private lateinit var retrieveMessageAction: RestAction<Message>
 
     @Mock
@@ -184,6 +194,37 @@ class ReportMessageContextMenuTest {
         verify(reportedMessageService).markReported(1L, 123L, 456L, urgent = false)
         verify(interactionHook).editOriginal("Your report has been sent to the moderation team.")
         verify(hookEditAction).queue()
+    }
+
+    @Test
+    fun `non-urgent report sends to configured report channel with here ping`() {
+        stubReport("Report Message")
+        whenever(event.replyModal(any())).thenReturn(modalAction)
+        whenever(reportSettingsService.getReportChannel(guild)).thenReturn(reportChannel)
+        whenever(reportSettingsService.canSendReportToConfiguredChannel(guild)).thenReturn(true)
+        whenever(reportChannel.sendMessage(any<MessageCreateData>()))
+            .thenReturn(sendReportAction)
+
+        command.onMessageContextInteraction(event)
+
+        stubReportReasonModal(urgent = false)
+
+        command.onModalInteraction(modalEvent)
+
+        verify(reportChannel).sendMessage(
+            argThat<MessageCreateData> {
+                content == "@here" && embeds.single().title == "Message report"
+            }
+        )
+        verify(sendReportAction).queue()
+        verify(guildLogger, never()).logWithContent(
+            any<EmbedBuilder>(),
+            any<User>(),
+            any<Guild>(),
+            isNull<List<MessageEmbed>>(),
+            any<GuildLogger.LogTypeAction>(),
+            any<String>()
+        )
     }
 
     @Test
@@ -617,7 +658,7 @@ class ReportMessageContextMenuTest {
         command.onMessageContextInteraction(event)
 
         verify(event).reply(
-            "Message reporting is not configured on this server. The bot needs a moderator log channel with permission to send messages and embeds."
+            "Message reporting is not configured on this server. The bot needs a report channel or moderator log channel with permission to send messages and embeds."
         )
         verify(replyAction).queue()
         verify(guildLogger, never()).logWithContent(
@@ -665,7 +706,7 @@ class ReportMessageContextMenuTest {
         whenever(reportSettingsService.isReportingEnabled(1L)).thenReturn(true)
         whenever(reportSettingsService.isUserBlocked(1L, 99L)).thenReturn(false)
         whenever(reportedMessageService.getState(1L, 123L, 456L)).thenReturn(existingState)
-        whenever(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
+        lenient().`when`(guildLogger.canSendModeratorLog(guild)).thenReturn(true)
         whenever(reportRateLimitService.hasActiveToken(1L, 99L)).thenReturn(false)
         if (retrieveMessage) {
             whenever(reportRateLimitService.tryConsume(1L, 99L)).thenReturn(true)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
@@ -6,6 +6,8 @@ import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.unions.GuildChannelUnion
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
@@ -49,6 +51,15 @@ class ReportSettingsCommandTest {
 
     @Mock
     private lateinit var roleOption: OptionMapping
+
+    @Mock
+    private lateinit var channelOption: OptionMapping
+
+    @Mock
+    private lateinit var channelUnion: GuildChannelUnion
+
+    @Mock
+    private lateinit var textChannel: TextChannel
 
     @Mock
     private lateinit var replyAction: ReplyCallbackAction
@@ -132,11 +143,44 @@ class ReportSettingsCommandTest {
     }
 
     @Test
-    fun `show displays reporting status, urgent role and blocked users`() {
+    fun `set channel stores report channel`() {
+        stubAuthorizedCommand("set-channel")
+        whenever(event.getOption("channel")).thenReturn(channelOption)
+        whenever(channelOption.asChannel).thenReturn(channelUnion)
+        whenever(channelUnion.asTextChannel()).thenReturn(textChannel)
+        whenever(textChannel.idLong).thenReturn(123L)
+        whenever(textChannel.asMention).thenReturn("<#123>")
+
+        command.onSlashCommandInteraction(event)
+
+        verify(reportSettingsService).setReportChannel(1L, 123L)
+        verify(event).reply("Message reports will now be sent to <#123>.")
+    }
+
+    @Test
+    fun `clear channel removes report channel`() {
+        stubAuthorizedCommand("clear-channel")
+
+        command.onSlashCommandInteraction(event)
+
+        verify(reportSettingsService).clearReportChannel(1L)
+        verify(event).reply("Report channel cleared. Reports will use the moderator log channel.")
+    }
+
+    @Test
+    fun `show displays reporting status, report channel, urgent role and blocked users`() {
         stubAuthorizedCommand("show")
         whenever(guild.name).thenReturn("Test Guild")
+        whenever(guild.getTextChannelById(123L)).thenReturn(textChannel)
+        whenever(textChannel.asMention).thenReturn("<#123>")
         whenever(reportSettingsService.getSettings(1L)).thenReturn(
-            ReportSettings(1L, urgentRoleId = 5L, enabled = true, blockedUserIds = mutableSetOf(99L))
+            ReportSettings(
+                1L,
+                urgentRoleId = 5L,
+                reportChannelId = 123L,
+                enabled = true,
+                blockedUserIds = mutableSetOf(99L)
+            )
         )
         whenever(reportSettingsService.getUrgentMention(guild)).thenReturn("<@&5>")
 
@@ -146,6 +190,7 @@ class ReportSettingsCommandTest {
         verify(event).reply(replyCaptor.capture())
         assertTrue(replyCaptor.firstValue.contains("Report settings for Test Guild"))
         assertTrue(replyCaptor.firstValue.contains("- Reporting: enabled"))
+        assertTrue(replyCaptor.firstValue.contains("- Report channel: <#123>"))
         assertTrue(replyCaptor.firstValue.contains("- Urgent mention: <@&5>"))
         assertTrue(replyCaptor.firstValue.contains("- Blocked users: <@99>"))
     }
@@ -177,7 +222,16 @@ class ReportSettingsCommandTest {
         assertEquals("reportsettings", commandData.name)
         assertEquals(setOf(InteractionContextType.GUILD), commandData.contexts)
         assertEquals(
-            listOf("show", "block-user", "allow-user", "set-urgent-role", "clear-urgent-role", "toggle"),
+            listOf(
+                "show",
+                "block-user",
+                "allow-user",
+                "set-urgent-role",
+                "clear-urgent-role",
+                "set-channel",
+                "clear-channel",
+                "toggle"
+            ),
             commandData.subcommands.map(SubcommandData::getName)
         )
     }

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsCommandTest.kt
@@ -145,6 +145,7 @@ class ReportSettingsCommandTest {
     @Test
     fun `set channel stores report channel`() {
         stubAuthorizedCommand("set-channel")
+        whenever(member.hasPermission(Permission.MANAGE_CHANNEL)).thenReturn(true)
         whenever(event.getOption("channel")).thenReturn(channelOption)
         whenever(channelOption.asChannel).thenReturn(channelUnion)
         whenever(channelUnion.asTextChannel()).thenReturn(textChannel)
@@ -158,13 +159,36 @@ class ReportSettingsCommandTest {
     }
 
     @Test
+    fun `set channel requires manage channel permission`() {
+        stubAuthorizedCommandWithoutGuildId("set-channel")
+        whenever(member.hasPermission(Permission.MANAGE_CHANNEL)).thenReturn(false)
+
+        command.onSlashCommandInteraction(event)
+
+        verify(event).reply("You need manage channel permission to use this command.")
+        verify(reportSettingsService, never()).setReportChannel(any(), any())
+    }
+
+    @Test
     fun `clear channel removes report channel`() {
         stubAuthorizedCommand("clear-channel")
+        whenever(member.hasPermission(Permission.MANAGE_CHANNEL)).thenReturn(true)
 
         command.onSlashCommandInteraction(event)
 
         verify(reportSettingsService).clearReportChannel(1L)
         verify(event).reply("Report channel cleared. Reports will use the moderator log channel.")
+    }
+
+    @Test
+    fun `clear channel requires manage channel permission`() {
+        stubAuthorizedCommandWithoutGuildId("clear-channel")
+        whenever(member.hasPermission(Permission.MANAGE_CHANNEL)).thenReturn(false)
+
+        command.onSlashCommandInteraction(event)
+
+        verify(event).reply("You need manage channel permission to use this command.")
+        verify(reportSettingsService, never()).clearReportChannel(any())
     }
 
     @Test
@@ -240,6 +264,11 @@ class ReportSettingsCommandTest {
         stubGuildCommand(subcommandName)
         whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
         whenever(guild.idLong).thenReturn(1L)
+    }
+
+    private fun stubAuthorizedCommandWithoutGuildId(subcommandName: String) {
+        stubGuildCommand(subcommandName)
+        whenever(member.hasPermission(Permission.MANAGE_ROLES)).thenReturn(true)
     }
 
     private fun stubGuildCommand(subcommandName: String) {

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ReportSettingsServiceTest.kt
@@ -4,6 +4,7 @@ import be.duncanc.discordmodbot.moderation.persistence.ReportSettings
 import be.duncanc.discordmodbot.moderation.persistence.ReportSettingsRepository
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -28,6 +29,9 @@ class ReportSettingsServiceTest {
 
     @Mock
     private lateinit var role: Role
+
+    @Mock
+    private lateinit var textChannel: TextChannel
 
     @Test
     fun `urgent mention falls back to everyone when role is not configured`() {
@@ -145,5 +149,40 @@ class ReportSettingsServiceTest {
         verify(reportSettingsRepository).save(settingsCaptor.capture())
         assertFalse(enabled)
         assertFalse(settingsCaptor.firstValue.enabled)
+    }
+
+    @Test
+    fun `setReportChannel creates settings and stores channel id`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+
+        service.setReportChannel(1L, 123L)
+
+        val settingsCaptor = argumentCaptor<ReportSettings>()
+        verify(reportSettingsRepository).save(settingsCaptor.capture())
+        assertEquals(123L, settingsCaptor.firstValue.reportChannelId)
+    }
+
+    @Test
+    fun `clearReportChannel without existing settings does not create a row`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(reportSettingsRepository.findById(1L)).thenReturn(Optional.empty())
+
+        service.clearReportChannel(1L)
+
+        verify(reportSettingsRepository, never()).save(any<ReportSettings>())
+    }
+
+    @Test
+    fun `getReportChannel returns configured text channel`() {
+        val service = ReportSettingsService(reportSettingsRepository)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guild.getTextChannelById(123L)).thenReturn(textChannel)
+        whenever(reportSettingsRepository.findById(1L))
+            .thenReturn(Optional.of(ReportSettings(1L, reportChannelId = 123L)))
+
+        val channel = service.getReportChannel(guild)
+
+        assertEquals(textChannel, channel)
     }
 }


### PR DESCRIPTION
Summary: add configurable message report channels via /reportsettings set-channel and clear-channel, with moderator log fallback. Testing: ./gradlew.bat test.