### PR TITLE
feat(member-gate): add optional max-members limit to review queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,11 @@ Repository guidance for coding agents working in `DiscordModBot`.
   SPRING_DATASOURCE_DRIVERCLASSNAME=org.mariadb.jdbc.Driver \
   ./gradlew check
   ```
+  - On some machines Docker is Podman-backed: the `docker compose` v2 plugin is unavailable; use the standalone
+    `docker-compose` binary instead (e.g. `docker-compose up -d`).
+  - Environment variables do not invalidate Gradle's up-to-date checks, so a `check` run right after a plain
+    `./gradlew check` will skip `test` as UP-TO-DATE. Force re-execution with `./gradlew check --rerun-tasks` to
+    actually run the tests against MariaDB.
 - Prefer H2 unless changing DB-specific behavior.
 - Some tests (e.g. `GuildWarnPointRepositoryTest`) are `@Disabled` due to known Hibernate issues; leave them unless
   fixing the root cause.

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
@@ -88,6 +88,7 @@ class ReviewCommand(
             return
         }
 
+        reviewManager.pruneStaleApplicants(guild, event.jda)
         val maxMembers = event.getOption(OPTION_MAX_MEMBERS)?.asInt
         val session = reviewManager.createSession(guild.idLong, maxMembers)
         if (session == null) {
@@ -327,6 +328,7 @@ class ReviewCommand(
             return
         }
 
+        reviewManager.pruneStaleApplicants(guild, event.jda)
         val session = reviewManager.createSession(guild.idLong, confirmation.maxMembers)
         if (session == null) {
             event.editMessage("Nobody is currently waiting for approval.").setComponents(emptyList()).queue()
@@ -454,11 +456,17 @@ class ReviewCommand(
     }
 
     private fun logReviewStarted(guild: Guild, moderator: Member, session: ReviewSession) {
+        val sessionSize = session.toPendingUserIds().size
+        val totalPending = reviewManager.countPendingApplicants(guild.idLong)
         val logEmbed = EmbedBuilder()
             .setColor(Color.GREEN)
             .setTitle("Member gate review started")
             .addField("Moderator", moderator.nicknameAndUsername, false)
-            .addField("Pending applicants", session.toPendingUserIds().size.toString(), true)
+            .addField("Pending applicants", totalPending.toString(), true)
+
+        if (sessionSize != totalPending) {
+            logEmbed.addField("In this session", sessionSize.toString(), true)
+        }
 
         guildLogger.log(logEmbed, moderator.user, guild, null, GuildLogger.LogTypeAction.MODERATOR)
     }

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommand.kt
@@ -19,7 +19,9 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions
+import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
+import net.dv8tion.jda.api.interactions.commands.build.OptionData
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData
 import net.dv8tion.jda.api.utils.MarkdownUtil
 import net.dv8tion.jda.api.utils.TimeFormat
@@ -37,6 +39,7 @@ class ReviewCommand(
 ) : ListenerAdapter(), SlashCommand {
     companion object {
         private const val COMMAND = "review"
+        private const val OPTION_MAX_MEMBERS = "max-members"
         private const val BUTTON_PREFIX = "member-gate-review:"
         private const val INTERRUPT_CONFIRM_PREFIX = "member-gate-review-interrupt:"
         private const val APPROVE_ACTION = "approve"
@@ -62,6 +65,10 @@ class ReviewCommand(
             Commands.slash(COMMAND, "Review pending member gate applications")
                 .setContexts(InteractionContextType.GUILD)
                 .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_ROLES))
+                .addOptions(
+                    OptionData(OptionType.INTEGER, OPTION_MAX_MEMBERS, "Maximum number of members to review")
+                        .setMinValue(1)
+                )
         )
     }
 
@@ -81,7 +88,8 @@ class ReviewCommand(
             return
         }
 
-        val session = reviewManager.createSession(guild.idLong)
+        val maxMembers = event.getOption(OPTION_MAX_MEMBERS)?.asInt
+        val session = reviewManager.createSession(guild.idLong, maxMembers)
         if (session == null) {
             event.reply("Nobody is currently waiting for approval.").setEphemeral(true).queue()
             return
@@ -96,7 +104,7 @@ class ReviewCommand(
 
         val otherSessions = reviewSessionRegistry.getOtherSessions(guild.idLong, event.user.idLong)
         if (otherSessions.isNotEmpty()) {
-            val token = rememberInterruptConfirmation(guild.idLong, event.user.idLong, otherSessions)
+            val token = rememberInterruptConfirmation(guild.idLong, event.user.idLong, otherSessions, maxMembers)
             event.reply(buildInterruptPrompt(guild, otherSessions))
                 .setEphemeral(true)
                 .addComponents(ActionRow.of(buildInterruptButtons(token)))
@@ -230,7 +238,9 @@ class ReviewCommand(
         if (pendingQuestion == null) {
             logReviewCompleted(guild, event.member!!, session)
             reviewSessionRegistry.forget(guild.idLong, event.user.idLong)
-            event.editMessage(buildCompletionMessage(feedback)).setComponents(emptyList()).queue()
+            event.editMessage(buildCompletionMessage(feedback, reviewManager.hasPendingApplicants(guild.idLong)))
+                .setComponents(emptyList())
+                .queue()
             return
         }
 
@@ -247,7 +257,9 @@ class ReviewCommand(
         if (pendingQuestion == null) {
             logReviewCompleted(guild, event.member!!, session)
             reviewSessionRegistry.forget(guild.idLong, event.user.idLong)
-            event.editMessage(buildCompletionMessage(feedback)).setComponents(emptyList()).queue()
+            event.editMessage(buildCompletionMessage(feedback, reviewManager.hasPendingApplicants(guild.idLong)))
+                .setComponents(emptyList())
+                .queue()
             return
         }
 
@@ -315,7 +327,7 @@ class ReviewCommand(
             return
         }
 
-        val session = reviewManager.createSession(guild.idLong)
+        val session = reviewManager.createSession(guild.idLong, confirmation.maxMembers)
         if (session == null) {
             event.editMessage("Nobody is currently waiting for approval.").setComponents(emptyList()).queue()
             return
@@ -355,7 +367,8 @@ class ReviewCommand(
     private fun rememberInterruptConfirmation(
         guildId: Long,
         reviewerId: Long,
-        sessions: List<ReviewSessionRegistry.StoredReviewSession>
+        sessions: List<ReviewSessionRegistry.StoredReviewSession>,
+        maxMembers: Int? = null
     ): String {
         val token = UUID.randomUUID().toString().replace("-", "").take(12)
         reviewInterruptConfirmationRepository.save(
@@ -363,7 +376,8 @@ class ReviewCommand(
                 id = token,
                 guildId = guildId,
                 reviewerId = reviewerId,
-                targetSessionIds = sessions.associate { it.reviewerId to it.sessionId }
+                targetSessionIds = sessions.associate { it.reviewerId to it.sessionId },
+                maxMembers = maxMembers
             )
         )
         return token
@@ -407,8 +421,12 @@ class ReviewCommand(
                 "\nChoose `Approve`, `Reject`, or `Manual action`."
     }
 
-    private fun buildCompletionMessage(feedback: String): String {
-        return "$feedback\n\nThere are no more pending applicants in the queue."
+    private fun buildCompletionMessage(feedback: String, hasMoreApplicants: Boolean): String {
+        return if (hasMoreApplicants) {
+            "$feedback\n\nThere are still applicants waiting for approval. Run `/review` again to continue."
+        } else {
+            "$feedback\n\nThere are no more pending applicants in the queue."
+        }
     }
 
     private fun buildInterruptPrompt(

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
@@ -5,6 +5,9 @@ import be.duncanc.discordmodbot.member.gate.persistence.MemberGateQuestionReposi
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.exceptions.ErrorResponseException
+import net.dv8tion.jda.api.requests.ErrorResponse
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.TimeUnit
@@ -15,6 +18,10 @@ class ReviewManager(
     private val memberGateService: MemberGateService,
     private val promptRegistry: ReviewPromptRegistry
 ) {
+    companion object {
+        private val LOG = LoggerFactory.getLogger(ReviewManager::class.java)
+    }
+
     @Transactional(readOnly = true)
     fun createSession(guildId: Long, maxMembers: Int? = null): ReviewSession? {
         val storedQuestions = memberGateQuestionRepository.findAll()
@@ -36,8 +43,23 @@ class ReviewManager(
         memberGateQuestionRepository.findAll()
             .filterNotNull()
             .filter { it.guildId == guild.idLong && it.userId.toULong() > 0uL }
-            .filter { guild.getMemberById(it.userId) == null }
-            .forEach { clearPendingQuestion(guild.idLong, jda, it.userId) }
+            .forEach { question ->
+                guild.retrieveMemberById(question.userId).queue(
+                    { },
+                    { throwable ->
+                        if ((throwable as? ErrorResponseException)?.errorResponse == ErrorResponse.UNKNOWN_MEMBER) {
+                            clearPendingQuestion(guild.idLong, jda, question.userId)
+                        } else {
+                            LOG.warn(
+                                "Failed to check membership of {} in guild {}; keeping the pending question.",
+                                question.userId,
+                                guild.idLong,
+                                throwable
+                            )
+                        }
+                    }
+                )
+            }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
@@ -31,11 +31,27 @@ class ReviewManager(
         return pendingUserIds.takeIf { it.isNotEmpty() }?.let(::ReviewSession)
     }
 
+    @Transactional
+    fun pruneStaleApplicants(guild: Guild, jda: JDA) {
+        memberGateQuestionRepository.findAll()
+            .filterNotNull()
+            .filter { it.guildId == guild.idLong && it.userId.toULong() > 0uL }
+            .filter { guild.getMemberById(it.userId) == null }
+            .forEach { clearPendingQuestion(guild.idLong, jda, it.userId) }
+    }
+
     @Transactional(readOnly = true)
     fun hasPendingApplicants(guildId: Long): Boolean {
         return memberGateQuestionRepository.findAll()
             .filterNotNull()
             .any { it.guildId == guildId && it.userId.toULong() > 0uL }
+    }
+
+    @Transactional(readOnly = true)
+    fun countPendingApplicants(guildId: Long): Int {
+        return memberGateQuestionRepository.findAll()
+            .filterNotNull()
+            .count { it.guildId == guildId && it.userId.toULong() > 0uL }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManager.kt
@@ -16,7 +16,7 @@ class ReviewManager(
     private val promptRegistry: ReviewPromptRegistry
 ) {
     @Transactional(readOnly = true)
-    fun createSession(guildId: Long): ReviewSession? {
+    fun createSession(guildId: Long, maxMembers: Int? = null): ReviewSession? {
         val storedQuestions = memberGateQuestionRepository.findAll()
 
         val pendingUserIds = storedQuestions
@@ -25,9 +25,17 @@ class ReviewManager(
             .filter { it.guildId == guildId && it.userId.toULong() > 0uL }
             .sortedBy { it.queuedAt }
             .map { it.userId }
+            .take(maxMembers ?: Int.MAX_VALUE)
             .toList()
 
         return pendingUserIds.takeIf { it.isNotEmpty() }?.let(::ReviewSession)
+    }
+
+    @Transactional(readOnly = true)
+    fun hasPendingApplicants(guildId: Long): Boolean {
+        return memberGateQuestionRepository.findAll()
+            .filterNotNull()
+            .any { it.guildId == guildId && it.userId.toULong() > 0uL }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewInterruptConfirmation.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/member/gate/persistence/ReviewInterruptConfirmation.kt
@@ -9,5 +9,6 @@ data class ReviewInterruptConfirmation(
     val id: String,
     val guildId: Long,
     val reviewerId: Long,
-    val targetSessionIds: Map<Long, String>
+    val targetSessionIds: Map<Long, String>,
+    val maxMembers: Int? = null
 )

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
@@ -15,6 +15,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -263,6 +264,98 @@ class ReviewCommandTest {
     }
 
     @Test
+    fun `starting review with max members passes the limit to session creation`() {
+        stubSlashReviewStart()
+        stubModeratorName()
+
+        val maxMembersOption = mock<OptionMapping>()
+        whenever(maxMembersOption.asInt).thenReturn(2)
+        whenever(slashEvent.getOption("max-members")).thenReturn(maxMembersOption)
+
+        val session = ReviewSession(listOf(10L, 20L))
+        whenever(reviewManager.createSession(1L, 2)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        stubApplicantPresent(10L, "<@10>")
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verify(reviewManager).createSession(1L, 2)
+        verify(reviewSessionRegistry).remember(eq(1L), eq(99L), same(session))
+        val messageCaptor = argumentCaptor<String>()
+        verify(slashEvent).reply(messageCaptor.capture())
+        assertTrue(messageCaptor.firstValue.contains("Applicant: <@10> (`10`)"))
+    }
+
+    @Test
+    fun `confirming interruption carries the max members limit over to the new session`() {
+        stubInterruptButtonInteraction("member-gate-review-interrupt:confirm:token")
+        stubModeratorName()
+        stubButtonEditWithActionRow()
+
+        val storedSession = ReviewSessionRegistry.StoredReviewSession(
+            reviewerId = 42L,
+            session = ReviewSession(listOf(50L), sessionId = "session-42"),
+            sessionId = "session-42",
+            updatedAt = Instant.parse("2026-06-28T12:00:00Z")
+        )
+        whenever(reviewInterruptConfirmationRepository.findById("token")).thenReturn(
+            Optional.of(
+                ReviewInterruptConfirmation(
+                    id = "token",
+                    guildId = 1L,
+                    reviewerId = 99L,
+                    targetSessionIds = mapOf(42L to "session-42"),
+                    maxMembers = 5
+                )
+            )
+        )
+        whenever(reviewSessionRegistry.getOtherSessions(1L, 99L)).thenReturn(listOf(storedSession))
+        whenever(reviewSessionRegistry.forgetSessions(1L, setOf(42L))).thenReturn(listOf(storedSession))
+
+        val session = ReviewSession(listOf(10L))
+        whenever(reviewManager.createSession(1L, 5)).thenReturn(session)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        whenever(guild.getMemberById(42L)).thenReturn(null)
+        stubApplicantPresent(10L, "<@10>")
+
+        command.onButtonInteraction(buttonEvent)
+
+        verify(reviewManager).createSession(1L, 5)
+        verify(reviewSessionRegistry).remember(eq(1L), eq(99L), same(session))
+    }
+
+    @Test
+    fun `approve completion mentions remaining applicants when more are waiting`() {
+        stubSlashReviewStart()
+        stubApproveButtonInteraction()
+        stubButtonEditWithList()
+
+        val session = ReviewSession(listOf(10L))
+        whenever(reviewManager.createSession(1L)).thenReturn(session)
+        whenever(reviewSessionRegistry.get(1L, 99L)).thenReturn(null, session)
+        stubModeratorName()
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        stubApplicantPresent(10L, "<@10>")
+        whenever(reviewManager.approve(eq(guild), eq(jda), eq(10L))).thenReturn("Approved <@10>.")
+        whenever(reviewManager.hasPendingApplicants(1L)).thenReturn(true)
+
+        command.onSlashCommandInteraction(slashEvent)
+        command.onButtonInteraction(buttonEvent)
+
+        val messageCaptor = argumentCaptor<String>()
+        verify(buttonEvent).editMessage(messageCaptor.capture())
+        val completionMessage = messageCaptor.allValues.last()
+        assertTrue(completionMessage.contains("Approved <@10>."))
+        assertTrue(completionMessage.contains("There are still applicants waiting for approval. Run `/review` again to continue."))
+    }
+
+    @Test
     fun `starting review again continues existing moderator session`() {
         stubSlashReviewCommand()
 
@@ -283,7 +376,7 @@ class ReviewCommandTest {
         verify(slashEvent).reply(messageCaptor.capture())
         assertTrue(messageCaptor.firstValue.contains("Applicant: <@20> (`20`)"))
         assertTrue(messageCaptor.firstValue.contains("Continuing with the next pending applicant."))
-        verify(reviewManager, never()).createSession(any())
+        verify(reviewManager, never()).createSession(any(), anyOrNull())
         verify(reviewSessionRegistry, never()).forgetOtherSessions(any(), any())
         verify(reviewSessionRegistry).remember(eq(1L), eq(99L), same(storedSession))
         verify(guildLogger, never()).log(
@@ -455,7 +548,7 @@ class ReviewCommandTest {
         verify(buttonEvent).editMessage("The active review sessions changed. Run `/review` again to confirm the current sessions.")
         verify(reviewInterruptConfirmationRepository).deleteById("token")
         verify(reviewSessionRegistry, never()).forgetSessions(any(), any())
-        verify(reviewManager, never()).createSession(any())
+        verify(reviewManager, never()).createSession(any(), anyOrNull())
     }
 
     @Test
@@ -495,7 +588,7 @@ class ReviewCommandTest {
         verify(buttonEvent).editMessage("The active review sessions changed. Run `/review` again to confirm the current sessions.")
         verify(reviewInterruptConfirmationRepository).deleteById("token")
         verify(reviewSessionRegistry, never()).forgetSessions(any(), any())
-        verify(reviewManager, never()).createSession(any())
+        verify(reviewManager, never()).createSession(any(), anyOrNull())
     }
 
     @Test
@@ -571,7 +664,7 @@ class ReviewCommandTest {
         verify(buttonEvent).editMessage("Review start cancelled. The other moderator's review session was not interrupted.")
         verify(reviewInterruptConfirmationRepository).deleteById("token")
         verify(reviewSessionRegistry, never()).forgetOtherSessions(any(), any())
-        verify(reviewManager, never()).createSession(any())
+        verify(reviewManager, never()).createSession(any(), anyOrNull())
     }
 
     @Test

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewCommandTest.kt
@@ -253,6 +253,7 @@ class ReviewCommandTest {
 
         val session = ReviewSession(listOf(10L, 20L))
         whenever(reviewManager.createSession(1L)).thenReturn(session)
+        whenever(reviewManager.countPendingApplicants(1L)).thenReturn(2)
         whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
             pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
         )
@@ -282,10 +283,34 @@ class ReviewCommandTest {
         command.onSlashCommandInteraction(slashEvent)
 
         verify(reviewManager).createSession(1L, 2)
+        verify(reviewManager).pruneStaleApplicants(guild, jda)
         verify(reviewSessionRegistry).remember(eq(1L), eq(99L), same(session))
         val messageCaptor = argumentCaptor<String>()
         verify(slashEvent).reply(messageCaptor.capture())
         assertTrue(messageCaptor.firstValue.contains("Applicant: <@10> (`10`)"))
+    }
+
+    @Test
+    fun `starting review with max members logs queue total and session size`() {
+        stubSlashReviewStart()
+        stubModeratorName()
+
+        val maxMembersOption = mock<OptionMapping>()
+        whenever(maxMembersOption.asInt).thenReturn(2)
+        whenever(slashEvent.getOption("max-members")).thenReturn(maxMembersOption)
+
+        val session = ReviewSession(listOf(10L, 20L))
+        whenever(reviewManager.createSession(1L, 2)).thenReturn(session)
+        whenever(reviewManager.countPendingApplicants(1L)).thenReturn(3)
+        whenever(reviewManager.getPendingQuestion(1L, 10L)).thenReturn(
+            pendingQuestion(guildId = 1L, userId = 10L, question = "Q1", answer = "A1", queuedAt = 10L)
+        )
+        stubApplicantPresent(10L, "<@10>")
+
+        command.onSlashCommandInteraction(slashEvent)
+
+        verifyReviewLog("Member gate review started", "Pending applicants", "3")
+        verifyReviewLog("Member gate review started", "In this session", "2")
     }
 
     @Test
@@ -352,7 +377,8 @@ class ReviewCommandTest {
         verify(buttonEvent).editMessage(messageCaptor.capture())
         val completionMessage = messageCaptor.allValues.last()
         assertTrue(completionMessage.contains("Approved <@10>."))
-        assertTrue(completionMessage.contains("There are still applicants waiting for approval. Run `/review` again to continue."))
+        val expectedMessage = "There are still applicants waiting for approval. Run `/review` again to continue."
+        assertTrue(completionMessage.contains(expectedMessage))
     }
 
     @Test

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManagerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManagerTest.kt
@@ -139,6 +139,42 @@ class ReviewManagerTest {
     }
 
     @Test
+    fun `countPendingApplicants counts only the guild's queued applicants`() {
+        val repositoryEntries = listOf(
+            pendingQuestion(guildId = 1L, userId = 10L, queuedAt = 10L, question = "Q1", answer = "A1"),
+            pendingQuestion(guildId = 1L, userId = 20L, queuedAt = 20L, question = "Q2", answer = "A2"),
+            pendingQuestion(guildId = 2L, userId = 99L, queuedAt = 5L, question = "QX", answer = "AX")
+        )
+        whenever(memberGateQuestionRepository.findAll()).thenReturn(repositoryEntries)
+
+        assertEquals(2, reviewManager.countPendingApplicants(1L))
+    }
+
+    @Test
+    fun `pruneStaleApplicants removes only applicants who left the guild`() {
+        val staleQuestion = pendingQuestion(guildId = 1L, userId = 20L, queuedAt = 20L, question = "Q2", answer = "A2")
+        val repositoryEntries = listOf(
+            pendingQuestion(guildId = 1L, userId = 10L, queuedAt = 10L, question = "Q1", answer = "A1"),
+            staleQuestion,
+            pendingQuestion(guildId = 2L, userId = 99L, queuedAt = 5L, question = "QX", answer = "AX")
+        )
+        whenever(memberGateQuestionRepository.findAll()).thenReturn(repositoryEntries)
+        whenever(memberGateQuestionRepository.findById(MemberGateQuestion.createId(1L, 20L))).thenReturn(
+            Optional.of(staleQuestion)
+        )
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(guild.getMemberById(10L)).thenReturn(member)
+        whenever(guild.getMemberById(20L)).thenReturn(null)
+        whenever(promptRegistry.forget(1L, 20L)).thenReturn(null)
+
+        reviewManager.pruneStaleApplicants(guild, jda)
+
+        verify(memberGateQuestionRepository).deleteById(MemberGateQuestion.createId(1L, 20L))
+        verify(memberGateQuestionRepository, never()).deleteById(MemberGateQuestion.createId(1L, 10L))
+        verify(memberGateQuestionRepository, never()).deleteById(MemberGateQuestion.createId(2L, 99L))
+    }
+
+    @Test
     fun `getPendingQuestion uses guild scoped redis id`() {
         val question = pendingQuestion(guildId = 1L, userId = 10L, queuedAt = 10L, question = "Q1", answer = "A1")
         whenever(memberGateQuestionRepository.findById(MemberGateQuestion.createId(1L, 10L))).thenReturn(Optional.of(question))

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManagerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManagerTest.kt
@@ -103,6 +103,42 @@ class ReviewManagerTest {
     }
 
     @Test
+    fun `createSession limits the session to the oldest max members`() {
+        val repositoryEntries = listOf(
+            pendingQuestion(guildId = 1L, userId = 30L, queuedAt = 30L, question = "Q3", answer = "A3"),
+            pendingQuestion(guildId = 1L, userId = 10L, queuedAt = 10L, question = "Q1", answer = "A1"),
+            pendingQuestion(guildId = 1L, userId = 20L, queuedAt = 20L, question = "Q2", answer = "A2")
+        )
+        whenever(memberGateQuestionRepository.findAll()).thenReturn(repositoryEntries)
+
+        val session = reviewManager.createSession(1L, 2)
+
+        assertEquals(10L, session?.getCurrentUserId())
+        assertEquals(20L, session?.advanceAfterReview())
+        assertNull(session?.advanceAfterReview())
+    }
+
+    @Test
+    fun `hasPendingApplicants returns true when the guild has queued applicants`() {
+        val repositoryEntries = listOf(
+            pendingQuestion(guildId = 1L, userId = 10L, queuedAt = 10L, question = "Q1", answer = "A1")
+        )
+        whenever(memberGateQuestionRepository.findAll()).thenReturn(repositoryEntries)
+
+        assertEquals(true, reviewManager.hasPendingApplicants(1L))
+    }
+
+    @Test
+    fun `hasPendingApplicants returns false when the guild has no queued applicants`() {
+        val repositoryEntries = listOf(
+            pendingQuestion(guildId = 2L, userId = 10L, queuedAt = 10L, question = "Q1", answer = "A1")
+        )
+        whenever(memberGateQuestionRepository.findAll()).thenReturn(repositoryEntries)
+
+        assertEquals(false, reviewManager.hasPendingApplicants(1L))
+    }
+
+    @Test
     fun `getPendingQuestion uses guild scoped redis id`() {
         val question = pendingQuestion(guildId = 1L, userId = 10L, queuedAt = 10L, question = "Q1", answer = "A1")
         whenever(memberGateQuestionRepository.findById(MemberGateQuestion.createId(1L, 10L))).thenReturn(Optional.of(question))

--- a/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManagerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/member/gate/ReviewManagerTest.kt
@@ -8,7 +8,11 @@ import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Role
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.exceptions.ErrorResponseException
+import net.dv8tion.jda.api.requests.ErrorResponse
+import net.dv8tion.jda.api.requests.Response
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction
+import net.dv8tion.jda.api.requests.restaction.CacheRestAction
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -19,6 +23,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.*
 import java.util.*
+import java.util.function.Consumer
 
 @ExtendWith(MockitoExtension::class)
 class ReviewManagerTest {
@@ -163,8 +168,20 @@ class ReviewManagerTest {
             Optional.of(staleQuestion)
         )
         whenever(guild.idLong).thenReturn(1L)
-        whenever(guild.getMemberById(10L)).thenReturn(member)
-        whenever(guild.getMemberById(20L)).thenReturn(null)
+        val presentMemberAction = mock<CacheRestAction<Member>>()
+        whenever(guild.retrieveMemberById(10L)).thenReturn(presentMemberAction)
+        doAnswer { invocation ->
+            invocation.component1<Consumer<Member>>().accept(member)
+            null
+        }.whenever(presentMemberAction).queue(any(), any())
+        val missingMemberAction = mock<CacheRestAction<Member>>()
+        whenever(guild.retrieveMemberById(20L)).thenReturn(missingMemberAction)
+        doAnswer { invocation ->
+            invocation.component2<Consumer<Throwable>>().accept(
+                ErrorResponseException.create(ErrorResponse.UNKNOWN_MEMBER, Response(10007L, emptySet<String>()))
+            )
+            null
+        }.whenever(missingMemberAction).queue(any(), any())
         whenever(promptRegistry.forget(1L, 20L)).thenReturn(null)
 
         reviewManager.pruneStaleApplicants(guild, jda)
@@ -172,6 +189,27 @@ class ReviewManagerTest {
         verify(memberGateQuestionRepository).deleteById(MemberGateQuestion.createId(1L, 20L))
         verify(memberGateQuestionRepository, never()).deleteById(MemberGateQuestion.createId(1L, 10L))
         verify(memberGateQuestionRepository, never()).deleteById(MemberGateQuestion.createId(2L, 99L))
+    }
+
+    @Test
+    fun `pruneStaleApplicants keeps applicants when member retrieval fails transiently`() {
+        val repositoryEntries = listOf(
+            pendingQuestion(guildId = 1L, userId = 20L, queuedAt = 20L, question = "Q2", answer = "A2")
+        )
+        whenever(memberGateQuestionRepository.findAll()).thenReturn(repositoryEntries)
+        whenever(guild.idLong).thenReturn(1L)
+        val failingMemberAction = mock<CacheRestAction<Member>>()
+        whenever(guild.retrieveMemberById(20L)).thenReturn(failingMemberAction)
+        doAnswer { invocation ->
+            invocation.component2<Consumer<Throwable>>().accept(
+                ErrorResponseException.create(ErrorResponse.SERVER_ERROR, Response(500L, emptySet<String>()))
+            )
+            null
+        }.whenever(failingMemberAction).queue(any(), any())
+
+        reviewManager.pruneStaleApplicants(guild, jda)
+
+        verify(memberGateQuestionRepository, never()).deleteById(MemberGateQuestion.createId(1L, 20L))
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional `max-members` limit to `/review`, allowing moderators to review a selected number of applicants at a time.
  - Preserved the limit when a review is interrupted and resumed.
  - Added clearer completion messages when additional applicants remain in the queue.

- **Bug Fixes**
  - Automatically removes applicants who are no longer members of the server before reviews begin.

- **Documentation**
  - Clarified Docker Compose and Gradle test-environment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->