### PR TITLE
feat(logging): include reply links in deletion logs

### DIFF
--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -45,6 +45,7 @@ import java.util.*
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 /**
@@ -231,6 +232,9 @@ class GuildLogger
                 logEmbed.setColor(LIGHT_BLUE)
             }
             logEmbed.addField("Message URL", "[Link](${oldMessage.jumpUrl})", false)
+            oldMessage.repliedToUrl?.let {
+                logEmbed.addField("Replied to", "[Link]($it)", false)
+            }
             oldMessage.emotes?.let {
                 logEmbed.addField("Emote(s)", oldMessage.emotes, false)
             }
@@ -323,34 +327,43 @@ class GuildLogger
             .setTitle("#" + event.channel.name + ": Bulk delete")
             .addField("Amount of deleted messages", event.messageIds.size.toString(), false)
 
-        val logWriter = StringBuilder(event.channel.toString()).append("\n")
-
-        var messageLogged = false
-        event.messageIds.forEach { id ->
+        val messages = event.messageIds.mapNotNull { id ->
             val idLong = java.lang.Long.parseUnsignedLong(id)
-            val message = messageHistory.getMessage(event.channel.idLong, idLong)
-            if (message != null) {
-                messageLogged = true
-                event.jda.retrieveUserById(message.userId).queue { user ->
-                    logWriter.append(user.toString()).append(":\n").append(message.content).append("\n\n")
-                    val attachmentString = messageHistory.getAttachmentsString(idLong)
-                    if (attachmentString != null) {
-                        logWriter.append("Attachment(s):\n").append(attachmentString).append("\n")
-                    } else {
-                        logWriter.append("\n")
-                    }
-                    message.emotes?.let {
-                        logWriter.append("Emote(s):\n")
-                        logWriter.append(it)
-                    }
+            messageHistory.getMessage(event.channel.idLong, idLong)?.let { message ->
+                idLong to message
+            }
+        }
+        if (messages.isEmpty()) {
+            return
+        }
+
+        val remainingLookups = AtomicInteger(messages.size)
+        val entries = arrayOfNulls<String>(messages.size)
+        messages.forEachIndexed { index, (id, message) ->
+            event.jda.retrieveUserById(message.userId).queue { user ->
+                val entry = StringBuilder(user.toString()).append(":\n").append(message.content).append("\n\n")
+                val attachmentString = messageHistory.getAttachmentsString(id)
+                if (attachmentString != null) {
+                    entry.append("Attachment(s):\n").append(attachmentString).append("\n")
+                } else {
+                    entry.append("\n")
+                }
+                message.repliedToUrl?.let {
+                    entry.append("Replied to:\n").append(it).append("\n")
+                }
+                message.emotes?.let {
+                    entry.append("Emote(s):\n").append(it)
+                }
+                entries[index] = entry.toString()
+
+                if (remainingLookups.decrementAndGet() == 0) {
+                    val logWriter = StringBuilder(event.channel.toString()).append("\n")
+                    entries.filterNotNull().forEach { logWriter.append(it).append("\n") }
+                    logWriter.append("Logged on ").append(OffsetDateTime.now().toString())
+                    logBulkDelete(event, logEmbed, logWriter.toString().toByteArray())
                 }
             }
         }
-        if (messageLogged) {
-            logWriter.append("Logged on ").append(OffsetDateTime.now().toString())
-            logBulkDelete(event, logEmbed, logWriter.toString().toByteArray())
-        }
-
     }
 
     private fun logBulkDelete(event: MessageBulkDeleteEvent, logEmbed: EmbedBuilder, bytes: ByteArray) {

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/GuildLogger.kt
@@ -340,8 +340,8 @@ class GuildLogger
         val remainingLookups = AtomicInteger(messages.size)
         val entries = arrayOfNulls<String>(messages.size)
         messages.forEachIndexed { index, (id, message) ->
-            event.jda.retrieveUserById(message.userId).queue { user ->
-                val entry = StringBuilder(user.toString()).append(":\n").append(message.content).append("\n\n")
+            fun completeLookup(author: String) {
+                val entry = StringBuilder(author).append(":\n").append(message.content).append("\n\n")
                 val attachmentString = messageHistory.getAttachmentsString(id)
                 if (attachmentString != null) {
                     entry.append("Attachment(s):\n").append(attachmentString).append("\n")
@@ -363,6 +363,11 @@ class GuildLogger
                     logBulkDelete(event, logEmbed, logWriter.toString().toByteArray())
                 }
             }
+
+            event.jda.retrieveUserById(message.userId).queue(
+                { user -> completeLookup(user.toString()) },
+                { completeLookup(message.userId.toString()) }
+            )
         }
     }
 

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageHistory.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/MessageHistory.kt
@@ -3,6 +3,7 @@ package be.duncanc.discordmodbot.logging
 import be.duncanc.discordmodbot.logging.persistence.DiscordMessage
 import be.duncanc.discordmodbot.logging.persistence.DiscordMessageRepository
 import net.dv8tion.jda.api.entities.emoji.CustomEmoji
+import net.dv8tion.jda.api.entities.MessageReference.MessageReferenceType
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.events.message.MessageUpdateEvent
 import org.springframework.beans.factory.annotation.Autowired
@@ -45,7 +46,14 @@ constructor(
             message.channel.idLong,
             message.author.idLong,
             messageContentEncryptor.encrypt(message.contentDisplay),
-            linkEmotes(message.mentions.customEmojis)
+            linkEmotes(message.mentions.customEmojis),
+            message.messageReference?.takeIf { it.type == MessageReferenceType.DEFAULT }?.let { reference ->
+                reference.messageIdLong.takeIf {
+                    it != 0L && reference.guildIdLong != 0L && reference.channelIdLong != 0L
+                }?.let { messageId ->
+                    "https://discord.com/channels/${reference.guildIdLong}/${reference.channelIdLong}/$messageId"
+                }
+            }
         )
         discordMessageRepository.save(discordMessage)
         if (message.attachments.size > 0) {
@@ -72,7 +80,8 @@ constructor(
                 message.channel.idLong,
                 message.author.idLong,
                 messageContentEncryptor.encrypt(message.contentDisplay),
-                existingMessage?.emotes
+                existingMessage?.emotes,
+                existingMessage?.repliedToUrl
             )
             discordMessageRepository.save(discordMessage)
         }

--- a/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/DiscordMessage.kt
+++ b/src/main/kotlin/be/duncanc/discordmodbot/logging/persistence/DiscordMessage.kt
@@ -13,7 +13,8 @@ data class DiscordMessage(
     val channelId: Long,
     val userId: Long,
     val content: String,
-    val emotes: String? = null
+    val emotes: String? = null,
+    val repliedToUrl: String? = null
 ) {
     @Transient
     val jumpUrl = "https://discord.com/channels/$guildId/$channelId/$messageId"

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/GuildLoggerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/GuildLoggerTest.kt
@@ -234,7 +234,7 @@ class GuildLoggerTest {
         doAnswer { invocation ->
             invocation.component1<Consumer<User>>().accept(user)
             null
-        }.whenever(retrieveUserAction).queue(any())
+        }.whenever(retrieveUserAction).queue(any(), any())
         whenever(loggingSettingsRepository.findById(1L)).thenReturn(
             Optional.of(LoggingSettings(1L, userLogChannel = 30L))
         )
@@ -247,6 +247,43 @@ class GuildLoggerTest {
         verify(logChannel, timeout(1000)).sendFiles(fileCaptor.capture())
         val logContent = fileCaptor.firstValue.data.use { it.readBytes().toString(Charsets.UTF_8) }
         assertTrue(logContent.contains("Replied to:\nhttps://discord.com/channels/1/10/50"))
+    }
+
+    @Test
+    fun `bulk deleted message log is produced when author lookup fails`() {
+        val guildLogger = guildLogger()
+        val oldMessage = DiscordMessage(
+            messageId = 100L,
+            guildId = 1L,
+            channelId = 10L,
+            userId = 20L,
+            content = "deleted content"
+        )
+        whenever(bulkDeleteEvent.guild).thenReturn(guild)
+        whenever(bulkDeleteEvent.channel).thenReturn(bulkChannel)
+        whenever(bulkDeleteEvent.jda).thenReturn(jda)
+        whenever(bulkDeleteEvent.messageIds).thenReturn(listOf("100"))
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(bulkChannel.idLong).thenReturn(10L)
+        whenever(bulkChannel.name).thenReturn("general")
+        whenever(messageHistory.getMessage(10L, 100L)).thenReturn(oldMessage)
+        whenever(jda.retrieveUserById(20L)).thenReturn(retrieveUserAction)
+        doAnswer { invocation ->
+            invocation.component2<Consumer<Throwable>>().accept(RuntimeException("lookup failed"))
+            null
+        }.whenever(retrieveUserAction).queue(any(), any())
+        whenever(loggingSettingsRepository.findById(1L)).thenReturn(
+            Optional.of(LoggingSettings(1L, userLogChannel = 30L))
+        )
+        whenever(guild.getTextChannelById(30L)).thenReturn(logChannel)
+        whenever(logChannel.sendFiles(any<FileUpload>())).thenReturn(sendAction)
+
+        guildLogger.onMessageBulkDelete(bulkDeleteEvent)
+
+        val fileCaptor = argumentCaptor<FileUpload>()
+        verify(logChannel, timeout(1000)).sendFiles(fileCaptor.capture())
+        val logContent = fileCaptor.firstValue.data.use { it.readBytes().toString(Charsets.UTF_8) }
+        assertTrue(logContent.contains("20:\ndeleted content"))
     }
 
     private fun guildLogger(): GuildLogger {

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/GuildLoggerTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/GuildLoggerTest.kt
@@ -1,19 +1,40 @@
 package be.duncanc.discordmodbot.logging
 
+import be.duncanc.discordmodbot.logging.persistence.DiscordMessage
 import be.duncanc.discordmodbot.logging.persistence.LoggingSettings
 import be.duncanc.discordmodbot.logging.persistence.LoggingSettingsRepository
 import net.dv8tion.jda.api.Permission
+import net.dv8tion.jda.api.JDA
+import net.dv8tion.jda.api.audit.AuditLogEntry
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.SelfMember
+import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion
+import net.dv8tion.jda.api.events.message.MessageBulkDeleteEvent
+import net.dv8tion.jda.api.events.message.MessageDeleteEvent
+import net.dv8tion.jda.api.requests.restaction.CacheRestAction
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
+import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction
+import net.dv8tion.jda.api.requests.restaction.pagination.PaginationAction
+import net.dv8tion.jda.api.utils.FileUpload
+import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.timeout
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Optional
+import java.util.function.Consumer
 
 @ExtendWith(MockitoExtension::class)
 class GuildLoggerTest {
@@ -33,7 +54,40 @@ class GuildLoggerTest {
     private lateinit var textChannel: TextChannel
 
     @Mock
+    private lateinit var channel: MessageChannelUnion
+
+    @Mock
+    private lateinit var bulkChannel: GuildMessageChannelUnion
+
+    @Mock
     private lateinit var selfMember: SelfMember
+
+    @Mock
+    private lateinit var event: MessageDeleteEvent
+
+    @Mock
+    private lateinit var bulkDeleteEvent: MessageBulkDeleteEvent
+
+    @Mock
+    private lateinit var jda: JDA
+
+    @Mock
+    private lateinit var user: User
+
+    @Mock
+    private lateinit var auditLogs: AuditLogPaginationAction
+
+    @Mock
+    private lateinit var auditLogIterator: PaginationAction.PaginationIterator<AuditLogEntry>
+
+    @Mock
+    private lateinit var retrieveUserAction: CacheRestAction<User>
+
+    @Mock
+    private lateinit var logChannel: TextChannel
+
+    @Mock
+    private lateinit var sendAction: MessageCreateAction
 
     @Test
     fun `canSendModeratorLog returns false when no logging settings exist`() {
@@ -113,6 +167,86 @@ class GuildLoggerTest {
         val canSend = guildLogger.canSendModeratorLog(guild)
 
         assertTrue(canSend)
+    }
+
+    @Test
+    fun `deleted message log includes the replied to URL`() {
+        val guildLogger = guildLogger()
+        val oldMessage = DiscordMessage(
+            messageId = 100L,
+            guildId = 1L,
+            channelId = 10L,
+            userId = 20L,
+            content = "deleted content",
+            repliedToUrl = "https://discord.com/channels/1/10/50"
+        )
+        whenever(event.guild).thenReturn(guild)
+        whenever(event.channel).thenReturn(channel)
+        whenever(event.jda).thenReturn(jda)
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(channel.idLong).thenReturn(10L)
+        whenever(channel.name).thenReturn("general")
+        whenever(guild.retrieveAuditLogs()).thenReturn(auditLogs)
+        whenever(auditLogs.cache(false)).thenReturn(auditLogs)
+        whenever(auditLogs.limit(5)).thenReturn(auditLogs)
+        whenever(auditLogs.iterator()).thenReturn(auditLogIterator)
+        whenever(auditLogIterator.hasNext()).thenReturn(false)
+        whenever(jda.retrieveUserById(20L)).thenReturn(retrieveUserAction)
+        whenever(user.name).thenReturn("user")
+        doAnswer { invocation ->
+            invocation.component1<Consumer<User>>().accept(user)
+            null
+        }.whenever(retrieveUserAction).queue(any())
+        whenever(loggingSettingsRepository.findById(1L)).thenReturn(
+            Optional.of(LoggingSettings(1L, userLogChannel = 30L))
+        )
+        whenever(guild.getTextChannelById(30L)).thenReturn(logChannel)
+        whenever(logChannel.sendMessage(any<MessageCreateData>())).thenReturn(sendAction)
+
+        guildLogger.logDeletedMessage(event, oldMessage, null)
+
+        val messageCaptor = argumentCaptor<MessageCreateData>()
+        verify(logChannel).sendMessage(messageCaptor.capture())
+        val repliedToField = messageCaptor.firstValue.embeds.single().fields.first { it.name == "Replied to" }
+        assertEquals("[Link](https://discord.com/channels/1/10/50)", repliedToField.value)
+    }
+
+    @Test
+    fun `bulk deleted message log includes the replied to URL`() {
+        val guildLogger = guildLogger()
+        val oldMessage = DiscordMessage(
+            messageId = 100L,
+            guildId = 1L,
+            channelId = 10L,
+            userId = 20L,
+            content = "deleted content",
+            repliedToUrl = "https://discord.com/channels/1/10/50"
+        )
+        whenever(bulkDeleteEvent.guild).thenReturn(guild)
+        whenever(bulkDeleteEvent.channel).thenReturn(bulkChannel)
+        whenever(bulkDeleteEvent.jda).thenReturn(jda)
+        whenever(bulkDeleteEvent.messageIds).thenReturn(listOf("100"))
+        whenever(guild.idLong).thenReturn(1L)
+        whenever(bulkChannel.idLong).thenReturn(10L)
+        whenever(bulkChannel.name).thenReturn("general")
+        whenever(messageHistory.getMessage(10L, 100L)).thenReturn(oldMessage)
+        whenever(jda.retrieveUserById(20L)).thenReturn(retrieveUserAction)
+        doAnswer { invocation ->
+            invocation.component1<Consumer<User>>().accept(user)
+            null
+        }.whenever(retrieveUserAction).queue(any())
+        whenever(loggingSettingsRepository.findById(1L)).thenReturn(
+            Optional.of(LoggingSettings(1L, userLogChannel = 30L))
+        )
+        whenever(guild.getTextChannelById(30L)).thenReturn(logChannel)
+        whenever(logChannel.sendFiles(any<FileUpload>())).thenReturn(sendAction)
+
+        guildLogger.onMessageBulkDelete(bulkDeleteEvent)
+
+        val fileCaptor = argumentCaptor<FileUpload>()
+        verify(logChannel, timeout(1000)).sendFiles(fileCaptor.capture())
+        val logContent = fileCaptor.firstValue.data.use { it.readBytes().toString(Charsets.UTF_8) }
+        assertTrue(logContent.contains("Replied to:\nhttps://discord.com/channels/1/10/50"))
     }
 
     private fun guildLogger(): GuildLogger {

--- a/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageHistoryTest.kt
+++ b/src/test/kotlin/be/duncanc/discordmodbot/logging/MessageHistoryTest.kt
@@ -4,6 +4,7 @@ import be.duncanc.discordmodbot.logging.persistence.DiscordMessage
 import be.duncanc.discordmodbot.logging.persistence.DiscordMessageRepository
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageReference
 import net.dv8tion.jda.api.entities.Mentions
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion
@@ -52,6 +53,9 @@ class MessageHistoryTest {
     @Mock
     private lateinit var mentions: Mentions
 
+    @Mock
+    private lateinit var messageReference: MessageReference
+
     private lateinit var messageContentEncryptor: MessageContentEncryptor
     private lateinit var messageHistory: MessageHistory
 
@@ -79,6 +83,25 @@ class MessageHistoryTest {
     }
 
     @Test
+    fun `store message preserves the replied to message URL`() {
+        stubReceivedMessage(content = "reply")
+        whenever(message.messageReference).thenReturn(messageReference)
+        whenever(messageReference.type).thenReturn(MessageReference.MessageReferenceType.DEFAULT)
+        whenever(messageReference.guildIdLong).thenReturn(1L)
+        whenever(messageReference.channelIdLong).thenReturn(10L)
+        whenever(messageReference.messageIdLong).thenReturn(200L)
+
+        messageHistory.storeMessage(receivedEvent)
+
+        val messageCaptor = argumentCaptor<DiscordMessage>()
+        verify(discordMessageRepository).save(messageCaptor.capture())
+        assertEquals(
+            "https://discord.com/channels/1/10/200",
+            messageCaptor.firstValue.repliedToUrl
+        )
+    }
+
+    @Test
     fun `update message encrypts content before saving`() {
         stubUpdatedMessage(content = "updated content")
         whenever(discordMessageRepository.existsById(100L)).thenReturn(true)
@@ -90,7 +113,8 @@ class MessageHistoryTest {
                     channelId = 10L,
                     userId = 20L,
                     content = messageContentEncryptor.encrypt("old content"),
-                    emotes = "[wave](https://cdn.discordapp.com/emote.png)"
+                    emotes = "[wave](https://cdn.discordapp.com/emote.png)",
+                    repliedToUrl = "https://discord.com/channels/1/10/50"
                 )
             )
         )
@@ -102,6 +126,7 @@ class MessageHistoryTest {
         assertNotEquals("updated content", messageCaptor.firstValue.content)
         assertEquals("updated content", messageContentEncryptor.decrypt(messageCaptor.firstValue.content))
         assertEquals("[wave](https://cdn.discordapp.com/emote.png)", messageCaptor.firstValue.emotes)
+        assertEquals("https://discord.com/channels/1/10/50", messageCaptor.firstValue.repliedToUrl)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- store reply jump URLs with cached messages
- include reply links in single and bulk deletion logs
- add coverage for message storage and deletion logging

## Verification
- ./gradlew.bat test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deleted-message logs now show a link to the message being replied to, when applicable.
  * Bulk-deletion logs preserve message order and include reply links and emotes.
  * Reply links are retained when messages are updated.

* **Bug Fixes**
  * Bulk-deletion logs are now written only after all message details are resolved.
  * Empty bulk deletions no longer produce unnecessary log entries.
  * Logs remain complete when author details cannot be retrieved, displaying the available user ID instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->