### PR TITLE
fix: add missing audit log reasons

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/JoinCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/JoinCommand.kt
@@ -171,7 +171,11 @@ class JoinCommand(
     private fun accept(member: Member) {
         val guild = member.guild
         memberGateService.getMemberRole(guild.idLong, member.jda)
-            ?.let { guild.addRoleToMember(member, it).queue() }
+            ?.let {
+                guild.addRoleToMember(member, it)
+                    .reason("Member gate auto-accept: no questions configured.")
+                    .queue()
+            }
     }
 
     private fun informMember(member: Member, question: String, answer: String, event: ModalInteractionEvent) {

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/MemberGateService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/MemberGateService.kt
@@ -192,18 +192,23 @@ class MemberGateService(
                     val noRoles = it.roles.isEmpty()
                     noRoles && reachedTimeLimit && notQueuedForApproval
                 }.forEach { member ->
+                    val reason =
+                        "You did not complete the server entry process within ${guildSettings.removeTimeHours} hour(s)"
                     val userKickNotification = EmbedBuilder()
                         .setColor(Color.RED)
                         .setTitle("${guild.name}: You have been kicked", null)
-                        .setDescription("Reason: You did not complete the server entry process within ${guildSettings.removeTimeHours} hour(s)")
+                        .setDescription("Reason: $reason")
                         .build()
                     member.user.openPrivateChannel().queue(
                         {
                             it.sendMessageEmbeds(userKickNotification)
-                                .queue({ guild.kick(member).queue() }, { guild.kick(member).queue() })
+                                .queue(
+                                    { guild.kick(member).reason(reason).queue() },
+                                    { guild.kick(member).reason(reason).queue() }
+                                )
                         },
                         {
-                            guild.kick(member).queue()
+                            guild.kick(member).reason(reason).queue()
                         })
                 }
             }

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
@@ -71,7 +71,8 @@ class ReviewManager(
 
         val member = guild.getMemberById(userId)
         if (member != null) {
-            memberGateService.getMemberRole(guild.idLong, jda)?.let { guild.addRoleToMember(member, it).queue() }
+            memberGateService.getMemberRole(guild.idLong, jda)
+                ?.let { guild.addRoleToMember(member, it).reason("Member gate approval.").queue() }
         }
 
         clearPendingQuestion(guild.idLong, jda, userId)

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/RemoveMuteCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/RemoveMuteCommand.kt
@@ -19,6 +19,7 @@ class RemoveMuteCommand(
         private const val COMMAND = "unmute"
         private const val DESCRIPTION = "This command will remove the muted role from a user."
         private const val OPTION_USER = "user"
+        private const val AUDIT_REASON = "User used /unmute slash command."
     }
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
@@ -55,7 +56,7 @@ class RemoveMuteCommand(
 
         event.deferReply(true).queue { hook ->
             val guild = event.guild!!
-            guild.removeRoleFromMember(targetMember, muteRole).queue({
+            guild.removeRoleFromMember(targetMember, muteRole).reason(AUDIT_REASON).queue({
                 hook.editOriginal("Unmuted ${targetMember.asMention}.").queue()
             }) { throwable ->
                 hook.editOriginal("Failed to unmute ${targetMember.asMention}: ${throwable.message}").queue()

--- a/src/main/kotlin/be/duncanc/discordmodbot/moderation/ScheduledUnmuteService.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/moderation/ScheduledUnmuteService.kt
@@ -116,7 +116,7 @@ class ScheduledUnmuteService(
     }
 
     private fun removeMute(guild: Guild, member: Member, scheduledUnmute: ScheduledUnmute, role: Role) {
-        guild.removeRoleFromMember(member, role).queue {
+        guild.removeRoleFromMember(member, role).reason("Mute expired").queue {
             scheduledUnmuteRepository.delete(scheduledUnmute)
             logUnmute(guild, member)
             informUserIsUnmuted(member)

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManagerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManagerTest.kt
@@ -148,11 +148,13 @@ class ReviewManagerTest {
         whenever(user.asMention).thenReturn("<@10>")
         whenever(memberGateService.getMemberRole(1L, jda)).thenReturn(role)
         whenever(guild.addRoleToMember(member, role)).thenReturn(addRoleAction)
+        whenever(addRoleAction.reason("Member gate approval.")).thenReturn(addRoleAction)
         whenever(promptRegistry.forget(1L, 10L)).thenReturn(null)
 
         val result = reviewManager.approve(guild, jda, 10L)
 
         assertEquals("Approved <@10>.", result)
+        verify(addRoleAction).reason("Member gate approval.")
         verify(addRoleAction).queue()
         verify(memberGateQuestionRepository).deleteById(MemberGateQuestion.createId(1L, 10L))
         verify(promptRegistry).forget(1L, 10L)

--- a/src/test/kotlin/be/duncanc/discordmodbot/moderation/ScheduledUnmuteServiceTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/moderation/ScheduledUnmuteServiceTest.kt
@@ -159,6 +159,7 @@ class ScheduledUnmuteServiceTest(
         whenever(jda.getGuildById(1)).thenReturn(guild)
         whenever(guild.getRoleById(1)).thenReturn(role)
         whenever(guild.removeRoleFromMember(member, role)).thenReturn(auditableRestAction)
+        whenever(auditableRestAction.reason("Mute expired")).thenReturn(auditableRestAction)
         whenever(guild.getMemberById(any<Long>())).thenReturn(member)
         // Act
         scheduledUnmuteService.performUnmute()
@@ -170,5 +171,6 @@ class ScheduledUnmuteServiceTest(
         verify(muteRolesRepository).findById(any())
         verify(guild).getRoleById(1)
         verify(guild).removeRoleFromMember(member, role)
+        verify(auditableRestAction).reason("Mute expired")
     }
 }


### PR DESCRIPTION
## Summary
- Add audit log reasons to missing kick and role-change actions
- Cover member gate approval, auto-accept, purge kick, manual unmute, and scheduled unmute paths
- Update tests to verify new audit reasons

## Testing
- ./gradlew test